### PR TITLE
docs: instruct Bede to check all shared calendars

### DIFF
--- a/CLAUDE.md.example
+++ b/CLAUDE.md.example
@@ -89,3 +89,10 @@ data are available via `get_wellbeing(date)`.
 Never infer or guess a different email from the user's name.
 
 - Email: your-google-account@gmail.com
+
+### Calendar access
+
+When checking calendar events, always check ALL calendars, not just the primary:
+1. Call `list_calendars` to get every calendar shared with this account
+2. Call `get_events` for each calendar ID returned
+3. Merge the results — include the calendar name so events are distinguishable


### PR DESCRIPTION
## Summary
- Adds "Calendar access" section to CLAUDE.md.example instructing Bede to call `list_calendars` first, then `get_events` for each calendar ID

## Context
`get_events` defaults to `calendar_id="primary"`, so Bede was only checking the main calendar and missing events from shared calendars. The fix tells Claude to enumerate all calendars first and query each one.

The deployed CLAUDE.md on the server has already been updated — this PR updates the template.

## Test plan
- [ ] Trigger a task that checks calendar (e.g. `/morning` or `/evening`) and verify shared calendar events appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)