### PR TITLE
fix: grant bede user write access to playwright-browsers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN curl -fsSL https://claude.ai/install.sh | bash && \
 RUN useradd --system --create-home --uid 1000 --shell /bin/bash bede && \
     mkdir -p /home/bede/.ssh /home/bede/.claude && \
     chmod 700 /home/bede/.ssh && \
-    chown -R bede:bede /home/bede/.ssh /home/bede/.claude
+    chown -R bede:bede /home/bede/.ssh /home/bede/.claude /opt/playwright-browsers
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Adds `/opt/playwright-browsers` to the `chown` for the bede user in the Dockerfile
- The `@playwright/mcp` server creates a temp dir (`mcp-chrome-for-testing-*`) inside this path at runtime; without write access it fails with `EACCES: permission denied, mkdir '/opt/playwright-browsers/mcp-chrome-for-testing-f53b52a'`
- This blocked all browser MCP usage in the Sunday Scout (Blundstone, Paddy Pallin clearance pages)

## Root cause
Chromium binary was installed as root and made executable via `chmod -R 755`, but the MCP server needs write access to manage browser profiles. The `bede` user (which runs all processes) couldn't create the temp directory.

## Test plan
- [ ] Rebuild image, deploy to test server
- [ ] Trigger a browser_navigate call (e.g. Blundstone clearance page) and verify it succeeds
- [ ] Confirm Sunday Scout clothing/camping steps can use browser for JS-rendered sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)