### PR TITLE
fix: prevent Telegram API timeouts from aborting task execution

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -222,19 +222,26 @@ async def handle_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
     )
 
 
+async def _safe_reply(message, text: str):
+    try:
+        await message.reply_text(text)
+    except Exception as e:
+        log.warning("Failed to send Telegram reply (%s): %s", text, e)
+
+
 async def _trigger_task(update: Update, task_name: str):
     """Look up a task by name and run it in the background."""
     if update.effective_user.id != ALLOWED_USER_ID:
         return
     if task_name in _running_tasks:
-        await update.message.reply_text(f"⚠️ {task_name} is already running.")
+        await _safe_reply(update.message, f"⚠️ {task_name} is already running.")
         return
     tasks = _parse_tasks()
     task = next((t for t in tasks if t.get("name") == task_name), None)
     if not task:
-        await update.message.reply_text(f"{task_name} not found in scheduled-tasks.md.")
+        await _safe_reply(update.message, f"{task_name} not found in scheduled-tasks.md.")
         return
-    await update.message.reply_text(f"Running {task_name}...")
+    await _safe_reply(update.message, f"Running {task_name}...")
     asyncio.create_task(_run_task(task))
 
 


### PR DESCRIPTION
## Summary
- Adds `_safe_reply` helper that wraps `reply_text` in try/except
- Uses it in `_trigger_task` so a Telegram ReadTimeout on the ack message no longer kills the handler before the task subprocess starts
- Observed in production: `/scout` command sent the "Running Sunday Scout..." message but the HTTP response timed out, crashing the handler and preventing the task from ever executing

## Test plan
- [ ] Trigger `/scout` or `/morning` via Telegram — task should run normally
- [ ] Simulate timeout (e.g. network blip) — task should still execute, warning logged

🤖 Generated with [Claude Code](https://claude.com/claude-code)