### PR TITLE
fix: decouple data-mcp from home-server-stack hostnames

### DIFF
--- a/data-mcp/server.py
+++ b/data-mcp/server.py
@@ -1,5 +1,6 @@
 """Bede Data MCP — FastMCP server exposing personal data tools."""
 
+import httpx
 from fastmcp import FastMCP
 
 from sources import health, location, vault, weather
@@ -136,7 +137,10 @@ async def get_location_summary(
         date: Local date — 'YYYY-MM-DD', 'today', or 'yesterday'.
         timezone: Olson timezone name (default: Australia/Sydney).
     """
-    return await location.get_location_summary(date, timezone=timezone)
+    try:
+        return await location.get_location_summary(date, timezone=timezone)
+    except (RuntimeError, httpx.ConnectError, httpx.HTTPStatusError) as e:
+        return {"error": "Location service unavailable", "detail": str(e)}
 
 
 @mcp.tool()
@@ -152,7 +156,10 @@ async def get_location_raw(
         to_date: End local date ('YYYY-MM-DD').
         timezone: Olson timezone name.
     """
-    return await location.get_location_raw(from_date, to_date, timezone=timezone)
+    try:
+        return await location.get_location_raw(from_date, to_date, timezone=timezone)
+    except (RuntimeError, httpx.ConnectError, httpx.HTTPStatusError) as e:
+        return {"error": "Location service unavailable", "detail": str(e)}
 
 
 # ---------------------------------------------------------------------------
@@ -255,7 +262,10 @@ async def get_weather() -> dict:
     daily forecast with rain chance, UV index, and sunrise/sunset times.
     Data sourced from the Australian Bureau of Meteorology.
     """
-    return await weather.get_weather()
+    try:
+        return await weather.get_weather()
+    except (httpx.ConnectError, httpx.HTTPStatusError) as e:
+        return {"error": "Weather service unavailable", "detail": str(e)}
 
 
 # ---------------------------------------------------------------------------

--- a/data-mcp/sources/location.py
+++ b/data-mcp/sources/location.py
@@ -12,8 +12,8 @@ from .common import DEFAULT_TZ, fmt_time, local_date_to_utc_range, resolve_date
 OWNTRACKS_URL = os.environ.get("OWNTRACKS_URL", "http://owntracks-recorder:8083")
 OWNTRACKS_USER = os.environ.get("OWNTRACKS_USER", "")
 OWNTRACKS_DEVICE = os.environ.get("OWNTRACKS_DEVICE", "")
-NOMINATIM_URL = "https://nominatim.openstreetmap.org/reverse"
-USER_AGENT = "data-mcp/1.0 (home-server-stack; personal use)"
+NOMINATIM_URL = os.environ.get("NOMINATIM_URL", "https://nominatim.openstreetmap.org/reverse")
+USER_AGENT = "data-mcp/1.0 (bede; personal use)"
 
 # In-memory geocoding cache: (lat_rounded, lon_rounded) -> place string
 _geocache: dict[tuple[float, float], dict] = {}
@@ -50,10 +50,20 @@ async def _fetch_points(from_date: date, to_date: date) -> list[dict]:
         "from": from_date.isoformat(),
         "to": to_date.isoformat(),
     }
-    async with httpx.AsyncClient(timeout=30) as client:
-        r = await client.get(f"{OWNTRACKS_URL}/api/0/locations", params=params)
-        r.raise_for_status()
-        data = r.json()
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            r = await client.get(f"{OWNTRACKS_URL}/api/0/locations", params=params)
+            r.raise_for_status()
+            data = r.json()
+    except httpx.ConnectError:
+        raise RuntimeError(
+            f"OwnTracks Recorder unreachable at {OWNTRACKS_URL}. "
+            "Set OWNTRACKS_URL to the correct address."
+        )
+    except httpx.HTTPStatusError as e:
+        raise RuntimeError(
+            f"OwnTracks Recorder returned {e.response.status_code} from {OWNTRACKS_URL}."
+        )
     return data.get("data", [])
 
 
@@ -63,13 +73,16 @@ async def _reverse_geocode(lat: float, lon: float) -> dict:
     if key in _geocache:
         return _geocache[key]
 
-    async with httpx.AsyncClient(timeout=10, headers={"User-Agent": USER_AGENT}) as client:
-        r = await client.get(
-            NOMINATIM_URL,
-            params={"lat": lat, "lon": lon, "format": "json"},
-        )
-        r.raise_for_status()
-        geo = r.json()
+    try:
+        async with httpx.AsyncClient(timeout=10, headers={"User-Agent": USER_AGENT}) as client:
+            r = await client.get(
+                NOMINATIM_URL,
+                params={"lat": lat, "lon": lon, "format": "json"},
+            )
+            r.raise_for_status()
+            geo = r.json()
+    except (httpx.ConnectError, httpx.HTTPStatusError):
+        geo = {"display_name": f"{lat:.4f}, {lon:.4f}", "address": {}}
 
     _geocache[key] = geo
     return geo

--- a/data-mcp/sources/weather.py
+++ b/data-mcp/sources/weather.py
@@ -1,8 +1,10 @@
 """Weather data via homepage-api BOM endpoint."""
 
+import os
+
 import httpx
 
-HOMEPAGE_API_URL = "http://homepage-api:5000"
+HOMEPAGE_API_URL = os.environ.get("HOMEPAGE_API_URL", "http://homepage-api:5000")
 
 
 async def get_weather() -> dict:


### PR DESCRIPTION
## Summary
- Add `HOMEPAGE_API_URL` and `NOMINATIM_URL` env var overrides (matching existing `OWNTRACKS_URL` pattern)
- Add graceful error handling: location/weather MCP tools return error dicts instead of crashing when backing services are unreachable
- Update User-Agent string from `home-server-stack` to `bede`

Closes #3

## Test plan
- [ ] Deploy and call `get_weather` — should return weather data as before
- [ ] Deploy and call `get_location_summary` — should return location data as before
- [ ] Stop homepage-api, call `get_weather` — should return `{"error": "Weather service unavailable", ...}` instead of crashing
- [ ] Verify Nominatim geocoding still works in location summaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)