### PR TITLE
refactor: replace /nightjournal with /morning and /evening commands

### DIFF
--- a/CLAUDE.md.example
+++ b/CLAUDE.md.example
@@ -10,11 +10,19 @@ You are Bede, a personal AI assistant.
 
 ## About the User
 
+Read `/vault/Bede/user.md` for full context. Key details:
+
 - Name: Your Name
 - Location: Your City, Your Country
 - Timezone: Your/Timezone
 - Role: Your role or job title
-- Interests: Your interests
+
+## Goals and Accountability
+
+Read `/vault/01 Projects/Career Direction 2026/goals.md` for the goals you measure against.
+Read `/vault/01 Projects/Career Direction 2026/weekly-schedule.md` for the daily rhythm.
+
+Follow the "How Bede Uses These Goals" section in goals.md for accountability guidance.
 
 ## What You Can Do
 
@@ -23,6 +31,7 @@ You are Bede, a personal AI assistant.
 - Query and update the Obsidian vault at `/vault/`
 - Summarise calendar events and emails via Google Workspace MCP tools
 - Query location, health, and daily activity data via personal-data MCP tools
+- Write daily journal entries to `/vault/Journal/` following `/vault/Bede/journal-template.md`
 
 ## What You Must Not Do
 

--- a/bot.py
+++ b/bot.py
@@ -234,15 +234,27 @@ async def handle_runtasks(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await asyncio.gather(*[_run_task(t) for t in tasks])
 
 
-async def handle_nightjournal(update: Update, context: ContextTypes.DEFAULT_TYPE):
+async def handle_morning(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if update.effective_user.id != ALLOWED_USER_ID:
         return
     tasks = _parse_tasks()
-    task = next((t for t in tasks if t.get("name") == "Night Journal"), None)
+    task = next((t for t in tasks if t.get("name") == "Morning Briefing"), None)
     if not task:
-        await update.message.reply_text("Night Journal task not found in scheduled-tasks.md.")
+        await update.message.reply_text("Morning Briefing task not found in scheduled-tasks.md.")
         return
-    await update.message.reply_text("Running Night Journal...")
+    await update.message.reply_text("Running Morning Briefing...")
+    await _run_task(task)
+
+
+async def handle_evening(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    if update.effective_user.id != ALLOWED_USER_ID:
+        return
+    tasks = _parse_tasks()
+    task = next((t for t in tasks if t.get("name") == "Evening Reflection"), None)
+    if not task:
+        await update.message.reply_text("Evening Reflection task not found in scheduled-tasks.md.")
+        return
+    await update.message.reply_text("Running Evening Reflection...")
     await _run_task(task)
 
 
@@ -252,7 +264,8 @@ async def post_init(app):
         BotCommand("start", "Start a conversation"),
         BotCommand("reset", "Clear session and start fresh"),
         BotCommand("runtasks", "Fire all scheduled tasks immediately"),
-        BotCommand("nightjournal", "Run the Night Journal task immediately"),
+        BotCommand("morning", "Run the Morning Briefing"),
+        BotCommand("evening", "Run the Evening Reflection"),
     ]
     await app.bot.set_my_commands(commands)
     await app.bot.set_my_commands(commands, scope=BotCommandScopeAllPrivateChats())
@@ -275,7 +288,8 @@ def main():
     app.add_handler(CommandHandler("start", handle_start))
     app.add_handler(CommandHandler("reset", handle_reset))
     app.add_handler(CommandHandler("runtasks", handle_runtasks))
-    app.add_handler(CommandHandler("nightjournal", handle_nightjournal))
+    app.add_handler(CommandHandler("morning", handle_morning))
+    app.add_handler(CommandHandler("evening", handle_evening))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
     log.info("Bede is running.")
     app.run_polling(drop_pending_updates=True)


### PR DESCRIPTION
## Summary
- Replace `/nightjournal` command with `/morning` (Morning Briefing) and `/evening` (Evening Reflection)
- Update `CLAUDE.md.example` to reference vault goal/schedule files and journal template
- Aligns bot commands with the new scheduled task names in the vault

## Context
Career direction change — moving from consultancy job-search schedule to structured DCCEEW work schedule. The old Night Journal (2am) and Morning Priorities/Digest are replaced by Evening Reflection (8:30pm) and Morning Briefing (8am).

## Test plan
- [ ] Deploy: `make bede-pull && make bede-restart`
- [ ] Verify `/morning` triggers Morning Briefing task
- [ ] Verify `/evening` triggers Evening Reflection task
- [ ] Verify `/runtasks` still lists and runs all tasks
- [ ] Verify Telegram command menu shows updated commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)