### PR TITLE
fix: add --no-sandbox to Playwright MCP

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -47,7 +47,7 @@ stderr_logfile=/dev/stderr
 stderr_logfile_maxbytes=0
 
 [program:playwright-mcp]
-command=npx @playwright/mcp@latest --port 8004 --host 0.0.0.0 --headless --browser chromium
+command=npx @playwright/mcp@latest --port 8004 --host 0.0.0.0 --headless --browser chromium --no-sandbox
 directory=/app
 autostart=true
 autorestart=true


### PR DESCRIPTION
## Summary
- Chromium's sandbox requires root or `CAP_SYS_ADMIN` to set up user namespaces, but the bede container runs as non-root user `bede`
- This causes EACCES errors when scout tasks invoke the browser MCP, making Playwright completely unusable despite being running and registered
- Container isolation already provides sandboxing, so `--no-sandbox` is safe here

## Context
Sunday Scout has been running since Apr 21 without ever successfully using the browser MCP. The scout prompt was updated to direct browser use at JS-rendered sites (Blundstone, Paddy Pallin, JB Hi-Fi), but every attempt fails with EACCES.

## Test plan
- [ ] GHCR image builds successfully
- [ ] Deploy to server: `make bede-pull && make bede-restart`
- [ ] Verify playwright-mcp starts: check `docker logs bede` for `playwright-mcp entered RUNNING state`
- [ ] Trigger a scout run and confirm browser tool calls succeed (no EACCES in logs)
- [ ] Verify Blundstone clearance page returns model/price data in scout report

🤖 Generated with [Claude Code](https://claude.com/claude-code)