### PR TITLE
fix: register bot module in sys.modules for interactive session handoff

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -392,4 +392,6 @@ def main():
 
 
 if __name__ == "__main__":
+    import sys
+    sys.modules["bot"] = sys.modules[__name__]
     main()


### PR DESCRIPTION
## Summary

- `bot.py` runs as `__main__` via supervisord (`uv run python3 /app/bot.py`). When `scheduler.py` does `import bot`, Python creates a **separate** module copy with its own `_interactive_session` variable. The interactive session handoff writes to the copy; `handle_message` reads from `__main__` — they never share state.
- Fix: `sys.modules["bot"] = sys.modules[__name__]` before `main()` so all `import bot` calls resolve to the same module object.

## Test plan

- [ ] Deploy to server, trigger `/evening` in Telegram
- [ ] Reply to the reflection — confirm the reply continues the conversation (not "New context started")
- [ ] Existing tests pass: `uv run pytest tests/test_interactive.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)