### PR TITLE
fix: detect truncated output and improve message chunking

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -153,13 +153,14 @@ def _append_correction(text: str):
         log.warning("Failed to commit reflection correction: %s", e)
 
 
-def _parse_output(stdout: str) -> tuple[str, str | None]:
+def _parse_output(stdout: str) -> tuple[str, str | None, str]:
     """
     claude --output-format json emits newline-delimited JSON objects.
-    The final object with type=result contains the answer and session_id.
+    The final object with type=result contains the answer, session_id, and stop_reason.
     """
     result_text = ""
     session_id = None
+    stop_reason = "end_turn"
 
     for line in stdout.splitlines():
         line = line.strip()
@@ -173,8 +174,30 @@ def _parse_output(stdout: str) -> tuple[str, str | None]:
         if obj.get("type") == "result":
             result_text = obj.get("result", "").strip()
             session_id = obj.get("session_id")
+            stop_reason = obj.get("stop_reason", "end_turn")
 
-    return result_text, session_id
+    return result_text, session_id, stop_reason
+
+
+def _chunk_text(text: str, max_len: int = 4096) -> list[str]:
+    """Split text into chunks at paragraph boundaries to avoid breaking markdown."""
+    if len(text) <= max_len:
+        return [text]
+    chunks = []
+    while text:
+        if len(text) <= max_len:
+            chunks.append(text)
+            break
+        split_at = text.rfind("\n\n", 0, max_len)
+        if split_at == -1:
+            split_at = text.rfind("\n", 0, max_len)
+        if split_at == -1:
+            split_at = text.rfind(" ", 0, max_len)
+        if split_at == -1:
+            split_at = max_len
+        chunks.append(text[:split_at].rstrip())
+        text = text[split_at:].lstrip("\n")
+    return chunks
 
 
 CLAUDE_TIMEOUT = 120
@@ -281,11 +304,15 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
         await update.message.reply_text(REAUTH_NOTICE, parse_mode="Markdown")
         return
 
-    result_text, new_session_id = _parse_output(proc.stdout)
+    result_text, new_session_id, stop_reason = _parse_output(proc.stdout)
 
     if not result_text:
         # Fallback: surface raw output so failures are visible
         result_text = (proc.stdout or proc.stderr or "No response.").strip()[:4096]
+
+    if stop_reason == "max_tokens":
+        log.warning("Response was truncated (stop_reason=max_tokens).")
+        result_text += "\n\n⚠️ _Response was truncated (output token limit reached)._"
 
     # Update session state
     if interactive and new_session_id:
@@ -303,8 +330,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if _sessions.pop(chat_id, None):
             await update.message.reply_text("_(Session reset — previous context lost)_", parse_mode="Markdown")
 
-    # Telegram message limit is 4096 chars; convert markdown to HTML, fall back to plain text
-    for chunk in [result_text[i:i + 4096] for i in range(0, len(result_text), 4096)]:
+    for chunk in _chunk_text(result_text):
         try:
             await update.message.reply_text(md_to_html(chunk), parse_mode="HTML")
         except Exception:

--- a/scheduler.py
+++ b/scheduler.py
@@ -97,8 +97,29 @@ def _parse_tasks() -> list[dict]:
         return []
 
 
+def _chunk_text(text: str, max_len: int = 4096) -> list[str]:
+    """Split text into chunks at paragraph boundaries to avoid breaking markdown."""
+    if len(text) <= max_len:
+        return [text]
+    chunks = []
+    while text:
+        if len(text) <= max_len:
+            chunks.append(text)
+            break
+        split_at = text.rfind("\n\n", 0, max_len)
+        if split_at == -1:
+            split_at = text.rfind("\n", 0, max_len)
+        if split_at == -1:
+            split_at = text.rfind(" ", 0, max_len)
+        if split_at == -1:
+            split_at = max_len
+        chunks.append(text[:split_at].rstrip())
+        text = text[split_at:].lstrip("\n")
+    return chunks
+
+
 async def _send(text: str):
-    """Send a message to the user's Telegram chat."""
+    """Send a message to the user's Telegram chat, falling back to plain text."""
     try:
         await _bot.send_message(
             chat_id=_chat_id,
@@ -106,8 +127,15 @@ async def _send(text: str):
             parse_mode="HTML",
             disable_web_page_preview=True,
         )
-    except Exception as e:
-        log.error("Failed to send scheduled message: %s", e)
+    except Exception:
+        try:
+            await _bot.send_message(
+                chat_id=_chat_id,
+                text=text,
+                disable_web_page_preview=True,
+            )
+        except Exception as e:
+            log.error("Failed to send scheduled message: %s", e)
 
 
 TYPING_MAX_DURATION = 3600
@@ -202,9 +230,10 @@ def _extract_session_id(stdout: str) -> str | None:
     return None
 
 
-def _extract_result(stdout: str) -> str:
-    """Extract the result text from claude --output-format json output."""
+def _extract_result(stdout: str) -> tuple[str, str]:
+    """Extract result text and stop_reason from claude JSON output."""
     result_text = ""
+    stop_reason = "end_turn"
     for line in stdout.splitlines():
         line = line.strip()
         if not line:
@@ -213,9 +242,10 @@ def _extract_result(stdout: str) -> str:
             obj = json.loads(line)
             if obj.get("type") == "result":
                 result_text = obj.get("result", "").strip()
+                stop_reason = obj.get("stop_reason", "end_turn")
         except json.JSONDecodeError:
             continue
-    return result_text
+    return result_text, stop_reason
 
 
 async def _run_task(task: dict):
@@ -289,7 +319,7 @@ async def _run_task_inner(task: dict, name: str):
         await _send(f"📅 *{name}*\n⚠️ Error: {e}")
         return
 
-    result_text = _extract_result(proc.stdout)
+    result_text, stop_reason = _extract_result(proc.stdout)
 
     if not result_text:
         if proc.returncode != 0:
@@ -297,8 +327,12 @@ async def _run_task_inner(task: dict, name: str):
         else:
             result_text = (proc.stdout or proc.stderr or "No response.").strip()
 
+    if stop_reason == "max_tokens":
+        log.warning("Task '%s' output was truncated (stop_reason=max_tokens).", name)
+        result_text += "\n\n⚠️ _Response was truncated (output token limit reached)._"
+
     full = header + result_text
-    for chunk in [full[i:i + 4096] for i in range(0, len(full), 4096)]:
+    for chunk in _chunk_text(full):
         await _send(chunk)
 
     if task.get("interactive"):
@@ -369,13 +403,17 @@ async def _run_single_step(step: dict, task_name: str, model: str, preamble: str
     except Exception as e:
         return step_name, f"⚠️ *{step_name}* — error: {e}", silent
 
-    result_text = _extract_result(proc.stdout)
+    result_text, stop_reason = _extract_result(proc.stdout)
 
     if not result_text:
         if proc.returncode != 0:
             result_text = f"⚠️ Failed (exit {proc.returncode}):\n{(proc.stderr or proc.stdout or 'No output.')[:500]}"
         else:
             result_text = (proc.stdout or proc.stderr or "No output.").strip()
+
+    if stop_reason == "max_tokens":
+        log.warning("Step '%s' output was truncated (stop_reason=max_tokens).", step_name)
+        result_text += "\n\n⚠️ _Response was truncated._"
 
     return step_name, result_text, silent
 
@@ -412,7 +450,7 @@ async def _run_steps_task(task: dict, name: str, steps: list[dict]):
                 step, name, model, preamble, now_date_str, step_timeout,
             )
             if not silent and result_text:
-                for chunk in [result_text[j:j + 4096] for j in range(0, len(result_text), 4096)]:
+                for chunk in _chunk_text(result_text):
                     await _send(chunk)
             elif silent:
                 log.info("Silent step '%s' completed.", step_name)
@@ -435,7 +473,7 @@ async def _run_steps_parallel(steps: list[dict], task_name: str, timeout: int,
         if result_text:
             visible = result_text.split(_NOTES_SEPARATOR, 1)[0].rstrip()
             if visible:
-                for chunk in [visible[j:j + 4096] for j in range(0, len(visible), 4096)]:
+                for chunk in _chunk_text(visible):
                     await _send(chunk)
         return step_name, result_text
 
@@ -463,7 +501,7 @@ async def _run_steps_parallel(steps: list[dict], task_name: str, timeout: int,
                 step, task_name, model, seq_preamble, now_date_str, step_timeout,
             )
             if not silent and result_text:
-                for chunk in [result_text[j:j + 4096] for j in range(0, len(result_text), 4096)]:
+                for chunk in _chunk_text(result_text):
                     await _send(chunk)
             else:
                 log.info("Silent step '%s' completed.", step_name)


### PR DESCRIPTION
## Summary

- Extract `stop_reason` from Claude CLI JSON output — when `max_tokens`, append a visible warning so truncation doesn't silently cut off responses mid-sentence
- Replace hard 4096-char splits with paragraph-aware `_chunk_text()` that splits at `\n\n` / `\n` / space boundaries, preventing broken markdown across Telegram messages
- Add plain text fallback to scheduler's `_send()` — if HTML conversion fails on a chunk, retry as plain text instead of silently dropping the message

## Test plan

- [ ] Trigger a task that produces >4096 chars of output and verify chunking splits at paragraph boundaries
- [ ] Check that truncated responses show the `⚠️ Response was truncated` warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)