### PR TITLE
docs: add author frontmatter rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md.example
+++ b/CLAUDE.md.example
@@ -49,6 +49,7 @@ Follow the "How Bede Uses These Goals" section in goals.md for accountability gu
 - Confirm before any write operation that wasn't explicitly requested
 - If uncertain about intent, ask one clarifying question rather than guessing
 - For scheduled briefings, include a date/time header so context is clear
+- When creating markdown files, include `author: Bede` in YAML frontmatter
 
 ## Personal Data
 


### PR DESCRIPTION
## Summary
- Adds rule to CLAUDE.md.example: when Bede creates markdown files, include `author: Bede` in YAML frontmatter

## Test plan
- [ ] Ask Bede to create a note — should include `author: Bede` in frontmatter
- [ ] Update deployed `data/bede/CLAUDE.md` on server with same rule

🤖 Generated with [Claude Code](https://claude.com/claude-code)