### PR TITLE
fix: scheduler misfire grace time and Google email instruction

### DIFF
--- a/CLAUDE.md.example
+++ b/CLAUDE.md.example
@@ -84,4 +84,8 @@ data are available via `get_wellbeing(date)`.
 
 ## Google Account
 
+**IMPORTANT:** Always use this email for ALL Google workspace-mcp tool calls
+(get_events, list_calendars, send_email, search_emails, list_tasks, etc.).
+Never infer or guess a different email from the user's name.
+
 - Email: your-google-account@gmail.com

--- a/scheduler.py
+++ b/scheduler.py
@@ -231,7 +231,9 @@ def setup_scheduler(bot, chat_id: int) -> AsyncIOScheduler:
 
     tz = ZoneInfo(TIMEZONE)
 
-    scheduler = AsyncIOScheduler()
+    scheduler = AsyncIOScheduler(
+        job_defaults={"misfire_grace_time": 300, "coalesce": True}
+    )
     scheduler.add_job(
         reload,
         "interval",


### PR DESCRIPTION
## Summary
- Sets APScheduler `misfire_grace_time` to 300s (was default 1s) and `coalesce=True` to prevent scheduled tasks from silently skipping
- Strengthens `CLAUDE.md.example` Google Account section to prevent Claude from inferring the wrong email

## Context
Sunday Scout was consistently firing late or not at all. Root cause: APScheduler's default `misfire_grace_time` of 1 second meant that if the async event loop was busy (e.g. processing a Telegram poll) at the exact scheduled time, the job was considered "misfired" and skipped. The 5-minute task reload watcher then removed and re-added the job, resetting the next fire time to the following week.

Setting `misfire_grace_time=300` (matching the reload interval) ensures late-firing jobs still execute. `coalesce=True` ensures only one instance runs if multiple fire times were missed.

The CLAUDE.md.example change addresses a separate recurring issue where Claude infers `joeradford@gmail.com` from the user's name instead of using the configured `ai.joeradford@gmail.com`.

Companion PR: josephradford/home-server-stack#160

## Test plan
- [ ] Build new image and deploy to server
- [ ] Verify Sunday Scout fires at 14:00 AEST next Sunday
- [ ] Verify workspace-mcp tool calls use `ai.joeradford@gmail.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)