### PR TITLE
feat: interactive task sessions with reflection memory

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -35,12 +35,19 @@ ALLOWED_USER_ID = int(os.environ["ALLOWED_USER_ID"])
 CLAUDE_WORKDIR = os.environ.get("CLAUDE_WORKDIR", "/app")
 CLAUDE_MODEL = os.environ.get("CLAUDE_MODEL", "claude-haiku-4-5-20251001")
 SESSION_TIMEOUT_SECS = int(os.environ.get("SESSION_TIMEOUT_MINUTES", "10")) * 60
+INTERACTIVE_IDLE_TIMEOUT_SECS = int(os.environ.get("INTERACTIVE_IDLE_TIMEOUT_MINUTES", "30")) * 60
+INTERACTIVE_MAX_AGE_SECS = int(os.environ.get("INTERACTIVE_MAX_AGE_HOURS", "2")) * 3600
 VAULT_REPO = os.environ.get("VAULT_REPO", "")
+VAULT_PATH = "/vault"
+REFLECTION_MEMORY_PATH = os.path.join(VAULT_PATH, "Bede", "reflection-memory.md")
 
 _scheduler: AsyncIOScheduler | None = None
 
 # {chat_id: {"session_id": str, "ts": float}}
 _sessions: dict[int, dict] = {}
+
+# Single interactive task session: {"session_id": str, "model": str, "ts": float, "created": float}
+_interactive_session: dict | None = None
 
 REAUTH_NOTICE = (
     "\u26a0\ufe0f Claude auth has expired.\n\n"
@@ -76,6 +83,73 @@ def _pull_vault():
         )
     except Exception:
         pass
+
+
+def register_interactive_session(session_id: str, model: str):
+    """Called by scheduler (via call_soon_threadsafe) to hand off an interactive task session."""
+    global _interactive_session
+    now = time.monotonic()
+    _interactive_session = {
+        "session_id": session_id,
+        "model": model,
+        "ts": now,
+        "created": now,
+    }
+    log.info("Interactive session registered: %s (model: %s)", session_id, model)
+
+
+def _get_interactive_session(now: float) -> dict | None:
+    """Return the active interactive session if within both idle and max-age limits."""
+    global _interactive_session
+    if _interactive_session is None:
+        return None
+    idle_ok = (now - _interactive_session["ts"]) < INTERACTIVE_IDLE_TIMEOUT_SECS
+    age_ok = (now - _interactive_session["created"]) < INTERACTIVE_MAX_AGE_SECS
+    if idle_ok and age_ok:
+        return _interactive_session
+    log.info("Interactive session expired (idle_ok=%s, age_ok=%s).", idle_ok, age_ok)
+    _interactive_session = None
+    return None
+
+
+def _append_correction(text: str):
+    """Append a timestamped correction to reflection-memory.md. Creates the file if missing."""
+    from datetime import datetime
+    from zoneinfo import ZoneInfo
+    tz_name = os.environ.get("TIMEZONE", "UTC")
+    now = datetime.now(ZoneInfo(tz_name))
+    timestamp = now.strftime("%Y-%m-%d %H:%M")
+
+    header = (
+        "# Reflection Memory\n\n"
+        "Corrections and preferences Joe has provided about Evening Reflections.\n"
+        "Bede reads this at the start of each reflection to avoid repeating mistakes.\n\n"
+        "## Corrections\n\n"
+    )
+
+    if not os.path.isfile(REFLECTION_MEMORY_PATH):
+        os.makedirs(os.path.dirname(REFLECTION_MEMORY_PATH), exist_ok=True)
+        with open(REFLECTION_MEMORY_PATH, "w") as f:
+            f.write(header)
+
+    with open(REFLECTION_MEMORY_PATH, "a") as f:
+        f.write(f"- [{timestamp}] {text}\n")
+
+    try:
+        subprocess.run(
+            ["git", "-C", VAULT_PATH, "add", REFLECTION_MEMORY_PATH],
+            capture_output=True, timeout=10,
+        )
+        subprocess.run(
+            ["git", "-C", VAULT_PATH, "commit", "-m", "reflection: save correction"],
+            capture_output=True, timeout=10,
+        )
+        subprocess.run(
+            ["git", "-C", VAULT_PATH, "push"],
+            capture_output=True, timeout=30,
+        )
+    except Exception as e:
+        log.warning("Failed to commit reflection correction: %s", e)
 
 
 def _parse_output(stdout: str) -> tuple[str, str | None]:
@@ -124,6 +198,7 @@ async def _keep_typing(bot, chat_id: int):
 
 
 async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    global _interactive_session
     if update.effective_user.id != ALLOWED_USER_ID:
         log.warning("Rejected message from user %s", update.effective_user.id)
         return
@@ -132,16 +207,22 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
     text = update.message.text
     now = time.monotonic()
 
-    # Determine session continuity
-    session = _sessions.get(chat_id)
-    resume_id = None
-    if session and (now - session["ts"]) < SESSION_TIMEOUT_SECS:
-        resume_id = session["session_id"]
+    # Check interactive task session first, then regular chat session
+    interactive = _get_interactive_session(now)
+    if interactive:
+        resume_id = interactive["session_id"]
+        model = interactive.get("model")
+    else:
+        session = _sessions.get(chat_id)
+        resume_id = None
+        model = None
+        if session and (now - session["ts"]) < SESSION_TIMEOUT_SECS:
+            resume_id = session["session_id"]
 
     reset_sent = False
     await asyncio.to_thread(_pull_vault)
 
-    cmd = _build_cmd(text, resume_id)
+    cmd = _build_cmd(text, resume_id, model=model)
     log.info("Running: %s", " ".join(cmd[:4]) + " ...")
 
     typing_task = asyncio.create_task(_keep_typing(context.bot, chat_id))
@@ -158,6 +239,9 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if resume_id and "no conversation found" in proc.stderr.lower():
         log.warning("Stale session %s, retrying fresh.", resume_id)
         _sessions.pop(chat_id, None)
+        if interactive:
+            _interactive_session = None
+            interactive = None
         await update.message.reply_text("_(Session reset — previous context lost)_", parse_mode="Markdown")
         reset_sent = True
         cmd = _build_cmd(text, None)
@@ -186,11 +270,16 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
         # Fallback: surface raw output so failures are visible
         result_text = (proc.stdout or proc.stderr or "No response.").strip()[:4096]
 
-    # Update session — if no new session ID came back, the old one was consumed;
-    # clear it so the next message starts fresh rather than hitting a stale resume.
-    if new_session_id:
+    # Update session state
+    if interactive and new_session_id:
+        _interactive_session["session_id"] = new_session_id
+        _interactive_session["ts"] = now
+        await asyncio.to_thread(_append_correction, text)
+    elif interactive and not new_session_id:
+        _interactive_session = None
+        log.info("Interactive session ended (no session_id returned).")
+    elif new_session_id:
         _sessions[chat_id] = {"session_id": new_session_id, "ts": now}
-        # Notify on new context (but not if we already sent a reset message)
         if not resume_id and not reset_sent:
             await update.message.reply_text("_(New context started)_", parse_mode="Markdown")
     else:
@@ -206,10 +295,12 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
 
 async def handle_reset(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    global _interactive_session
     if update.effective_user.id != ALLOWED_USER_ID:
         return
     chat_id = update.effective_chat.id
     _sessions.pop(chat_id, None)
+    _interactive_session = None
     await update.message.reply_text("Session cleared. Next message starts fresh.")
 
 

--- a/scheduler.py
+++ b/scheduler.py
@@ -82,8 +82,14 @@ def _parse_tasks() -> list[dict]:
         data = yaml.safe_load(match.group(1)) or {}
         tasks = data.get("tasks", [])
         enabled = [t for t in tasks if t.get("enabled", True)]
-        log.info("Loaded %d scheduled task(s) from vault.", len(enabled))
-        return enabled
+        valid = []
+        for t in enabled:
+            if t.get("interactive") and t.get("steps"):
+                log.error("Task '%s': interactive + steps is not supported — skipping.", t.get("name"))
+                continue
+            valid.append(t)
+        log.info("Loaded %d scheduled task(s) from vault.", len(valid))
+        return valid
     except yaml.YAMLError as e:
         log.error("Failed to parse tasks YAML: %s", e)
         return []
@@ -125,6 +131,21 @@ def _get_task_env() -> dict:
         _task_env = {k: v for k, v in os.environ.items()
                      if k not in ("TELEGRAM_BOT_TOKEN", "ALLOWED_USER_ID")}
     return _task_env
+
+
+def _extract_session_id(stdout: str) -> str | None:
+    """Extract just the session_id from claude JSON output."""
+    for line in reversed(stdout.splitlines()):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+            if obj.get("type") == "result":
+                return obj.get("session_id")
+        except json.JSONDecodeError:
+            continue
+    return None
 
 
 def _extract_result(stdout: str) -> str:
@@ -221,6 +242,15 @@ async def _run_task_inner(task: dict, name: str):
     full = header + result_text
     for chunk in [full[i:i + 4096] for i in range(0, len(full), 4096)]:
         await _send(chunk)
+
+    if task.get("interactive"):
+        session_id = _extract_session_id(proc.stdout)
+        if session_id:
+            import bot as _bot_module
+            _bot_module.register_interactive_session(session_id, model)
+            log.info("Interactive session handed off for task '%s': %s", name, session_id)
+        else:
+            log.warning("Task '%s' is interactive but no session_id was returned.", name)
 
 
 def _next_run_str(cron: str, tz, now) -> str:

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1,0 +1,225 @@
+"""Tests for interactive task session features in bot.py and scheduler.py."""
+
+import json
+import os
+import time
+
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "test-token")
+os.environ.setdefault("ALLOWED_USER_ID", "12345")
+
+import pytest
+
+
+# -- scheduler: _extract_session_id ------------------------------------------
+
+from scheduler import _extract_session_id
+
+
+def _make_claude_output(result_text="Hello", session_id="sess-abc-123"):
+    lines = [
+        json.dumps({"type": "assistant", "content": "thinking..."}),
+        json.dumps({
+            "type": "result",
+            "result": result_text,
+            "session_id": session_id,
+        }),
+    ]
+    return "\n".join(lines)
+
+
+def test_extract_session_id_normal():
+    stdout = _make_claude_output(session_id="sess-xyz")
+    assert _extract_session_id(stdout) == "sess-xyz"
+
+
+def test_extract_session_id_missing():
+    stdout = json.dumps({"type": "result", "result": "hi"})
+    assert _extract_session_id(stdout) is None
+
+
+def test_extract_session_id_empty():
+    assert _extract_session_id("") is None
+
+
+def test_extract_session_id_malformed_json():
+    stdout = "not json\n{bad\n"
+    assert _extract_session_id(stdout) is None
+
+
+def test_extract_session_id_multiple_results():
+    lines = [
+        json.dumps({"type": "result", "result": "first", "session_id": "old"}),
+        json.dumps({"type": "result", "result": "second", "session_id": "new"}),
+    ]
+    stdout = "\n".join(lines)
+    assert _extract_session_id(stdout) == "new"
+
+
+# -- scheduler: _parse_tasks validation --------------------------------------
+
+from scheduler import _parse_tasks
+
+
+def _write_tasks_file(tmp_path, tasks_yaml):
+    md = f"# Tasks\n\n```yaml\n{tasks_yaml}\n```\n"
+    tasks_file = tmp_path / "Bede" / "scheduled-tasks.md"
+    tasks_file.parent.mkdir(parents=True)
+    tasks_file.write_text(md)
+    return tasks_file
+
+
+def test_parse_tasks_rejects_interactive_steps(tmp_path, monkeypatch):
+    yaml_content = """\
+tasks:
+  - name: Bad Task
+    schedule: "0 7 * * *"
+    interactive: true
+    steps:
+      - name: Step 1
+        prompt: "do something"
+    prompt: "ignored"
+  - name: Good Task
+    schedule: "0 8 * * *"
+    interactive: true
+    prompt: "this is fine"
+"""
+    _write_tasks_file(tmp_path, yaml_content)
+    monkeypatch.setattr("scheduler.VAULT_PATH", str(tmp_path))
+    monkeypatch.setattr("scheduler.TASKS_REL_PATH", "Bede/scheduled-tasks.md")
+
+    tasks = _parse_tasks()
+    assert len(tasks) == 1
+    assert tasks[0]["name"] == "Good Task"
+
+
+def test_parse_tasks_allows_non_interactive_steps(tmp_path, monkeypatch):
+    yaml_content = """\
+tasks:
+  - name: Multi Step
+    schedule: "0 7 * * *"
+    steps:
+      - name: Step 1
+        prompt: "do something"
+"""
+    _write_tasks_file(tmp_path, yaml_content)
+    monkeypatch.setattr("scheduler.VAULT_PATH", str(tmp_path))
+    monkeypatch.setattr("scheduler.TASKS_REL_PATH", "Bede/scheduled-tasks.md")
+
+    tasks = _parse_tasks()
+    assert len(tasks) == 1
+    assert tasks[0]["name"] == "Multi Step"
+
+
+# -- bot: register + get interactive session ----------------------------------
+
+import bot
+
+
+def test_register_and_get_interactive_session():
+    bot._interactive_session = None
+    bot.register_interactive_session("sess-1", "claude-sonnet-4-6")
+
+    now = time.monotonic()
+    session = bot._get_interactive_session(now)
+    assert session is not None
+    assert session["session_id"] == "sess-1"
+    assert session["model"] == "claude-sonnet-4-6"
+
+    bot._interactive_session = None
+
+
+def test_interactive_session_idle_timeout():
+    bot._interactive_session = None
+    bot.register_interactive_session("sess-1", "claude-sonnet-4-6")
+
+    future = time.monotonic() + bot.INTERACTIVE_IDLE_TIMEOUT_SECS + 1
+    session = bot._get_interactive_session(future)
+    assert session is None
+    assert bot._interactive_session is None
+
+
+def test_interactive_session_max_age_timeout():
+    bot._interactive_session = None
+    bot.register_interactive_session("sess-1", "claude-sonnet-4-6")
+    bot._interactive_session["ts"] = time.monotonic()
+
+    future = time.monotonic() + bot.INTERACTIVE_MAX_AGE_SECS + 1
+    session = bot._get_interactive_session(future)
+    assert session is None
+    assert bot._interactive_session is None
+
+
+def test_interactive_session_within_limits():
+    bot._interactive_session = None
+    bot.register_interactive_session("sess-1", "claude-sonnet-4-6")
+
+    future = time.monotonic() + 60
+    session = bot._get_interactive_session(future)
+    assert session is not None
+    assert session["session_id"] == "sess-1"
+
+    bot._interactive_session = None
+
+
+def test_get_interactive_session_when_none():
+    bot._interactive_session = None
+    assert bot._get_interactive_session(time.monotonic()) is None
+
+
+# -- bot: _append_correction --------------------------------------------------
+
+from bot import _append_correction
+
+
+def test_append_correction_creates_file(tmp_path, monkeypatch):
+    mem_path = str(tmp_path / "Bede" / "reflection-memory.md")
+    monkeypatch.setattr("bot.REFLECTION_MEMORY_PATH", mem_path)
+    monkeypatch.setattr("bot.VAULT_PATH", str(tmp_path))
+    monkeypatch.setenv("TIMEZONE", "UTC")
+    monkeypatch.setattr("subprocess.run", lambda *a, **kw: None)
+
+    _append_correction("I did go for a run, the GPS was off")
+
+    assert os.path.isfile(mem_path)
+    content = open(mem_path).read()
+    assert "# Reflection Memory" in content
+    assert "## Corrections" in content
+    assert "I did go for a run, the GPS was off" in content
+
+
+def test_append_correction_appends_to_existing(tmp_path, monkeypatch):
+    mem_dir = tmp_path / "Bede"
+    mem_dir.mkdir()
+    mem_path = str(mem_dir / "reflection-memory.md")
+    with open(mem_path, "w") as f:
+        f.write("# Reflection Memory\n\n## Corrections\n\n- [2026-04-27 20:45] first correction\n")
+
+    monkeypatch.setattr("bot.REFLECTION_MEMORY_PATH", mem_path)
+    monkeypatch.setattr("bot.VAULT_PATH", str(tmp_path))
+    monkeypatch.setenv("TIMEZONE", "UTC")
+    monkeypatch.setattr("subprocess.run", lambda *a, **kw: None)
+
+    _append_correction("second correction")
+
+    content = open(mem_path).read()
+    assert "first correction" in content
+    assert "second correction" in content
+
+
+def test_append_correction_timestamp_format(tmp_path, monkeypatch):
+    mem_dir = tmp_path / "Bede"
+    mem_dir.mkdir()
+    mem_path = str(mem_dir / "reflection-memory.md")
+    with open(mem_path, "w") as f:
+        f.write("# Reflection Memory\n\n## Corrections\n\n")
+
+    monkeypatch.setattr("bot.REFLECTION_MEMORY_PATH", mem_path)
+    monkeypatch.setattr("bot.VAULT_PATH", str(tmp_path))
+    monkeypatch.setenv("TIMEZONE", "UTC")
+    monkeypatch.setattr("subprocess.run", lambda *a, **kw: None)
+
+    _append_correction("test")
+
+    import re
+    content = open(mem_path).read()
+    assert re.search(r"- \[\d{4}-\d{2}-\d{2} \d{2}:\d{2}\] test", content)


### PR DESCRIPTION
## Summary

- Scheduled tasks marked `interactive: true` hand off their Claude session to the Telegram chat handler after completing, so Joe can reply with corrections that continue the same conversation
- Corrections are mechanically appended to `/vault/Bede/reflection-memory.md` with timestamps — deterministic Python I/O, not prompt-dependent
- Future Evening Reflections read the memory file to incorporate past corrections
- Interactive sessions have a 30-min idle timeout and 2-hour max age (both env-configurable)
- Validates that `interactive` and `steps` can't be combined at task-load time
- Self-healing: creates reflection-memory.md with standard header if the file is missing

## Test plan

- [ ] Deploy to server, trigger `/evening` in Telegram
- [ ] Verify reflection posts normally with correction invitation at end
- [ ] Reply with a correction — confirm reply continues the conversation (not a new chat)
- [ ] Check `reflection-memory.md` was updated with raw correction + timestamp
- [ ] Send `/reset` — confirm interactive session clears and next message starts fresh
- [ ] Wait 30+ min idle — confirm next message starts fresh chat
- [ ] Next evening: confirm reflection reads and references past corrections

🤖 Generated with [Claude Code](https://claude.com/claude-code)