### PR TITLE
fix: prevent event loop deadlock on subprocess timeout

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -9,6 +9,7 @@ import asyncio
 import json
 import logging
 import os
+import signal
 import subprocess
 import time
 
@@ -176,25 +177,41 @@ def _parse_output(stdout: str) -> tuple[str, str | None]:
     return result_text, session_id
 
 
+CLAUDE_TIMEOUT = 120
+
 def _run_claude(cmd: list[str], workdir: str) -> subprocess.CompletedProcess:
-    return subprocess.run(
-        cmd,
-        capture_output=True,
-        text=True,
-        stdin=subprocess.DEVNULL,
-        cwd=workdir,
-        timeout=120,
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        stdin=subprocess.DEVNULL, cwd=workdir, text=True,
+        start_new_session=True,
     )
+    try:
+        stdout, stderr = proc.communicate(timeout=CLAUDE_TIMEOUT)
+        return subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except (ProcessLookupError, OSError):
+            proc.kill()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            pass
+        raise
 
 
-async def _keep_typing(bot, chat_id: int):
-    """Sends typing action every 4s so it doesn't expire while Claude thinks."""
-    while True:
+TYPING_MAX_DURATION = 600
+
+async def _keep_typing(bot, chat_id: int, max_duration: float = TYPING_MAX_DURATION):
+    """Sends typing action every 4s. Auto-stops after max_duration as a safety net."""
+    deadline = time.monotonic() + max_duration
+    while time.monotonic() < deadline:
         try:
             await bot.send_chat_action(chat_id=chat_id, action="typing")
         except Exception:
             pass
         await asyncio.sleep(4)
+    log.warning("Typing indicator exceeded %ds safety limit.", int(max_duration))
 
 
 async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):

--- a/scheduler.py
+++ b/scheduler.py
@@ -26,6 +26,7 @@ import logging
 import os
 import signal
 import subprocess
+import time
 from datetime import datetime, timezone
 from zoneinfo import ZoneInfo
 
@@ -109,14 +110,18 @@ async def _send(text: str):
         log.error("Failed to send scheduled message: %s", e)
 
 
-async def _keep_typing():
-    """Send typing action every 4s so it doesn't expire while a task runs."""
-    while True:
+TYPING_MAX_DURATION = 3600
+
+async def _keep_typing(max_duration: float = TYPING_MAX_DURATION):
+    """Send typing action every 4s. Auto-stops after max_duration as a safety net."""
+    deadline = time.monotonic() + max_duration
+    while time.monotonic() < deadline:
         try:
             await _bot.send_chat_action(chat_id=_chat_id, action="typing")
         except Exception:
             pass
         await asyncio.sleep(4)
+    log.warning("Typing indicator exceeded %ds safety limit.", int(max_duration))
 
 
 DEFAULT_TASK_TIMEOUT = 300  # seconds
@@ -162,8 +167,21 @@ async def _run_subprocess(cmd: list[str], timeout: int, task_name: str) -> subpr
         stdout, stderr = await asyncio.to_thread(proc.communicate, timeout=timeout)
         return subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
     except subprocess.TimeoutExpired:
-        os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-        proc.wait()
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        except (ProcessLookupError, OSError):
+            pass
+        try:
+            await asyncio.to_thread(proc.wait, 10)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except (ProcessLookupError, OSError):
+                proc.kill()
+            try:
+                await asyncio.to_thread(proc.wait, 5)
+            except subprocess.TimeoutExpired:
+                pass
         raise
     finally:
         _running_procs.pop(task_name, None)
@@ -211,7 +229,10 @@ async def _run_task(task: dict):
 
     _running_tasks[name] = asyncio.current_task()
     await asyncio.to_thread(_pull_vault)
-    typing_task = asyncio.create_task(_keep_typing())
+    timeout = int(task.get("timeout", DEFAULT_TASK_TIMEOUT))
+    steps = task.get("steps")
+    max_typing = (timeout * len(steps) + 120) if steps else (timeout + 120)
+    typing_task = asyncio.create_task(_keep_typing(max_duration=max_typing))
     try:
         await _run_task_inner(task, name)
     except asyncio.CancelledError:


### PR DESCRIPTION
## Summary

- The Evening Reflection task hung tonight because `proc.wait()` in the timeout handler blocked the asyncio event loop. When Claude CLI didn't exit cleanly on SIGTERM (mid-MCP call), the entire bot froze — no typing, no polling, no message processing
- `scheduler.py`: moved `proc.wait()` to `asyncio.to_thread()` so it never blocks the event loop, added SIGTERM → SIGKILL escalation after 10s
- `bot.py`: switched `subprocess.run()` to `Popen` with `start_new_session=True` and process-group SIGKILL on timeout
- Both files: added `max_duration` safety net to `_keep_typing()` so the typing indicator self-stops even if task cancellation never reaches it

## Test plan

- [ ] Deploy to server and trigger Evening Reflection manually (`/evening`)
- [ ] Verify task completes or times out cleanly without freezing the bot
- [ ] Send a message during a running task to confirm the event loop stays responsive
- [ ] Check logs for clean SIGTERM → SIGKILL escalation if timeout fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)