### PR TITLE
feat: production skills, scout rename, vault-write rule

### DIFF
--- a/.claude/skills/calendar-check/SKILL.md
+++ b/.claude/skills/calendar-check/SKILL.md
@@ -3,10 +3,14 @@ name: calendar-check
 description: >
   Check all Google Calendars for events, not just the primary. Use this skill
   whenever you need to look up calendar events, check for conflicts, or list
-  what's on a given day/range.
+  what's on a given day/range. Also use for "what's on today", "am I free on
+  Saturday", "check for conflicts", or any calendar query.
 ---
 
 # Calendar Check Skill
+
+**Google account:** `ai.joeradford@gmail.com` — always use this email for
+all workspace-mcp calendar calls.
 
 Google Calendar lookups must check ALL calendars, not just the primary.
 Joe has multiple calendars (personal, work, birthdays, shared, etc.) and
@@ -18,7 +22,7 @@ events on secondary calendars are frequently missed.
    the account.
 
 2. For EACH calendar ID returned, call `get_events` with the requested date
-   range.
+   range. If no date range was specified, default to today.
 
 3. Merge all results into a single list, sorted chronologically. Include the
    calendar name with each event so they're distinguishable:
@@ -35,4 +39,3 @@ events on secondary calendars are frequently missed.
 - If a calendar API call fails, note which calendar failed and continue with
   the others — don't abort the whole check
 - For conflict checking, flag any overlapping events across all calendars
-- The Google account is `ai.joeradford@gmail.com` — always use this email

--- a/.claude/skills/calendar-check/SKILL.md
+++ b/.claude/skills/calendar-check/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: calendar-check
+description: >
+  Check all Google Calendars for events, not just the primary. Use this skill
+  whenever you need to look up calendar events, check for conflicts, or list
+  what's on a given day/range.
+---
+
+# Calendar Check Skill
+
+Google Calendar lookups must check ALL calendars, not just the primary.
+Joe has multiple calendars (personal, work, birthdays, shared, etc.) and
+events on secondary calendars are frequently missed.
+
+## Steps
+
+1. Call `list_calendars` via workspace-mcp to get every calendar shared with
+   the account.
+
+2. For EACH calendar ID returned, call `get_events` with the requested date
+   range.
+
+3. Merge all results into a single list, sorted chronologically. Include the
+   calendar name with each event so they're distinguishable:
+   - `[Personal] Dinner with friends — 18:00`
+   - `[Birthdays] Sarah's Birthday`
+   - `[Work] Team standup — 09:30`
+
+4. Return the merged list.
+
+## Rules
+
+- Never skip a calendar — even if the name looks irrelevant, it may contain
+  events Joe cares about
+- If a calendar API call fails, note which calendar failed and continue with
+  the others — don't abort the whole check
+- For conflict checking, flag any overlapping events across all calendars
+- The Google account is `ai.joeradford@gmail.com` — always use this email

--- a/.claude/skills/calendar-check/SKILL.md
+++ b/.claude/skills/calendar-check/SKILL.md
@@ -9,12 +9,12 @@ description: >
 
 # Calendar Check Skill
 
-**Google account:** `ai.joeradford@gmail.com` — always use this email for
-all workspace-mcp calendar calls.
+Use the Google account email from CLAUDE.md for all workspace-mcp calendar
+calls.
 
 Google Calendar lookups must check ALL calendars, not just the primary.
-Joe has multiple calendars (personal, work, birthdays, shared, etc.) and
-events on secondary calendars are frequently missed.
+The user may have multiple calendars (personal, work, birthdays, shared, etc.)
+and events on secondary calendars are frequently missed.
 
 ## Steps
 
@@ -35,7 +35,7 @@ events on secondary calendars are frequently missed.
 ## Rules
 
 - Never skip a calendar — even if the name looks irrelevant, it may contain
-  events Joe cares about
+  relevant events
 - If a calendar API call fails, note which calendar failed and continue with
   the others — don't abort the whole check
 - For conflict checking, flag any overlapping events across all calendars

--- a/.claude/skills/journal-write/SKILL.md
+++ b/.claude/skills/journal-write/SKILL.md
@@ -10,66 +10,22 @@ description: >
 # Journal Write Skill
 
 Write a structured daily journal entry from collected data and analysis.
-
-ARGUMENTS: the skill receives the date (YYYY-MM-DD) and the analysis content
-to write. If no arguments, use today's date.
+The date and analysis content come from the conversation context (e.g. the
+evening reflection passes its gathered data and analysis here).
 
 ## Step 1 — Read inputs
 
-- Read `/vault/Bede/journal-template.md` for the canonical structure
-- Read `/vault/Bede/reflection-memory.md` for formatting corrections and
-  preferences from past reflections — these override defaults
+- Read `/vault/Bede/journal-template.md` for the canonical structure — follow
+  it exactly
+- Read `/vault/Bede/reflection-memory.md` for corrections and preferences
+  from past reflections — these override the template defaults and the
+  quality checks below
 - Read `/vault/Journal/[date].md` if it exists — check for an existing
   `## Priorities` section to preserve
 
-## Step 2 — Build the journal file
+## Step 2 — Quality checks before writing
 
-Follow the template structure exactly:
-
-```markdown
----
-date: YYYY-MM-DD
-author: bede
-type: journal
-tags:
-  - daily
----
-
-# YYYY-MM-DD
-
-## Priorities
-[preserve from existing file if present, otherwise from analysis]
-
-## Timeline
-*Generated HH:MM*
-
-### Weather
-[conditions, high/low, precipitation, wind]
-
-[chronological reconstruction from all data sources]
-- **~HH:MM** — [event/activity] *(source)*
-
-## Analysis
-
-### Health
-### Work
-### Family
-### Screen Time
-### Safari
-### YouTube
-### Professional Development
-### Wellbeing
-
-## Priorities Check
-- ✓/✗/~/? [priority] — [evidence]
-
-> [one honest paragraph — Bede's assessment in second person]
-
-## Tomorrow's Priorities
-- [suggested priorities based on schedule and goals]
-```
-
-## Step 3 — Quality checks before writing
+Apply these checks to the analysis content before writing the journal:
 
 - **Timeline is the backbone.** It must be built from actual data, not
   summaries. Include approximate times, source attribution, and location
@@ -86,39 +42,21 @@ tags:
 - **Every section must have content or "data unavailable".** Never silently
   skip a section.
 
-## Step 4 — Write the journal
+## Step 3 — Write the journal
 
-Write to `/vault/Journal/[date].md`. If the file exists and has a
-`## Priorities` section, preserve that section and replace everything else.
+Write to `/vault/Journal/[date].md` following the structure from
+`journal-template.md`. If the file exists and has a `## Priorities` section,
+preserve that section and replace everything else.
 
-## Step 5 — Write tomorrow's priorities
+## Step 4 — Write tomorrow's priorities
 
-Calculate tomorrow's date. Create or update `/vault/Journal/[tomorrow].md`:
-
-```markdown
-# [tomorrow's date]
-
-## Priorities
-- [each suggested priority]
-```
+Calculate tomorrow's date. Create or update `/vault/Journal/[tomorrow].md`
+with a `## Priorities` section containing the suggested priorities.
 
 If tomorrow's file already exists, only add/update the `## Priorities`
 section — do not overwrite other content.
 
-## Step 6 — Commit and push
+## Step 5 — Commit and push
 
-Use `/vault-write` or directly:
-```bash
-cd /vault && git add -A && git commit -m "journal: [date] evening reflection" && git push
-```
-
-## Common mistakes (from reflection-memory.md)
-
-Read `/vault/Bede/reflection-memory.md` each time — it contains corrections
-Joe has given about past journal entries. These override any defaults above.
-Typical issues include:
-- Incorrect categorisation of screen time (e.g. calling productive time
-  "mindless")
-- Missing data sources that were available but not queried
-- Overly generous or overly harsh assessments
-- Wrong time attributions in the timeline
+Use /vault-write to commit both files with message
+`journal: [date] evening reflection`.

--- a/.claude/skills/journal-write/SKILL.md
+++ b/.claude/skills/journal-write/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: journal-write
+description: >
+  Write a daily journal entry to /vault/Journal/YYYY-MM-DD.md. Use this skill
+  when writing or updating journal entries, including from the evening
+  reflection. Handles the template, formatting, priorities preservation, and
+  tomorrow's file.
+---
+
+# Journal Write Skill
+
+Write a structured daily journal entry from collected data and analysis.
+
+ARGUMENTS: the skill receives the date (YYYY-MM-DD) and the analysis content
+to write. If no arguments, use today's date.
+
+## Step 1 — Read inputs
+
+- Read `/vault/Bede/journal-template.md` for the canonical structure
+- Read `/vault/Bede/reflection-memory.md` for formatting corrections and
+  preferences from past reflections — these override defaults
+- Read `/vault/Journal/[date].md` if it exists — check for an existing
+  `## Priorities` section to preserve
+
+## Step 2 — Build the journal file
+
+Follow the template structure exactly:
+
+```markdown
+---
+date: YYYY-MM-DD
+author: bede
+type: journal
+tags:
+  - daily
+---
+
+# YYYY-MM-DD
+
+## Priorities
+[preserve from existing file if present, otherwise from analysis]
+
+## Timeline
+*Generated HH:MM*
+
+### Weather
+[conditions, high/low, precipitation, wind]
+
+[chronological reconstruction from all data sources]
+- **~HH:MM** — [event/activity] *(source)*
+
+## Analysis
+
+### Health
+### Work
+### Family
+### Screen Time
+### Safari
+### YouTube
+### Professional Development
+### Wellbeing
+
+## Priorities Check
+- ✓/✗/~/? [priority] — [evidence]
+
+> [one honest paragraph — Bede's assessment in second person]
+
+## Tomorrow's Priorities
+- [suggested priorities based on schedule and goals]
+```
+
+## Step 3 — Quality checks before writing
+
+- **Timeline is the backbone.** It must be built from actual data, not
+  summaries. Include approximate times, source attribution, and location
+  transitions. Collapse quiet periods but don't skip them.
+- **Screen Time, Safari, YouTube must be critical.** Flag mindless consumption
+  directly. Don't soften or hedge. "You spent 2 hours on Reddit" not "there
+  was some browsing activity."
+- **Priorities Check needs evidence.** Each priority gets a symbol (✓/✗/~/?)
+  with a one-line justification referencing actual data (workout logs, location,
+  screen time, calendar).
+- **The honest paragraph** is Bede's voice in second person. It should name
+  the gap between intention and behaviour, or acknowledge when the day went
+  well. Don't be vague or generic.
+- **Every section must have content or "data unavailable".** Never silently
+  skip a section.
+
+## Step 4 — Write the journal
+
+Write to `/vault/Journal/[date].md`. If the file exists and has a
+`## Priorities` section, preserve that section and replace everything else.
+
+## Step 5 — Write tomorrow's priorities
+
+Calculate tomorrow's date. Create or update `/vault/Journal/[tomorrow].md`:
+
+```markdown
+# [tomorrow's date]
+
+## Priorities
+- [each suggested priority]
+```
+
+If tomorrow's file already exists, only add/update the `## Priorities`
+section — do not overwrite other content.
+
+## Step 6 — Commit and push
+
+Use `/vault-write` or directly:
+```bash
+cd /vault && git add -A && git commit -m "journal: [date] evening reflection" && git push
+```
+
+## Common mistakes (from reflection-memory.md)
+
+Read `/vault/Bede/reflection-memory.md` each time — it contains corrections
+Joe has given about past journal entries. These override any defaults above.
+Typical issues include:
+- Incorrect categorisation of screen time (e.g. calling productive time
+  "mindless")
+- Missing data sources that were available but not queried
+- Overly generous or overly harsh assessments
+- Wrong time attributions in the timeline

--- a/.claude/skills/vault-write/SKILL.md
+++ b/.claude/skills/vault-write/SKILL.md
@@ -3,13 +3,16 @@ name: vault-write
 description: >
   Write a file to the Obsidian vault and commit + push to git. Use this
   skill ANY time you write or modify a file under /vault/ to ensure changes
-  are persisted and synced.
+  are persisted and synced. This includes journal entries, reflection memory,
+  scout memory, preference files, and any other vault content.
 ---
 
 # Vault Write Skill
 
-Every vault write must be followed by a git commit and push. This skill
-ensures nothing is lost.
+The vault on the server is a git clone that pulls on every task execution.
+Any file written but not committed and pushed is invisible to Bede until the
+next git push — there is no other sync mechanism. This is why every write
+must be followed by a commit.
 
 ## Steps
 
@@ -26,10 +29,18 @@ The commit message should be short and descriptive:
 - `bede: scout memory 2026-04-28`
 - `vault: update event preferences`
 
+## Error handling
+
+- **Push conflict:** run `git pull --rebase && git push`
+- **Dirty index from previous failed commit:** run `git reset` then re-stage
+  and commit cleanly
+- **Auth failure:** report the error to the user — do not retry silently
+- **No .git directory:** report that the vault is not a git repo — something
+  is wrong with the container setup
+
 ## Rules
 
 - Always commit immediately after writing — never leave uncommitted changes
-- If the push fails (e.g. conflict), run `git pull --rebase && git push`
 - If multiple files are written as part of one logical operation, commit them
   together in a single commit
 - Never force push

--- a/.claude/skills/vault-write/SKILL.md
+++ b/.claude/skills/vault-write/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: vault-write
+description: >
+  Write a file to the Obsidian vault and commit + push to git. Use this
+  skill ANY time you write or modify a file under /vault/ to ensure changes
+  are persisted and synced.
+---
+
+# Vault Write Skill
+
+Every vault write must be followed by a git commit and push. This skill
+ensures nothing is lost.
+
+## Steps
+
+1. Write or modify the file(s) under `/vault/`.
+2. Stage, commit, and push:
+
+```bash
+cd /vault && git add -A && git commit -m "<short description>" && git push
+```
+
+The commit message should be short and descriptive:
+- `journal: 2026-04-28 evening reflection`
+- `bede: update reflection memory`
+- `bede: scout memory 2026-04-28`
+- `vault: update event preferences`
+
+## Rules
+
+- Always commit immediately after writing — never leave uncommitted changes
+- If the push fails (e.g. conflict), run `git pull --rebase && git push`
+- If multiple files are written as part of one logical operation, commit them
+  together in a single commit
+- Never force push

--- a/CLAUDE.md.example
+++ b/CLAUDE.md.example
@@ -50,6 +50,7 @@ Follow the "How Bede Uses These Goals" section in goals.md for accountability gu
 - If uncertain about intent, ask one clarifying question rather than guessing
 - For scheduled briefings, include a date/time header so context is clear
 - When creating markdown files, include `author: Bede` in YAML frontmatter
+- After any vault write, commit and push: `cd /vault && git add -A && git commit -m "<short description>" && git push`
 
 ## Personal Data
 

--- a/bot.py
+++ b/bot.py
@@ -342,7 +342,7 @@ async def _trigger_task(update: Update, task_name: str):
 
 
 async def handle_scout(update: Update, context: ContextTypes.DEFAULT_TYPE):
-    await _trigger_task(update, "Sunday Scout")
+    await _trigger_task(update, "Deal Scout")
 
 
 async def handle_morning(update: Update, context: ContextTypes.DEFAULT_TYPE):
@@ -368,7 +368,7 @@ async def post_init(app):
         BotCommand("reset", "Clear session and start fresh"),
         BotCommand("morning", "Run the Morning Briefing"),
         BotCommand("evening", "Run the Evening Reflection"),
-        BotCommand("scout", "Run the Sunday Scout price checker"),
+        BotCommand("scout", "Run the Deal Scout"),
         BotCommand("datacheck", "Run the Evening Data Check"),
         BotCommand("triage", "Triage today's emails for tasks and events"),
     ]


### PR DESCRIPTION
## Summary

- **Three new Claude Code skills** for Bede runtime (`.claude/skills/`):
  - `vault-write` — standardizes git commit+push after any vault file modification
  - `journal-write` — template-aware journal writing with quality checks, priorities preservation, and tomorrow's file creation
  - `calendar-check` — multi-calendar lookup that checks ALL Google calendars, not just primary
- **Rename `/scout`** trigger from "Sunday Scout" → "Deal Scout" (matching vault task rename)
- **CLAUDE.md.example** — add vault-write rule so all vault modifications are committed and pushed

Vault-side changes (scheduled-tasks.md) are deployed separately via vault sync and include:
- New Email Triage task (20:30 weekdays, interactive)
- Evening Reflection moved to 21:00 and slimmed down to use skills
- Morning Briefing: birthday calendar + news newsletter integration
- Deal Scout: venue calendar browsing, music newsletter emails, pruning rules
- All calendar checks now use /calendar-check skill
- Scout preamble: stricter no-preamble rules

## Test plan

- [ ] `/scout` triggers "Deal Scout" (not "Sunday Scout")
- [ ] Skills appear in `claude -p` system prompt inside container
- [ ] `/journal-write` produces correct template structure with frontmatter
- [ ] `/calendar-check` returns events from all calendars, not just primary
- [ ] `/vault-write` commits and pushes after file modification
- [ ] Existing commands (`/morning`, `/evening`, `/triage`, `/datacheck`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)