### PR TITLE
feat: add Playwright MCP and /scout command

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -7,6 +7,10 @@
     "personal-data": {
       "type": "http",
       "url": "http://localhost:8002/mcp"
+    },
+    "browser": {
+      "type": "http",
+      "url": "http://localhost:8004/mcp"
     }
   }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git curl ca-certificates openssh-client supervisor \
     && rm -rf /var/lib/apt/lists/*
 
+ENV PLAYWRIGHT_BROWSERS_PATH=/opt/playwright-browsers
+
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
+    npm install -g @playwright/mcp@latest && \
+    npx playwright install chromium --with-deps && \
+    chmod -R 755 /opt/playwright-browsers && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN curl -fsSL https://claude.ai/install.sh | bash && \
     cp /root/.local/bin/claude /usr/local/bin/claude
 
@@ -23,6 +32,6 @@ RUN chmod +x scripts/entrypoint.sh scripts/briefing.sh \
 
 USER bede
 
-EXPOSE 8001 8002 8003
+EXPOSE 8001 8002 8003 8004
 
 ENTRYPOINT ["scripts/entrypoint.sh"]

--- a/bot.py
+++ b/bot.py
@@ -222,16 +222,16 @@ async def handle_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
     )
 
 
-async def handle_runtasks(update: Update, context: ContextTypes.DEFAULT_TYPE):
+async def handle_scout(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if update.effective_user.id != ALLOWED_USER_ID:
         return
     tasks = _parse_tasks()
-    if not tasks:
-        await update.message.reply_text("No tasks found in scheduled-tasks.md.")
+    task = next((t for t in tasks if t.get("name") == "Sunday Scout"), None)
+    if not task:
+        await update.message.reply_text("Sunday Scout task not found in scheduled-tasks.md.")
         return
-    names = ", ".join(t.get("name", "?") for t in tasks)
-    await update.message.reply_text(f"Running {len(tasks)} task(s): {names}")
-    await asyncio.gather(*[_run_task(t) for t in tasks])
+    await update.message.reply_text("Running Sunday Scout...")
+    await _run_task(task)
 
 
 async def handle_morning(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -263,9 +263,9 @@ async def post_init(app):
     commands = [
         BotCommand("start", "Start a conversation"),
         BotCommand("reset", "Clear session and start fresh"),
-        BotCommand("runtasks", "Fire all scheduled tasks immediately"),
         BotCommand("morning", "Run the Morning Briefing"),
         BotCommand("evening", "Run the Evening Reflection"),
+        BotCommand("scout", "Run the Sunday Scout price checker"),
     ]
     await app.bot.set_my_commands(commands)
     await app.bot.set_my_commands(commands, scope=BotCommandScopeAllPrivateChats())
@@ -287,9 +287,9 @@ def main():
     app = Application.builder().token(BOT_TOKEN).post_init(post_init).post_shutdown(post_shutdown).build()
     app.add_handler(CommandHandler("start", handle_start))
     app.add_handler(CommandHandler("reset", handle_reset))
-    app.add_handler(CommandHandler("runtasks", handle_runtasks))
     app.add_handler(CommandHandler("morning", handle_morning))
     app.add_handler(CommandHandler("evening", handle_evening))
+    app.add_handler(CommandHandler("scout", handle_scout))
     app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
     log.info("Bede is running.")
     app.run_polling(drop_pending_updates=True)

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -45,3 +45,13 @@ stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
+
+[program:playwright-mcp]
+command=npx @playwright/mcp@latest --port 8004 --host 0.0.0.0 --headless --browser chromium
+directory=/app
+autostart=true
+autorestart=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0


### PR DESCRIPTION
## Summary

- Adds `@playwright/mcp` as a 5th supervisord process inside the Bede container, giving Claude headless browser tools for JS-heavy retailer sites
- Adds `/scout` Telegram command to trigger the Sunday Scout price checker on demand
- Removes the generic `/runtasks` command

## Changes

- **Dockerfile** — installs Node.js 20, `@playwright/mcp`, and Chromium with system deps to `/opt/playwright-browsers` (accessible by non-root `bede` user)
- **supervisord.conf** — adds `playwright-mcp` process on port 8004
- **.mcp.json** — registers `"browser"` MCP server at `localhost:8004/mcp`
- **bot.py** — replaces `/runtasks` with `/scout` command

## Test plan

- [x] Built image on test server (`docker build -t ghcr.io/josephradford/bede:playwright-test .`)
- [x] All 5 supervisord processes start and respond on their ports
- [x] Playwright MCP listening on port 8004
- [ ] `/scout` command triggers Sunday Scout task via Telegram

🤖 Generated with [Claude Code](https://claude.com/claude-code)