### PR TITLE
fix: pull vault before each scheduled task

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -153,6 +153,7 @@ async def _run_task(task: dict):
         return
 
     _running_tasks.add(name)
+    await asyncio.to_thread(_pull_vault)
     typing_task = asyncio.create_task(_keep_typing())
     try:
         await _run_task_inner(task, name)


### PR DESCRIPTION
## Summary
- Adds `await asyncio.to_thread(_pull_vault)` at the start of `_run_task()` so every scheduled (or manually triggered) task reads the latest vault state
- Previously vault was only pulled on container start, during `reload()` (every 5 min), or before Telegram messages — scheduled tasks could read stale preference files

## Test plan
- [ ] Deploy to test server, edit a vault preference file, verify the next task run picks up the change
- [ ] Confirm tasks still execute normally (no timeout or error from the pull)

🤖 Generated with [Claude Code](https://claude.com/claude-code)