### PR TITLE
fix: stop Claude subprocess from sending duplicate Telegram messages

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -160,12 +160,17 @@ async def _run_task_inner(task: dict, name: str):
         "--output-format", "json",
     ]
 
+    # Strip Telegram env vars so the Claude subprocess can't send messages
+    # directly — _run_task handles all Telegram delivery.
+    task_env = {k: v for k, v in os.environ.items()
+                if k not in ("TELEGRAM_BOT_TOKEN", "ALLOWED_USER_ID")}
+
     try:
         proc = await asyncio.to_thread(
             subprocess.run, cmd,
             capture_output=True, text=True,
             stdin=subprocess.DEVNULL, cwd=CLAUDE_WORKDIR,
-            timeout=timeout,
+            timeout=timeout, env=task_env,
         )
     except subprocess.TimeoutExpired:
         mins = timeout // 60


### PR DESCRIPTION
## Summary
- Strips `TELEGRAM_BOT_TOKEN` and `ALLOWED_USER_ID` from the environment passed to the `claude -p` subprocess

## Context
Scheduled task prompts say things like "Send Joe a structured Telegram message". Because Claude runs with `--dangerously-skip-permissions` and inherits the full environment, it curls the Telegram API directly using the bot token. Then `_run_task` also sends the result — producing duplicate messages.

By stripping the Telegram env vars, Claude can't send directly. It formats the text as output instead, and `_run_task` handles all Telegram delivery as intended.

## Test plan
- [ ] Build and deploy new image
- [ ] Trigger `/evening` or `/datacheck` — should get exactly 2 messages: "Running..." confirmation + result (not 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)