### PR TITLE
feat: bede-data service — ingest, storage, analytics, and API layer

### DIFF
--- a/.github/workflows/bede-data-ci.yml
+++ b/.github/workflows/bede-data-ci.yml
@@ -1,0 +1,32 @@
+name: bede-data CI
+
+on:
+  pull_request:
+    paths:
+      - "bede-data/**"
+  push:
+    branches: [main]
+    paths:
+      - "bede-data/**"
+
+defaults:
+  run:
+    working-directory: bede-data
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - run: uv sync --dev
+      - run: uv run ruff check src/ tests/
+      - run: uv run ruff format --check src/ tests/
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - run: uv sync --dev
+      - run: uv run pytest tests/ -v --tb=short

--- a/.github/workflows/bede-data-ci.yml
+++ b/.github/workflows/bede-data-ci.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
-      - run: uv sync --dev
+      - run: uv sync --extra dev
       - run: uv run ruff check src/ tests/
       - run: uv run ruff format --check src/ tests/
 
@@ -28,5 +28,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
-      - run: uv sync --dev
+      - run: uv sync --extra dev
       - run: uv run pytest tests/ -v --tb=short

--- a/bede-data/Dockerfile
+++ b/bede-data/Dockerfile
@@ -17,4 +17,4 @@ EXPOSE 8001
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8001/health')" || exit 1
 
-CMD ["uv", "run", "uvicorn", "bede_data.app:create_app", "--factory", "--host", "0.0.0.0", "--port", "8001"]
+CMD [".venv/bin/uvicorn", "bede_data.app:create_app", "--factory", "--host", "0.0.0.0", "--port", "8001"]

--- a/bede-data/Dockerfile
+++ b/bede-data/Dockerfile
@@ -1,0 +1,20 @@
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+
+WORKDIR /app
+
+COPY pyproject.toml .
+RUN uv sync --no-dev --no-install-project
+
+COPY src/ src/
+
+RUN uv sync --no-dev
+
+RUN useradd --create-home --uid 1000 bede
+USER bede
+
+EXPOSE 8001
+
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8001/health')" || exit 1
+
+CMD ["uv", "run", "uvicorn", "bede_data.app:create_app", "--factory", "--host", "0.0.0.0", "--port", "8001"]

--- a/bede-data/pyproject.toml
+++ b/bede-data/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.25.0",
+    "ruff>=0.11.0",
 ]
 
 [build-system]

--- a/bede-data/pyproject.toml
+++ b/bede-data/pyproject.toml
@@ -1,0 +1,30 @@
+[project]
+name = "bede-data"
+version = "0.1.0"
+description = "Bede data layer: ingest, store, analyse, serve"
+requires-python = ">=3.12"
+dependencies = [
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.32.0",
+    "pydantic>=2.10.0",
+    "pydantic-settings>=2.7.0",
+    "httpx>=0.28.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.25.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/bede_data"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+asyncio_mode = "auto"

--- a/bede-data/src/bede_data/analytics/engine.py
+++ b/bede-data/src/bede_data/analytics/engine.py
@@ -1,0 +1,34 @@
+import json
+import sqlite3
+from datetime import datetime, timezone
+
+from bede_data.analytics.signals import (
+    compute_activity_flags,
+    compute_bedtime_flags,
+    compute_goal_flags,
+    compute_medication_flags,
+    compute_screen_time_flags,
+    compute_sleep_flags,
+)
+
+
+def run_analytics(conn: sqlite3.Connection) -> list[dict]:
+    all_flags = []
+    all_flags.extend(compute_sleep_flags(conn))
+    all_flags.extend(compute_activity_flags(conn))
+    all_flags.extend(compute_goal_flags(conn))
+    all_flags.extend(compute_screen_time_flags(conn))
+    all_flags.extend(compute_medication_flags(conn))
+    all_flags.extend(compute_bedtime_flags(conn))
+    return all_flags
+
+
+def store_flags(conn: sqlite3.Connection, flags: list[dict]) -> int:
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    for flag in flags:
+        conn.execute(
+            "INSERT INTO analytics_flags (signal, severity, detail, data, computed_at) VALUES (?, ?, ?, ?, ?)",
+            (flag["signal"], flag["severity"], flag.get("detail"), json.dumps(flag.get("data", {})), now),
+        )
+    conn.commit()
+    return len(flags)

--- a/bede-data/src/bede_data/analytics/engine.py
+++ b/bede-data/src/bede_data/analytics/engine.py
@@ -12,14 +12,56 @@ from bede_data.analytics.signals import (
 )
 
 
+def _load_thresholds(conn: sqlite3.Connection) -> dict:
+    cursor = conn.execute("SELECT signal, config FROM analytics_thresholds")
+    result = {}
+    for row in cursor.fetchall():
+        try:
+            result[row["signal"]] = json.loads(row["config"])
+        except (json.JSONDecodeError, TypeError):
+            continue
+    return result
+
+
 def run_analytics(conn: sqlite3.Connection) -> list[dict]:
+    thresholds = _load_thresholds(conn)
     all_flags = []
-    all_flags.extend(compute_sleep_flags(conn))
-    all_flags.extend(compute_activity_flags(conn))
-    all_flags.extend(compute_goal_flags(conn))
-    all_flags.extend(compute_screen_time_flags(conn))
+
+    sleep_cfg = thresholds.get("sleep_declining", {})
+    all_flags.extend(compute_sleep_flags(
+        conn,
+        target_hours=sleep_cfg.get("target_hours", 7.0),
+        window_days=sleep_cfg.get("window_days", 3),
+    ))
+
+    activity_cfg = thresholds.get("exercise_gap", {})
+    all_flags.extend(compute_activity_flags(
+        conn,
+        gap_threshold_days=activity_cfg.get("gap_threshold_days", 5),
+    ))
+
+    goal_cfg = thresholds.get("goal_stale", {})
+    all_flags.extend(compute_goal_flags(
+        conn,
+        stale_threshold_days=goal_cfg.get("stale_threshold_days", 14),
+    ))
+
+    screen_cfg = thresholds.get("passive_screen_up", {})
+    all_flags.extend(compute_screen_time_flags(
+        conn,
+        spike_threshold_pct=screen_cfg.get("spike_threshold_pct", 40),
+        window_days=screen_cfg.get("window_days", 7),
+    ))
+
     all_flags.extend(compute_medication_flags(conn))
-    all_flags.extend(compute_bedtime_flags(conn))
+
+    bedtime_cfg = thresholds.get("bedtime_drifting", {})
+    all_flags.extend(compute_bedtime_flags(
+        conn,
+        drift_threshold_minutes=bedtime_cfg.get("drift_threshold_minutes", 30),
+        window_days=bedtime_cfg.get("window_days", 7),
+    ))
+
     return all_flags
 
 

--- a/bede-data/src/bede_data/analytics/engine.py
+++ b/bede-data/src/bede_data/analytics/engine.py
@@ -13,6 +13,7 @@ from bede_data.analytics.signals import (
 
 
 def _load_thresholds(conn: sqlite3.Connection) -> dict:
+    """Load per-signal threshold overrides from analytics_thresholds table. Each row's config is a JSON object whose keys are passed as kwargs to the corresponding compute function."""
     cursor = conn.execute("SELECT signal, config FROM analytics_thresholds")
     result = {}
     for row in cursor.fetchall():
@@ -24,43 +25,54 @@ def _load_thresholds(conn: sqlite3.Connection) -> dict:
 
 
 def run_analytics(conn: sqlite3.Connection) -> list[dict]:
+    """Run all signal computations using DB-driven thresholds (falling back to hardcoded defaults). Returns a flat list of flag dicts ready for store_flags()."""
     thresholds = _load_thresholds(conn)
     all_flags = []
 
     sleep_cfg = thresholds.get("sleep_declining", {})
-    all_flags.extend(compute_sleep_flags(
-        conn,
-        target_hours=sleep_cfg.get("target_hours", 7.0),
-        window_days=sleep_cfg.get("window_days", 3),
-    ))
+    all_flags.extend(
+        compute_sleep_flags(
+            conn,
+            target_hours=sleep_cfg.get("target_hours", 7.0),
+            window_days=sleep_cfg.get("window_days", 3),
+        )
+    )
 
     activity_cfg = thresholds.get("exercise_gap", {})
-    all_flags.extend(compute_activity_flags(
-        conn,
-        gap_threshold_days=activity_cfg.get("gap_threshold_days", 5),
-    ))
+    all_flags.extend(
+        compute_activity_flags(
+            conn,
+            gap_threshold_days=activity_cfg.get("gap_threshold_days", 5),
+        )
+    )
 
     goal_cfg = thresholds.get("goal_stale", {})
-    all_flags.extend(compute_goal_flags(
-        conn,
-        stale_threshold_days=goal_cfg.get("stale_threshold_days", 14),
-    ))
+    all_flags.extend(
+        compute_goal_flags(
+            conn,
+            stale_threshold_days=goal_cfg.get("stale_threshold_days", 14),
+        )
+    )
 
     screen_cfg = thresholds.get("passive_screen_up", {})
-    all_flags.extend(compute_screen_time_flags(
-        conn,
-        spike_threshold_pct=screen_cfg.get("spike_threshold_pct", 40),
-        window_days=screen_cfg.get("window_days", 7),
-    ))
+    all_flags.extend(
+        compute_screen_time_flags(
+            conn,
+            spike_threshold_pct=screen_cfg.get("spike_threshold_pct", 40),
+            window_days=screen_cfg.get("window_days", 7),
+        )
+    )
 
     all_flags.extend(compute_medication_flags(conn))
 
     bedtime_cfg = thresholds.get("bedtime_drifting", {})
-    all_flags.extend(compute_bedtime_flags(
-        conn,
-        drift_threshold_minutes=bedtime_cfg.get("drift_threshold_minutes", 30),
-        window_days=bedtime_cfg.get("window_days", 7),
-    ))
+    all_flags.extend(
+        compute_bedtime_flags(
+            conn,
+            drift_threshold_minutes=bedtime_cfg.get("drift_threshold_minutes", 30),
+            window_days=bedtime_cfg.get("window_days", 7),
+        )
+    )
 
     return all_flags
 
@@ -70,7 +82,13 @@ def store_flags(conn: sqlite3.Connection, flags: list[dict]) -> int:
     for flag in flags:
         conn.execute(
             "INSERT INTO analytics_flags (signal, severity, detail, data, computed_at) VALUES (?, ?, ?, ?, ?)",
-            (flag["signal"], flag["severity"], flag.get("detail"), json.dumps(flag.get("data", {})), now),
+            (
+                flag["signal"],
+                flag["severity"],
+                flag.get("detail"),
+                json.dumps(flag.get("data", {})),
+                now,
+            ),
         )
     conn.commit()
     return len(flags)

--- a/bede-data/src/bede_data/analytics/signals.py
+++ b/bede-data/src/bede_data/analytics/signals.py
@@ -86,6 +86,25 @@ def compute_goal_flags(
             "detail": f"'{row['name']}' inactive for {days_inactive} days",
             "data": {"goal_id": row["id"], "goal_name": row["name"], "days_inactive": days_inactive},
         })
+
+    cursor = conn.execute(
+        "SELECT id, name, deadline, updated_at FROM goals WHERE status = 'active' AND deadline IS NOT NULL AND deadline > ?",
+        (ref,),
+    )
+    for row in cursor.fetchall():
+        deadline = datetime.strptime(row["deadline"], "%Y-%m-%d").date()
+        days_remaining = (deadline - ref_date).days
+        updated = datetime.fromisoformat(row["updated_at"].replace("Z", "+00:00")).date()
+        days_since_update = (ref_date - updated).days
+
+        if days_remaining <= 14 and days_since_update >= 7:
+            flags.append({
+                "signal": "goal_drifting",
+                "severity": "concern",
+                "detail": f"'{row['name']}' deadline in {days_remaining} days, no update for {days_since_update} days",
+                "data": {"goal_id": row["id"], "goal_name": row["name"], "days_remaining": days_remaining, "days_since_update": days_since_update},
+            })
+
     return flags
 
 

--- a/bede-data/src/bede_data/analytics/signals.py
+++ b/bede-data/src/bede_data/analytics/signals.py
@@ -1,0 +1,198 @@
+import sqlite3
+from datetime import date, datetime, timedelta
+
+
+def _today_str(reference_date: str | None = None) -> str:
+    return reference_date or date.today().isoformat()
+
+
+def _date_range(reference: str, window_days: int) -> tuple[str, str]:
+    end = datetime.strptime(reference, "%Y-%m-%d").date()
+    start = end - timedelta(days=window_days - 1)
+    return start.isoformat(), end.isoformat()
+
+
+def compute_sleep_flags(
+    conn: sqlite3.Connection,
+    target_hours: float = 7.0,
+    window_days: int = 3,
+    reference_date: str | None = None,
+) -> list[dict]:
+    ref = _today_str(reference_date)
+    start, end = _date_range(ref, window_days)
+    cursor = conn.execute(
+        "SELECT date, SUM(hours) as total FROM sleep_phases WHERE date BETWEEN ? AND ? GROUP BY date ORDER BY date",
+        (start, end),
+    )
+    rows = cursor.fetchall()
+    if len(rows) < window_days:
+        return []
+    avg = sum(r["total"] for r in rows) / len(rows)
+    if avg < target_hours:
+        return [{
+            "signal": "sleep_declining",
+            "severity": "concern",
+            "detail": f"avg {avg:.1f}h vs {target_hours}h target over {window_days} days",
+            "data": {"avg_hours": round(avg, 1), "target_hours": target_hours, "window_days": window_days},
+        }]
+    return []
+
+
+def compute_activity_flags(
+    conn: sqlite3.Connection,
+    gap_threshold_days: int = 5,
+    reference_date: str | None = None,
+) -> list[dict]:
+    ref = _today_str(reference_date)
+    cursor = conn.execute(
+        "SELECT MAX(date) as last_date FROM workouts"
+    )
+    row = cursor.fetchone()
+    if not row or not row["last_date"]:
+        return [{"signal": "exercise_gap", "severity": "nudge", "detail": "No workouts recorded", "data": {}}]
+    last = datetime.strptime(row["last_date"], "%Y-%m-%d").date()
+    today = datetime.strptime(ref, "%Y-%m-%d").date()
+    gap = (today - last).days
+    if gap >= gap_threshold_days:
+        return [{
+            "signal": "exercise_gap",
+            "severity": "nudge",
+            "detail": f"{gap} days since last workout",
+            "data": {"days_since": gap},
+        }]
+    return []
+
+
+def compute_goal_flags(
+    conn: sqlite3.Connection,
+    stale_threshold_days: int = 14,
+    reference_date: str | None = None,
+) -> list[dict]:
+    ref = _today_str(reference_date)
+    ref_date = datetime.strptime(ref, "%Y-%m-%d").date()
+    cutoff = (ref_date - timedelta(days=stale_threshold_days)).isoformat()
+
+    cursor = conn.execute(
+        "SELECT id, name, updated_at FROM goals WHERE status = 'active' AND updated_at < ?",
+        (cutoff,),
+    )
+    flags = []
+    for row in cursor.fetchall():
+        updated = datetime.fromisoformat(row["updated_at"].replace("Z", "+00:00")).date()
+        days_inactive = (ref_date - updated).days
+        flags.append({
+            "signal": "goal_stale",
+            "severity": "nudge",
+            "detail": f"'{row['name']}' inactive for {days_inactive} days",
+            "data": {"goal_id": row["id"], "goal_name": row["name"], "days_inactive": days_inactive},
+        })
+    return flags
+
+
+def compute_screen_time_flags(
+    conn: sqlite3.Connection,
+    spike_threshold_pct: float = 40,
+    window_days: int = 7,
+    reference_date: str | None = None,
+) -> list[dict]:
+    ref = _today_str(reference_date)
+    start, end = _date_range(ref, window_days)
+    ref_date = datetime.strptime(ref, "%Y-%m-%d").date()
+    mid = (ref_date - timedelta(days=window_days // 2)).isoformat()
+
+    cursor = conn.execute(
+        "SELECT name, SUM(seconds) as total FROM screen_time WHERE date BETWEEN ? AND ? AND date < ? AND entry_type = 'app' GROUP BY name",
+        (start, end, mid),
+    )
+    early = {row["name"]: row["total"] for row in cursor.fetchall()}
+
+    cursor = conn.execute(
+        "SELECT name, SUM(seconds) as total FROM screen_time WHERE date BETWEEN ? AND ? AND date >= ? AND entry_type = 'app' GROUP BY name",
+        (start, end, mid),
+    )
+    late = {row["name"]: row["total"] for row in cursor.fetchall()}
+
+    flags = []
+    for app_name, late_total in late.items():
+        early_total = early.get(app_name, 0)
+        if early_total > 0:
+            pct_change = ((late_total - early_total) / early_total) * 100
+            if pct_change >= spike_threshold_pct:
+                flags.append({
+                    "signal": "passive_screen_up",
+                    "severity": "info",
+                    "detail": f"{app_name} +{pct_change:.0f}% this week",
+                    "data": {"app": app_name, "pct_change": round(pct_change, 1)},
+                })
+    return flags
+
+
+def compute_medication_flags(
+    conn: sqlite3.Connection,
+    reference_date: str | None = None,
+) -> list[dict]:
+    ref = _today_str(reference_date)
+    yesterday = (datetime.strptime(ref, "%Y-%m-%d").date() - timedelta(days=1)).isoformat()
+
+    cursor = conn.execute(
+        "SELECT DISTINCT medication FROM medications WHERE date >= ?",
+        (yesterday,),
+    )
+    recent_meds = {row["medication"] for row in cursor.fetchall()}
+
+    cursor = conn.execute(
+        "SELECT DISTINCT medication FROM medications"
+    )
+    all_meds = {row["medication"] for row in cursor.fetchall()}
+
+    flags = []
+    for med in all_meds - recent_meds:
+        cursor2 = conn.execute(
+            "SELECT MAX(date) as last_date FROM medications WHERE medication = ?", (med,)
+        )
+        last = cursor2.fetchone()
+        flags.append({
+            "signal": "medication_missed",
+            "severity": "alert",
+            "detail": f"{med} not logged since {last['last_date'] if last else 'unknown'}",
+            "data": {"medication": med},
+        })
+    return flags
+
+
+def compute_bedtime_flags(
+    conn: sqlite3.Connection,
+    drift_threshold_minutes: int = 30,
+    window_days: int = 7,
+) -> list[dict]:
+    cursor = conn.execute(
+        "SELECT date, MIN(start_time) as bedtime FROM sleep_phases WHERE start_time IS NOT NULL GROUP BY date ORDER BY date DESC LIMIT ?",
+        (window_days,),
+    )
+    rows = cursor.fetchall()
+    if len(rows) < 4:
+        return []
+
+    def _extract_hour_min(ts: str) -> float:
+        try:
+            dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+            hour = dt.hour + dt.minute / 60
+            if hour < 12:
+                hour += 24
+            return hour
+        except (ValueError, AttributeError):
+            return 23.0
+
+    bedtimes = [_extract_hour_min(r["bedtime"]) for r in rows]
+    early_avg = sum(bedtimes[len(bedtimes)//2:]) / len(bedtimes[len(bedtimes)//2:])
+    late_avg = sum(bedtimes[:len(bedtimes)//2]) / len(bedtimes[:len(bedtimes)//2])
+    drift_minutes = (late_avg - early_avg) * 60
+
+    if abs(drift_minutes) >= drift_threshold_minutes:
+        return [{
+            "signal": "bedtime_drifting",
+            "severity": "info",
+            "detail": f"avg bedtime shifted {abs(drift_minutes):.0f}min {'later' if drift_minutes > 0 else 'earlier'}",
+            "data": {"drift_minutes": round(drift_minutes, 1)},
+        }]
+    return []

--- a/bede-data/src/bede_data/analytics/signals.py
+++ b/bede-data/src/bede_data/analytics/signals.py
@@ -18,6 +18,7 @@ def compute_sleep_flags(
     window_days: int = 3,
     reference_date: str | None = None,
 ) -> list[dict]:
+    """Flag 'sleep_declining' if average total sleep is below target over the window. Requires data for every day in the window — partial data returns no flags."""
     ref = _today_str(reference_date)
     start, end = _date_range(ref, window_days)
     cursor = conn.execute(
@@ -29,12 +30,18 @@ def compute_sleep_flags(
         return []
     avg = sum(r["total"] for r in rows) / len(rows)
     if avg < target_hours:
-        return [{
-            "signal": "sleep_declining",
-            "severity": "concern",
-            "detail": f"avg {avg:.1f}h vs {target_hours}h target over {window_days} days",
-            "data": {"avg_hours": round(avg, 1), "target_hours": target_hours, "window_days": window_days},
-        }]
+        return [
+            {
+                "signal": "sleep_declining",
+                "severity": "concern",
+                "detail": f"avg {avg:.1f}h vs {target_hours}h target over {window_days} days",
+                "data": {
+                    "avg_hours": round(avg, 1),
+                    "target_hours": target_hours,
+                    "window_days": window_days,
+                },
+            }
+        ]
     return []
 
 
@@ -43,23 +50,31 @@ def compute_activity_flags(
     gap_threshold_days: int = 5,
     reference_date: str | None = None,
 ) -> list[dict]:
+    """Flag 'exercise_gap' if no workouts recorded in the last N days."""
     ref = _today_str(reference_date)
-    cursor = conn.execute(
-        "SELECT MAX(date) as last_date FROM workouts"
-    )
+    cursor = conn.execute("SELECT MAX(date) as last_date FROM workouts")
     row = cursor.fetchone()
     if not row or not row["last_date"]:
-        return [{"signal": "exercise_gap", "severity": "nudge", "detail": "No workouts recorded", "data": {}}]
+        return [
+            {
+                "signal": "exercise_gap",
+                "severity": "nudge",
+                "detail": "No workouts recorded",
+                "data": {},
+            }
+        ]
     last = datetime.strptime(row["last_date"], "%Y-%m-%d").date()
     today = datetime.strptime(ref, "%Y-%m-%d").date()
     gap = (today - last).days
     if gap >= gap_threshold_days:
-        return [{
-            "signal": "exercise_gap",
-            "severity": "nudge",
-            "detail": f"{gap} days since last workout",
-            "data": {"days_since": gap},
-        }]
+        return [
+            {
+                "signal": "exercise_gap",
+                "severity": "nudge",
+                "detail": f"{gap} days since last workout",
+                "data": {"days_since": gap},
+            }
+        ]
     return []
 
 
@@ -68,6 +83,7 @@ def compute_goal_flags(
     stale_threshold_days: int = 14,
     reference_date: str | None = None,
 ) -> list[dict]:
+    """Flag 'goal_stale' for goals not updated in N days, and 'goal_drifting' for goals with deadlines within 14 days but no update in the last 7."""
     ref = _today_str(reference_date)
     ref_date = datetime.strptime(ref, "%Y-%m-%d").date()
     cutoff = (ref_date - timedelta(days=stale_threshold_days)).isoformat()
@@ -78,14 +94,22 @@ def compute_goal_flags(
     )
     flags = []
     for row in cursor.fetchall():
-        updated = datetime.fromisoformat(row["updated_at"].replace("Z", "+00:00")).date()
+        updated = datetime.fromisoformat(
+            row["updated_at"].replace("Z", "+00:00")
+        ).date()
         days_inactive = (ref_date - updated).days
-        flags.append({
-            "signal": "goal_stale",
-            "severity": "nudge",
-            "detail": f"'{row['name']}' inactive for {days_inactive} days",
-            "data": {"goal_id": row["id"], "goal_name": row["name"], "days_inactive": days_inactive},
-        })
+        flags.append(
+            {
+                "signal": "goal_stale",
+                "severity": "nudge",
+                "detail": f"'{row['name']}' inactive for {days_inactive} days",
+                "data": {
+                    "goal_id": row["id"],
+                    "goal_name": row["name"],
+                    "days_inactive": days_inactive,
+                },
+            }
+        )
 
     cursor = conn.execute(
         "SELECT id, name, deadline, updated_at FROM goals WHERE status = 'active' AND deadline IS NOT NULL AND deadline > ?",
@@ -94,16 +118,25 @@ def compute_goal_flags(
     for row in cursor.fetchall():
         deadline = datetime.strptime(row["deadline"], "%Y-%m-%d").date()
         days_remaining = (deadline - ref_date).days
-        updated = datetime.fromisoformat(row["updated_at"].replace("Z", "+00:00")).date()
+        updated = datetime.fromisoformat(
+            row["updated_at"].replace("Z", "+00:00")
+        ).date()
         days_since_update = (ref_date - updated).days
 
         if days_remaining <= 14 and days_since_update >= 7:
-            flags.append({
-                "signal": "goal_drifting",
-                "severity": "concern",
-                "detail": f"'{row['name']}' deadline in {days_remaining} days, no update for {days_since_update} days",
-                "data": {"goal_id": row["id"], "goal_name": row["name"], "days_remaining": days_remaining, "days_since_update": days_since_update},
-            })
+            flags.append(
+                {
+                    "signal": "goal_drifting",
+                    "severity": "concern",
+                    "detail": f"'{row['name']}' deadline in {days_remaining} days, no update for {days_since_update} days",
+                    "data": {
+                        "goal_id": row["id"],
+                        "goal_name": row["name"],
+                        "days_remaining": days_remaining,
+                        "days_since_update": days_since_update,
+                    },
+                }
+            )
 
     return flags
 
@@ -114,6 +147,7 @@ def compute_screen_time_flags(
     window_days: int = 7,
     reference_date: str | None = None,
 ) -> list[dict]:
+    """Flag 'passive_screen_up' per app if usage in the second half of the window exceeds the first half by the threshold percentage. Splits the window at the midpoint to compare early vs recent usage."""
     ref = _today_str(reference_date)
     start, end = _date_range(ref, window_days)
     ref_date = datetime.strptime(ref, "%Y-%m-%d").date()
@@ -137,12 +171,14 @@ def compute_screen_time_flags(
         if early_total > 0:
             pct_change = ((late_total - early_total) / early_total) * 100
             if pct_change >= spike_threshold_pct:
-                flags.append({
-                    "signal": "passive_screen_up",
-                    "severity": "info",
-                    "detail": f"{app_name} +{pct_change:.0f}% this week",
-                    "data": {"app": app_name, "pct_change": round(pct_change, 1)},
-                })
+                flags.append(
+                    {
+                        "signal": "passive_screen_up",
+                        "severity": "info",
+                        "detail": f"{app_name} +{pct_change:.0f}% this week",
+                        "data": {"app": app_name, "pct_change": round(pct_change, 1)},
+                    }
+                )
     return flags
 
 
@@ -150,8 +186,11 @@ def compute_medication_flags(
     conn: sqlite3.Connection,
     reference_date: str | None = None,
 ) -> list[dict]:
+    """Flag 'medication_missed' for any medication seen historically but not logged yesterday or today."""
     ref = _today_str(reference_date)
-    yesterday = (datetime.strptime(ref, "%Y-%m-%d").date() - timedelta(days=1)).isoformat()
+    yesterday = (
+        datetime.strptime(ref, "%Y-%m-%d").date() - timedelta(days=1)
+    ).isoformat()
 
     cursor = conn.execute(
         "SELECT DISTINCT medication FROM medications WHERE date >= ?",
@@ -159,23 +198,24 @@ def compute_medication_flags(
     )
     recent_meds = {row["medication"] for row in cursor.fetchall()}
 
-    cursor = conn.execute(
-        "SELECT DISTINCT medication FROM medications"
-    )
+    cursor = conn.execute("SELECT DISTINCT medication FROM medications")
     all_meds = {row["medication"] for row in cursor.fetchall()}
 
     flags = []
     for med in all_meds - recent_meds:
         cursor2 = conn.execute(
-            "SELECT MAX(date) as last_date FROM medications WHERE medication = ?", (med,)
+            "SELECT MAX(date) as last_date FROM medications WHERE medication = ?",
+            (med,),
         )
         last = cursor2.fetchone()
-        flags.append({
-            "signal": "medication_missed",
-            "severity": "alert",
-            "detail": f"{med} not logged since {last['last_date'] if last else 'unknown'}",
-            "data": {"medication": med},
-        })
+        flags.append(
+            {
+                "signal": "medication_missed",
+                "severity": "alert",
+                "detail": f"{med} not logged since {last['last_date'] if last else 'unknown'}",
+                "data": {"medication": med},
+            }
+        )
     return flags
 
 
@@ -184,6 +224,7 @@ def compute_bedtime_flags(
     drift_threshold_minutes: int = 30,
     window_days: int = 7,
 ) -> list[dict]:
+    """Flag 'bedtime_drifting' if average bedtime in the recent half of the window differs from the earlier half by the threshold. Uses earliest sleep start_time per day; hours before noon are treated as after-midnight (e.g. 1am = 25.0)."""
     cursor = conn.execute(
         "SELECT date, MIN(start_time) as bedtime FROM sleep_phases WHERE start_time IS NOT NULL GROUP BY date ORDER BY date DESC LIMIT ?",
         (window_days,),
@@ -203,15 +244,19 @@ def compute_bedtime_flags(
             return 23.0
 
     bedtimes = [_extract_hour_min(r["bedtime"]) for r in rows]
-    early_avg = sum(bedtimes[len(bedtimes)//2:]) / len(bedtimes[len(bedtimes)//2:])
-    late_avg = sum(bedtimes[:len(bedtimes)//2]) / len(bedtimes[:len(bedtimes)//2])
+    early_avg = sum(bedtimes[len(bedtimes) // 2 :]) / len(
+        bedtimes[len(bedtimes) // 2 :]
+    )
+    late_avg = sum(bedtimes[: len(bedtimes) // 2]) / len(bedtimes[: len(bedtimes) // 2])
     drift_minutes = (late_avg - early_avg) * 60
 
     if abs(drift_minutes) >= drift_threshold_minutes:
-        return [{
-            "signal": "bedtime_drifting",
-            "severity": "info",
-            "detail": f"avg bedtime shifted {abs(drift_minutes):.0f}min {'later' if drift_minutes > 0 else 'earlier'}",
-            "data": {"drift_minutes": round(drift_minutes, 1)},
-        }]
+        return [
+            {
+                "signal": "bedtime_drifting",
+                "severity": "info",
+                "detail": f"avg bedtime shifted {abs(drift_minutes):.0f}min {'later' if drift_minutes > 0 else 'earlier'}",
+                "data": {"drift_minutes": round(drift_minutes, 1)},
+            }
+        ]
     return []

--- a/bede-data/src/bede_data/api/analytics.py
+++ b/bede-data/src/bede_data/api/analytics.py
@@ -1,0 +1,61 @@
+import sqlite3
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from bede_data.analytics.engine import run_analytics, store_flags
+from bede_data.db.connection import get_db
+
+router = APIRouter(prefix="/api/analytics", tags=["analytics"])
+
+
+@router.get("/flags")
+def get_flags(
+    severity: str | None = Query(None),
+    acknowledged: bool | None = Query(None),
+    limit: int = Query(100, ge=1, le=1000),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    query = "SELECT id, signal, severity, detail, data, computed_at, acknowledged FROM analytics_flags WHERE 1=1"
+    params: list = []
+    if severity:
+        query += " AND severity = ?"
+        params.append(severity)
+    if acknowledged is not None:
+        query += " AND acknowledged = ?"
+        params.append(int(acknowledged))
+    query += " ORDER BY computed_at DESC LIMIT ?"
+    params.append(limit)
+
+    cursor = conn.execute(query, params)
+    flags = [dict(r) for r in cursor.fetchall()]
+    for f in flags:
+        f["acknowledged"] = bool(f["acknowledged"])
+    return {"flags": flags}
+
+
+@router.post("/run")
+def trigger_analytics(
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    flags = run_analytics(conn)
+    count = store_flags(conn, flags)
+    return {"status": "ok", "flags_stored": count}
+
+
+@router.put("/flags/{flag_id}/acknowledge")
+def acknowledge_flag(
+    flag_id: int,
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    cursor = conn.execute("SELECT id FROM analytics_flags WHERE id = ?", (flag_id,))
+    if not cursor.fetchone():
+        raise HTTPException(status_code=404, detail="Flag not found")
+    conn.execute("UPDATE analytics_flags SET acknowledged = 1 WHERE id = ?", (flag_id,))
+    conn.commit()
+    cursor = conn.execute(
+        "SELECT id, signal, severity, detail, data, computed_at, acknowledged FROM analytics_flags WHERE id = ?",
+        (flag_id,),
+    )
+    r = dict(cursor.fetchone())
+    r["acknowledged"] = bool(r["acknowledged"])
+    return r

--- a/bede-data/src/bede_data/api/config_api.py
+++ b/bede-data/src/bede_data/api/config_api.py
@@ -15,6 +15,7 @@ def _now() -> str:
 
 # ---- Schedules ----
 
+
 class ScheduleCreate(BaseModel):
     task_name: str
     cron_expression: str
@@ -40,8 +41,17 @@ def create_schedule(body: ScheduleCreate, conn: sqlite3.Connection = Depends(get
     cursor = conn.execute(
         """INSERT INTO schedules (task_name, cron_expression, prompt, model, timeout_seconds, interactive, enabled, created_at, updated_at)
            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
-        (body.task_name, body.cron_expression, body.prompt, body.model,
-         body.timeout_seconds, int(body.interactive), int(body.enabled), now, now),
+        (
+            body.task_name,
+            body.cron_expression,
+            body.prompt,
+            body.model,
+            body.timeout_seconds,
+            int(body.interactive),
+            int(body.enabled),
+            now,
+            now,
+        ),
     )
     conn.commit()
     return _get_schedule(conn, cursor.lastrowid)
@@ -60,7 +70,9 @@ def list_schedules(conn: sqlite3.Connection = Depends(get_db)):
 
 
 @router.put("/schedules/{schedule_id}")
-def update_schedule(schedule_id: int, body: ScheduleUpdate, conn: sqlite3.Connection = Depends(get_db)):
+def update_schedule(
+    schedule_id: int, body: ScheduleUpdate, conn: sqlite3.Connection = Depends(get_db)
+):
     existing = _get_schedule(conn, schedule_id)
     if not existing:
         raise HTTPException(status_code=404, detail="Schedule not found")
@@ -76,7 +88,10 @@ def update_schedule(schedule_id: int, body: ScheduleUpdate, conn: sqlite3.Connec
         updates["enabled"] = int(body.enabled)
 
     set_clause = ", ".join(f"{k} = ?" for k in updates)
-    conn.execute(f"UPDATE schedules SET {set_clause} WHERE id = ?", [*updates.values(), schedule_id])
+    conn.execute(
+        f"UPDATE schedules SET {set_clause} WHERE id = ?",
+        [*updates.values(), schedule_id],
+    )
     conn.commit()
     return _get_schedule(conn, schedule_id)
 
@@ -97,12 +112,15 @@ def _get_schedule(conn: sqlite3.Connection, sid: int) -> dict | None:
 
 # ---- Settings (key-value) ----
 
+
 class SettingValue(BaseModel):
     value: str
 
 
 @router.put("/settings/{key}")
-def set_setting(key: str, body: SettingValue, conn: sqlite3.Connection = Depends(get_db)):
+def set_setting(
+    key: str, body: SettingValue, conn: sqlite3.Connection = Depends(get_db)
+):
     conn.execute(
         "INSERT OR REPLACE INTO settings (key, value, updated_at) VALUES (?, ?, ?)",
         (key, body.value, _now()),
@@ -113,7 +131,9 @@ def set_setting(key: str, body: SettingValue, conn: sqlite3.Connection = Depends
 
 @router.get("/settings/{key}")
 def get_setting(key: str, conn: sqlite3.Connection = Depends(get_db)):
-    cursor = conn.execute("SELECT key, value, updated_at FROM settings WHERE key = ?", (key,))
+    cursor = conn.execute(
+        "SELECT key, value, updated_at FROM settings WHERE key = ?", (key,)
+    )
     row = cursor.fetchone()
     if not row:
         raise HTTPException(status_code=404, detail="Setting not found")
@@ -128,6 +148,7 @@ def list_settings(conn: sqlite3.Connection = Depends(get_db)):
 
 # ---- Monitored Items ----
 
+
 class MonitoredItemCreate(BaseModel):
     category: str
     name: str
@@ -141,7 +162,9 @@ class MonitoredItemUpdate(BaseModel):
 
 
 @router.post("/monitored-items", status_code=201)
-def create_monitored_item(body: MonitoredItemCreate, conn: sqlite3.Connection = Depends(get_db)):
+def create_monitored_item(
+    body: MonitoredItemCreate, conn: sqlite3.Connection = Depends(get_db)
+):
     now = _now()
     cursor = conn.execute(
         "INSERT INTO monitored_items (category, name, config, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
@@ -152,7 +175,9 @@ def create_monitored_item(body: MonitoredItemCreate, conn: sqlite3.Connection = 
 
 
 @router.get("/monitored-items")
-def list_monitored_items(category: str | None = Query(None), conn: sqlite3.Connection = Depends(get_db)):
+def list_monitored_items(
+    category: str | None = Query(None), conn: sqlite3.Connection = Depends(get_db)
+):
     query = "SELECT id, category, name, config, enabled, created_at, updated_at FROM monitored_items WHERE enabled = 1"
     params: list = []
     if category:

--- a/bede-data/src/bede_data/api/config_api.py
+++ b/bede-data/src/bede_data/api/config_api.py
@@ -1,0 +1,186 @@
+import sqlite3
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from bede_data.db.connection import get_db
+
+router = APIRouter(prefix="/api/config", tags=["config"])
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---- Schedules ----
+
+class ScheduleCreate(BaseModel):
+    task_name: str
+    cron_expression: str
+    prompt: str
+    model: str | None = None
+    timeout_seconds: int = 300
+    interactive: bool = False
+    enabled: bool = True
+
+
+class ScheduleUpdate(BaseModel):
+    cron_expression: str | None = None
+    prompt: str | None = None
+    model: str | None = None
+    timeout_seconds: int | None = None
+    interactive: bool | None = None
+    enabled: bool | None = None
+
+
+@router.post("/schedules", status_code=201)
+def create_schedule(body: ScheduleCreate, conn: sqlite3.Connection = Depends(get_db)):
+    now = _now()
+    cursor = conn.execute(
+        """INSERT INTO schedules (task_name, cron_expression, prompt, model, timeout_seconds, interactive, enabled, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (body.task_name, body.cron_expression, body.prompt, body.model,
+         body.timeout_seconds, int(body.interactive), int(body.enabled), now, now),
+    )
+    conn.commit()
+    return _get_schedule(conn, cursor.lastrowid)
+
+
+@router.get("/schedules")
+def list_schedules(conn: sqlite3.Connection = Depends(get_db)):
+    cursor = conn.execute(
+        "SELECT id, task_name, cron_expression, prompt, model, timeout_seconds, interactive, enabled, created_at, updated_at FROM schedules ORDER BY task_name"
+    )
+    rows = [dict(r) for r in cursor.fetchall()]
+    for r in rows:
+        r["interactive"] = bool(r["interactive"])
+        r["enabled"] = bool(r["enabled"])
+    return {"schedules": rows}
+
+
+@router.put("/schedules/{schedule_id}")
+def update_schedule(schedule_id: int, body: ScheduleUpdate, conn: sqlite3.Connection = Depends(get_db)):
+    existing = _get_schedule(conn, schedule_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Schedule not found")
+
+    updates: dict = {"updated_at": _now()}
+    for field in ("cron_expression", "prompt", "model", "timeout_seconds"):
+        val = getattr(body, field)
+        if val is not None:
+            updates[field] = val
+    if body.interactive is not None:
+        updates["interactive"] = int(body.interactive)
+    if body.enabled is not None:
+        updates["enabled"] = int(body.enabled)
+
+    set_clause = ", ".join(f"{k} = ?" for k in updates)
+    conn.execute(f"UPDATE schedules SET {set_clause} WHERE id = ?", [*updates.values(), schedule_id])
+    conn.commit()
+    return _get_schedule(conn, schedule_id)
+
+
+def _get_schedule(conn: sqlite3.Connection, sid: int) -> dict | None:
+    cursor = conn.execute(
+        "SELECT id, task_name, cron_expression, prompt, model, timeout_seconds, interactive, enabled, created_at, updated_at FROM schedules WHERE id = ?",
+        (sid,),
+    )
+    row = cursor.fetchone()
+    if not row:
+        return None
+    r = dict(row)
+    r["interactive"] = bool(r["interactive"])
+    r["enabled"] = bool(r["enabled"])
+    return r
+
+
+# ---- Settings (key-value) ----
+
+class SettingValue(BaseModel):
+    value: str
+
+
+@router.put("/settings/{key}")
+def set_setting(key: str, body: SettingValue, conn: sqlite3.Connection = Depends(get_db)):
+    conn.execute(
+        "INSERT OR REPLACE INTO settings (key, value, updated_at) VALUES (?, ?, ?)",
+        (key, body.value, _now()),
+    )
+    conn.commit()
+    return {"key": key, "value": body.value}
+
+
+@router.get("/settings/{key}")
+def get_setting(key: str, conn: sqlite3.Connection = Depends(get_db)):
+    cursor = conn.execute("SELECT key, value, updated_at FROM settings WHERE key = ?", (key,))
+    row = cursor.fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Setting not found")
+    return dict(row)
+
+
+@router.get("/settings")
+def list_settings(conn: sqlite3.Connection = Depends(get_db)):
+    cursor = conn.execute("SELECT key, value, updated_at FROM settings ORDER BY key")
+    return {"settings": [dict(r) for r in cursor.fetchall()]}
+
+
+# ---- Monitored Items ----
+
+class MonitoredItemCreate(BaseModel):
+    category: str
+    name: str
+    config: str
+
+
+class MonitoredItemUpdate(BaseModel):
+    name: str | None = None
+    config: str | None = None
+    enabled: bool | None = None
+
+
+@router.post("/monitored-items", status_code=201)
+def create_monitored_item(body: MonitoredItemCreate, conn: sqlite3.Connection = Depends(get_db)):
+    now = _now()
+    cursor = conn.execute(
+        "INSERT INTO monitored_items (category, name, config, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+        (body.category, body.name, body.config, now, now),
+    )
+    conn.commit()
+    return _get_monitored_item(conn, cursor.lastrowid)
+
+
+@router.get("/monitored-items")
+def list_monitored_items(category: str | None = Query(None), conn: sqlite3.Connection = Depends(get_db)):
+    query = "SELECT id, category, name, config, enabled, created_at, updated_at FROM monitored_items WHERE enabled = 1"
+    params: list = []
+    if category:
+        query += " AND category = ?"
+        params.append(category)
+    query += " ORDER BY name"
+    cursor = conn.execute(query, params)
+    rows = [dict(r) for r in cursor.fetchall()]
+    for r in rows:
+        r["enabled"] = bool(r["enabled"])
+    return {"items": rows}
+
+
+@router.delete("/monitored-items/{item_id}")
+def delete_monitored_item(item_id: int, conn: sqlite3.Connection = Depends(get_db)):
+    conn.execute("UPDATE monitored_items SET enabled = 0 WHERE id = ?", (item_id,))
+    conn.commit()
+    return {"status": "deleted", "id": item_id}
+
+
+def _get_monitored_item(conn: sqlite3.Connection, item_id: int) -> dict | None:
+    cursor = conn.execute(
+        "SELECT id, category, name, config, enabled, created_at, updated_at FROM monitored_items WHERE id = ?",
+        (item_id,),
+    )
+    row = cursor.fetchone()
+    if not row:
+        return None
+    r = dict(row)
+    r["enabled"] = bool(r["enabled"])
+    return r

--- a/bede-data/src/bede_data/api/conversations.py
+++ b/bede-data/src/bede_data/api/conversations.py
@@ -1,0 +1,69 @@
+import json
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+
+from bede_data.config import settings
+
+router = APIRouter(prefix="/api/conversations", tags=["conversations"])
+
+
+def _scan_sessions() -> list[dict]:
+    sessions_path = Path(settings.claude_sessions_dir)
+    if not sessions_path.exists():
+        return []
+
+    sessions = []
+    for session_dir in sorted(sessions_path.iterdir()):
+        if not session_dir.is_dir():
+            continue
+        jsonl_file = session_dir / "session.jsonl"
+        if not jsonl_file.exists():
+            continue
+
+        first_line = None
+        line_count = 0
+        with open(jsonl_file) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                if first_line is None:
+                    try:
+                        first_line = json.loads(line)
+                    except json.JSONDecodeError:
+                        pass
+                line_count += 1
+
+        sessions.append({
+            "session_id": session_dir.name,
+            "message_count": line_count,
+            "first_timestamp": first_line.get("timestamp") if first_line else None,
+        })
+
+    return sessions
+
+
+@router.get("")
+def list_conversations():
+    return {"sessions": _scan_sessions()}
+
+
+@router.get("/{session_id}")
+def get_conversation(session_id: str):
+    jsonl_file = Path(settings.claude_sessions_dir) / session_id / "session.jsonl"
+    if not jsonl_file.exists():
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    messages = []
+    with open(jsonl_file) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                messages.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+
+    return {"session_id": session_id, "messages": messages}

--- a/bede-data/src/bede_data/api/conversations.py
+++ b/bede-data/src/bede_data/api/conversations.py
@@ -12,6 +12,7 @@ _SESSION_ID_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
 def _scan_sessions() -> list[dict]:
+    """Walk the sessions directory for subdirectories containing session.jsonl files. Returns lightweight metadata (id, message count, first timestamp) without loading full transcripts."""
     sessions_path = Path(settings.claude_sessions_dir)
     if not sessions_path.exists():
         return []
@@ -38,11 +39,13 @@ def _scan_sessions() -> list[dict]:
                         pass
                 line_count += 1
 
-        sessions.append({
-            "session_id": session_dir.name,
-            "message_count": line_count,
-            "first_timestamp": first_line.get("timestamp") if first_line else None,
-        })
+        sessions.append(
+            {
+                "session_id": session_dir.name,
+                "message_count": line_count,
+                "first_timestamp": first_line.get("timestamp") if first_line else None,
+            }
+        )
 
     return sessions
 

--- a/bede-data/src/bede_data/api/conversations.py
+++ b/bede-data/src/bede_data/api/conversations.py
@@ -1,4 +1,5 @@
 import json
+import re
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
@@ -6,6 +7,8 @@ from fastapi import APIRouter, HTTPException
 from bede_data.config import settings
 
 router = APIRouter(prefix="/api/conversations", tags=["conversations"])
+
+_SESSION_ID_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
 def _scan_sessions() -> list[dict]:
@@ -51,6 +54,8 @@ def list_conversations():
 
 @router.get("/{session_id}")
 def get_conversation(session_id: str):
+    if not _SESSION_ID_RE.match(session_id):
+        raise HTTPException(status_code=400, detail="Invalid session ID")
     jsonl_file = Path(settings.claude_sessions_dir) / session_id / "session.jsonl"
     if not jsonl_file.exists():
         raise HTTPException(status_code=404, detail="Session not found")

--- a/bede-data/src/bede_data/api/freshness.py
+++ b/bede-data/src/bede_data/api/freshness.py
@@ -1,0 +1,15 @@
+import sqlite3
+
+from fastapi import APIRouter, Depends
+
+from bede_data.db.connection import get_db
+
+router = APIRouter(prefix="/api/freshness", tags=["freshness"])
+
+
+@router.get("")
+def get_freshness(conn: sqlite3.Connection = Depends(get_db)):
+    cursor = conn.execute(
+        "SELECT source, last_received_at, expected_interval_seconds, updated_at FROM data_freshness ORDER BY source"
+    )
+    return {"sources": [dict(r) for r in cursor.fetchall()]}

--- a/bede-data/src/bede_data/api/goals.py
+++ b/bede-data/src/bede_data/api/goals.py
@@ -55,7 +55,14 @@ def create_goal(
     cursor = conn.execute(
         """INSERT INTO goals (name, description, deadline, measurable_indicators, created_at, updated_at)
            VALUES (?, ?, ?, ?, ?, ?)""",
-        (body.name, body.description, body.deadline, body.measurable_indicators, now, now),
+        (
+            body.name,
+            body.description,
+            body.deadline,
+            body.measurable_indicators,
+            now,
+            now,
+        ),
     )
     conn.commit()
     return _get_goal(conn, cursor.lastrowid)

--- a/bede-data/src/bede_data/api/goals.py
+++ b/bede-data/src/bede_data/api/goals.py
@@ -1,0 +1,110 @@
+import sqlite3
+from datetime import datetime, timezone
+from enum import Enum
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from bede_data.db.connection import get_db
+
+router = APIRouter(prefix="/api/goals", tags=["goals"])
+
+
+class GoalStatus(str, Enum):
+    active = "active"
+    completed = "completed"
+    dropped = "dropped"
+
+
+class GoalCreate(BaseModel):
+    name: str
+    description: str | None = None
+    deadline: str | None = None
+    measurable_indicators: str | None = None
+
+
+class GoalUpdate(BaseModel):
+    name: str | None = None
+    description: str | None = None
+    deadline: str | None = None
+    measurable_indicators: str | None = None
+    status: GoalStatus | None = None
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _get_goal(conn: sqlite3.Connection, goal_id: int) -> dict:
+    cursor = conn.execute(
+        "SELECT id, name, description, deadline, measurable_indicators, status, created_at, updated_at FROM goals WHERE id = ?",
+        (goal_id,),
+    )
+    row = cursor.fetchone()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Goal not found")
+    return dict(row)
+
+
+@router.post("", status_code=201)
+def create_goal(
+    body: GoalCreate,
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    now = _now()
+    cursor = conn.execute(
+        """INSERT INTO goals (name, description, deadline, measurable_indicators, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (body.name, body.description, body.deadline, body.measurable_indicators, now, now),
+    )
+    conn.commit()
+    return _get_goal(conn, cursor.lastrowid)
+
+
+@router.get("")
+def list_goals(
+    status: GoalStatus | None = Query(None),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    query = "SELECT id, name, description, deadline, measurable_indicators, status, created_at, updated_at FROM goals"
+    params: list = []
+    if status:
+        query += " WHERE status = ?"
+        params.append(status.value)
+    query += " ORDER BY created_at DESC"
+    cursor = conn.execute(query, params)
+    return {"goals": [dict(row) for row in cursor.fetchall()]}
+
+
+@router.get("/{goal_id}")
+def get_goal(
+    goal_id: int,
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    return _get_goal(conn, goal_id)
+
+
+@router.put("/{goal_id}")
+def update_goal(
+    goal_id: int,
+    body: GoalUpdate,
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    _get_goal(conn, goal_id)
+
+    updates = {}
+    for field in ("name", "description", "deadline", "measurable_indicators"):
+        val = getattr(body, field)
+        if val is not None:
+            updates[field] = val
+    if body.status is not None:
+        updates["status"] = body.status.value
+    updates["updated_at"] = _now()
+
+    set_clause = ", ".join(f"{k} = ?" for k in updates)
+    conn.execute(
+        f"UPDATE goals SET {set_clause} WHERE id = ?",
+        [*updates.values(), goal_id],
+    )
+    conn.commit()
+    return _get_goal(conn, goal_id)

--- a/bede-data/src/bede_data/api/health.py
+++ b/bede-data/src/bede_data/api/health.py
@@ -1,0 +1,137 @@
+import sqlite3
+from datetime import date, timedelta
+
+from fastapi import APIRouter, Depends, Query
+
+from bede_data.db.connection import get_db
+
+router = APIRouter(prefix="/api/health", tags=["health"])
+
+
+def _resolve_date(date_str: str) -> str:
+    if date_str == "today":
+        return date.today().isoformat()
+    if date_str == "yesterday":
+        return (date.today() - timedelta(days=1)).isoformat()
+    return date_str
+
+
+@router.get("/sleep")
+def get_sleep(
+    date: str = Query(..., description="YYYY-MM-DD, 'today', or 'yesterday'"),
+    timezone: str = Query("Australia/Sydney"),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    d = _resolve_date(date)
+    cursor = conn.execute(
+        "SELECT phase, hours, start_time, end_time, source FROM sleep_phases WHERE date = ? ORDER BY start_time",
+        (d,),
+    )
+    phases = [dict(row) for row in cursor.fetchall()]
+    total_hours = round(sum(p["hours"] for p in phases), 2)
+
+    bedtime = phases[0]["start_time"] if phases else None
+    wake_time = phases[-1]["end_time"] if phases else None
+
+    return {
+        "date": d,
+        "total_hours": total_hours,
+        "bedtime": bedtime,
+        "wake_time": wake_time,
+        "phases": phases,
+    }
+
+
+@router.get("/activity")
+def get_activity(
+    date: str = Query(...),
+    timezone: str = Query("Australia/Sydney"),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    d = _resolve_date(date)
+    cursor = conn.execute(
+        "SELECT metric, value FROM health_metrics WHERE date = ?", (d,)
+    )
+    metrics = {row["metric"]: row["value"] for row in cursor.fetchall()}
+    return {
+        "date": d,
+        "steps": metrics.get("step_count", 0),
+        "active_energy": metrics.get("active_energy", 0),
+        "exercise_minutes": metrics.get("apple_exercise_time", 0),
+        "stand_hours": metrics.get("apple_stand_hour", 0),
+    }
+
+
+@router.get("/workouts")
+def get_workouts(
+    date: str = Query(...),
+    timezone: str = Query("Australia/Sydney"),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    d = _resolve_date(date)
+    cursor = conn.execute(
+        "SELECT workout_type, duration_minutes, active_energy_kj, avg_heart_rate, max_heart_rate, start_time FROM workouts WHERE date = ? ORDER BY start_time",
+        (d,),
+    )
+    return {"date": d, "workouts": [dict(row) for row in cursor.fetchall()]}
+
+
+@router.get("/heart-rate")
+def get_heart_rate(
+    date: str = Query(...),
+    timezone: str = Query("Australia/Sydney"),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    d = _resolve_date(date)
+    cursor = conn.execute(
+        "SELECT metric, value FROM health_metrics WHERE date = ? AND metric IN ('resting_heart_rate', 'heart_rate_variability')",
+        (d,),
+    )
+    metrics = {row["metric"]: row["value"] for row in cursor.fetchall()}
+    return {
+        "date": d,
+        "resting_heart_rate": metrics.get("resting_heart_rate"),
+        "heart_rate_variability": metrics.get("heart_rate_variability"),
+    }
+
+
+@router.get("/wellbeing")
+def get_wellbeing(
+    date: str = Query(...),
+    timezone: str = Query("Australia/Sydney"),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    d = _resolve_date(date)
+
+    cursor = conn.execute(
+        "SELECT value FROM health_metrics WHERE date = ? AND metric = 'mindful_minutes'",
+        (d,),
+    )
+    row = cursor.fetchone()
+    mindful_minutes = row["value"] if row else 0
+
+    cursor = conn.execute(
+        "SELECT valence, labels, context, associations, recorded_at FROM state_of_mind WHERE date = ? ORDER BY recorded_at",
+        (d,),
+    )
+    state_of_mind = [dict(row) for row in cursor.fetchall()]
+
+    return {
+        "date": d,
+        "mindful_minutes": mindful_minutes,
+        "state_of_mind": state_of_mind,
+    }
+
+
+@router.get("/medications")
+def get_medications(
+    date: str = Query(...),
+    timezone: str = Query("Australia/Sydney"),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    d = _resolve_date(date)
+    cursor = conn.execute(
+        "SELECT medication, quantity, unit, recorded_at FROM medications WHERE date = ? ORDER BY recorded_at",
+        (d,),
+    )
+    return {"date": d, "medications": [dict(row) for row in cursor.fetchall()]}

--- a/bede-data/src/bede_data/api/location.py
+++ b/bede-data/src/bede_data/api/location.py
@@ -39,14 +39,24 @@ async def get_location_summary(
     stops = []
     for c in clusters:
         name = await reverse_geocode(c["lat"], c["lon"])
-        stops.append({
-            "name": name,
-            "lat": c["lat"],
-            "lon": c["lon"],
-            "arrived": datetime.fromtimestamp(c["arrived_tst"], tz=tz_info).isoformat() if isinstance(c["arrived_tst"], (int, float)) else c["arrived_tst"],
-            "departed": datetime.fromtimestamp(c["departed_tst"], tz=tz_info).isoformat() if isinstance(c["departed_tst"], (int, float)) else c["departed_tst"],
-            "point_count": c["point_count"],
-        })
+        stops.append(
+            {
+                "name": name,
+                "lat": c["lat"],
+                "lon": c["lon"],
+                "arrived": datetime.fromtimestamp(
+                    c["arrived_tst"], tz=tz_info
+                ).isoformat()
+                if isinstance(c["arrived_tst"], (int, float))
+                else c["arrived_tst"],
+                "departed": datetime.fromtimestamp(
+                    c["departed_tst"], tz=tz_info
+                ).isoformat()
+                if isinstance(c["departed_tst"], (int, float))
+                else c["departed_tst"],
+                "point_count": c["point_count"],
+            }
+        )
 
     return {"date": d, "stops": stops}
 

--- a/bede-data/src/bede_data/api/location.py
+++ b/bede-data/src/bede_data/api/location.py
@@ -1,0 +1,61 @@
+from datetime import date, datetime, timedelta, timezone
+
+from fastapi import APIRouter, Query
+
+from bede_data.live.location import (
+    cluster_points,
+    fetch_owntracks_points,
+    reverse_geocode,
+)
+
+router = APIRouter(prefix="/api/location", tags=["location"])
+
+
+def _resolve_date(date_str: str) -> str:
+    if date_str == "today":
+        return date.today().isoformat()
+    if date_str == "yesterday":
+        return (date.today() - timedelta(days=1)).isoformat()
+    return date_str
+
+
+def _date_to_timestamps(date_str: str) -> tuple[int, int]:
+    d = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    return int(d.timestamp()), int((d + timedelta(days=1)).timestamp())
+
+
+@router.get("/summary")
+async def get_location_summary(
+    date: str = Query(...),
+    timezone: str = Query("Australia/Sydney"),
+):
+    d = _resolve_date(date)
+    from_ts, to_ts = _date_to_timestamps(d)
+    points = await fetch_owntracks_points(from_ts, to_ts)
+    clusters = cluster_points(points)
+
+    stops = []
+    for c in clusters:
+        name = await reverse_geocode(c["lat"], c["lon"])
+        stops.append({
+            "name": name,
+            "lat": c["lat"],
+            "lon": c["lon"],
+            "arrived": datetime.fromtimestamp(c["arrived_tst"], tz=timezone).isoformat() if isinstance(c["arrived_tst"], (int, float)) else c["arrived_tst"],
+            "departed": datetime.fromtimestamp(c["departed_tst"], tz=timezone).isoformat() if isinstance(c["departed_tst"], (int, float)) else c["departed_tst"],
+            "point_count": c["point_count"],
+        })
+
+    return {"date": d, "stops": stops}
+
+
+@router.get("/raw")
+async def get_location_raw(
+    from_date: str = Query(...),
+    to_date: str = Query(...),
+    timezone: str = Query("Australia/Sydney"),
+):
+    from_ts, _ = _date_to_timestamps(_resolve_date(from_date))
+    _, to_ts = _date_to_timestamps(_resolve_date(to_date))
+    points = await fetch_owntracks_points(from_ts, to_ts)
+    return {"from_date": from_date, "to_date": to_date, "points": points}

--- a/bede-data/src/bede_data/api/location.py
+++ b/bede-data/src/bede_data/api/location.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Query
 
@@ -27,12 +28,13 @@ def _date_to_timestamps(date_str: str) -> tuple[int, int]:
 @router.get("/summary")
 async def get_location_summary(
     date: str = Query(...),
-    timezone: str = Query("Australia/Sydney"),
+    tz: str = Query("Australia/Sydney"),
 ):
     d = _resolve_date(date)
     from_ts, to_ts = _date_to_timestamps(d)
     points = await fetch_owntracks_points(from_ts, to_ts)
     clusters = cluster_points(points)
+    tz_info = ZoneInfo(tz)
 
     stops = []
     for c in clusters:
@@ -41,8 +43,8 @@ async def get_location_summary(
             "name": name,
             "lat": c["lat"],
             "lon": c["lon"],
-            "arrived": datetime.fromtimestamp(c["arrived_tst"], tz=timezone).isoformat() if isinstance(c["arrived_tst"], (int, float)) else c["arrived_tst"],
-            "departed": datetime.fromtimestamp(c["departed_tst"], tz=timezone).isoformat() if isinstance(c["departed_tst"], (int, float)) else c["departed_tst"],
+            "arrived": datetime.fromtimestamp(c["arrived_tst"], tz=tz_info).isoformat() if isinstance(c["arrived_tst"], (int, float)) else c["arrived_tst"],
+            "departed": datetime.fromtimestamp(c["departed_tst"], tz=tz_info).isoformat() if isinstance(c["departed_tst"], (int, float)) else c["departed_tst"],
             "point_count": c["point_count"],
         })
 
@@ -53,7 +55,6 @@ async def get_location_summary(
 async def get_location_raw(
     from_date: str = Query(...),
     to_date: str = Query(...),
-    timezone: str = Query("Australia/Sydney"),
 ):
     from_ts, _ = _date_to_timestamps(_resolve_date(from_date))
     _, to_ts = _date_to_timestamps(_resolve_date(to_date))

--- a/bede-data/src/bede_data/api/memories.py
+++ b/bede-data/src/bede_data/api/memories.py
@@ -1,0 +1,144 @@
+import sqlite3
+from datetime import datetime, timezone
+from enum import Enum
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from bede_data.db.connection import get_db
+
+router = APIRouter(prefix="/api/memories", tags=["memories"])
+
+
+class MemoryType(str, Enum):
+    fact = "fact"
+    preference = "preference"
+    correction = "correction"
+    commitment = "commitment"
+
+
+class MemoryCreate(BaseModel):
+    content: str
+    type: MemoryType
+    source_conversation: str | None = None
+    supersedes: int | None = None
+
+
+class MemoryUpdate(BaseModel):
+    content: str | None = None
+    type: MemoryType | None = None
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@router.post("", status_code=201)
+def create_memory(
+    body: MemoryCreate,
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    now = _now()
+    cursor = conn.execute(
+        """INSERT INTO memories (content, type, source_conversation, created_at)
+           VALUES (?, ?, ?, ?)""",
+        (body.content, body.type.value, body.source_conversation, now),
+    )
+    mem_id = cursor.lastrowid
+
+    if body.supersedes is not None:
+        conn.execute(
+            "UPDATE memories SET active = 0, superseded_by = ? WHERE id = ?",
+            (mem_id, body.supersedes),
+        )
+
+    conn.commit()
+    return _get_memory_by_id(conn, mem_id)
+
+
+@router.get("")
+def list_memories(
+    type: MemoryType | None = Query(None),
+    search: str | None = Query(None),
+    limit: int = Query(50, ge=1, le=500),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    query = "SELECT id, content, type, created_at, last_referenced_at, source_conversation, superseded_by, active FROM memories WHERE active = 1"
+    params: list = []
+
+    if type:
+        query += " AND type = ?"
+        params.append(type.value)
+    if search:
+        query += " AND content LIKE ?"
+        params.append(f"%{search}%")
+
+    query += " ORDER BY created_at DESC LIMIT ?"
+    params.append(limit)
+
+    cursor = conn.execute(query, params)
+    return {"memories": [dict(row) for row in cursor.fetchall()]}
+
+
+@router.put("/{memory_id}")
+def update_memory(
+    memory_id: int,
+    body: MemoryUpdate,
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    existing = _get_memory_by_id(conn, memory_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Memory not found")
+
+    updates = {}
+    if body.content is not None:
+        updates["content"] = body.content
+    if body.type is not None:
+        updates["type"] = body.type.value
+
+    if updates:
+        set_clause = ", ".join(f"{k} = ?" for k in updates)
+        conn.execute(
+            f"UPDATE memories SET {set_clause} WHERE id = ?",
+            [*updates.values(), memory_id],
+        )
+        conn.commit()
+
+    return _get_memory_by_id(conn, memory_id)
+
+
+@router.delete("/{memory_id}")
+def delete_memory(
+    memory_id: int,
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    conn.execute("UPDATE memories SET active = 0 WHERE id = ?", (memory_id,))
+    conn.commit()
+    return {"status": "deleted", "id": memory_id}
+
+
+@router.post("/{memory_id}/reference")
+def reference_memory(
+    memory_id: int,
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    now = _now()
+    conn.execute(
+        "UPDATE memories SET last_referenced_at = ? WHERE id = ?",
+        (now, memory_id),
+    )
+    conn.commit()
+    return _get_memory_by_id(conn, memory_id)
+
+
+def _get_memory_by_id(conn: sqlite3.Connection, memory_id: int) -> dict | None:
+    cursor = conn.execute(
+        "SELECT id, content, type, created_at, last_referenced_at, source_conversation, superseded_by, active FROM memories WHERE id = ?",
+        (memory_id,),
+    )
+    row = cursor.fetchone()
+    if row is None:
+        return None
+    result = dict(row)
+    result["active"] = bool(result["active"])
+    return result

--- a/bede-data/src/bede_data/api/memories.py
+++ b/bede-data/src/bede_data/api/memories.py
@@ -38,6 +38,7 @@ def create_memory(
     body: MemoryCreate,
     conn: sqlite3.Connection = Depends(get_db),
 ):
+    """Create a memory. If supersedes is set, the old memory is marked inactive and linked to this one — used for corrections that preserve history."""
     now = _now()
     cursor = conn.execute(
         """INSERT INTO memories (content, type, source_conversation, created_at)
@@ -112,6 +113,7 @@ def delete_memory(
     memory_id: int,
     conn: sqlite3.Connection = Depends(get_db),
 ):
+    """Soft-delete: marks the memory inactive rather than removing the row."""
     conn.execute("UPDATE memories SET active = 0 WHERE id = ?", (memory_id,))
     conn.commit()
     return {"status": "deleted", "id": memory_id}
@@ -122,6 +124,7 @@ def reference_memory(
     memory_id: int,
     conn: sqlite3.Connection = Depends(get_db),
 ):
+    """Touch last_referenced_at — tracks which memories are actively being used for relevance ranking."""
     now = _now()
     conn.execute(
         "UPDATE memories SET last_referenced_at = ? WHERE id = ?",

--- a/bede-data/src/bede_data/api/message_queue.py
+++ b/bede-data/src/bede_data/api/message_queue.py
@@ -58,7 +58,9 @@ def list_messages(
 
 
 @router.put("/{msg_id}")
-def update_message(msg_id: int, body: MsgUpdate, conn: sqlite3.Connection = Depends(get_db)):
+def update_message(
+    msg_id: int, body: MsgUpdate, conn: sqlite3.Connection = Depends(get_db)
+):
     existing = _get_msg(conn, msg_id)
     if not existing:
         raise HTTPException(status_code=404, detail="Message not found")

--- a/bede-data/src/bede_data/api/message_queue.py
+++ b/bede-data/src/bede_data/api/message_queue.py
@@ -1,0 +1,80 @@
+import sqlite3
+from datetime import datetime, timezone
+from enum import Enum
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from bede_data.db.connection import get_db
+
+router = APIRouter(prefix="/api/message-queue", tags=["message-queue"])
+
+
+class MsgStatus(str, Enum):
+    pending = "pending"
+    processing = "processing"
+    done = "done"
+    failed = "failed"
+
+
+class MsgCreate(BaseModel):
+    message: str
+    source: str
+
+
+class MsgUpdate(BaseModel):
+    status: MsgStatus
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@router.post("", status_code=201)
+def enqueue_message(body: MsgCreate, conn: sqlite3.Connection = Depends(get_db)):
+    cursor = conn.execute(
+        "INSERT INTO message_queue (message, source, created_at) VALUES (?, ?, ?)",
+        (body.message, body.source, _now()),
+    )
+    conn.commit()
+    return _get_msg(conn, cursor.lastrowid)
+
+
+@router.get("")
+def list_messages(
+    status: MsgStatus | None = Query(None),
+    limit: int = Query(50),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    query = "SELECT id, message, source, status, created_at, processed_at FROM message_queue"
+    params: list = []
+    if status:
+        query += " WHERE status = ?"
+        params.append(status.value)
+    query += " ORDER BY created_at ASC LIMIT ?"
+    params.append(limit)
+    cursor = conn.execute(query, params)
+    return {"messages": [dict(r) for r in cursor.fetchall()]}
+
+
+@router.put("/{msg_id}")
+def update_message(msg_id: int, body: MsgUpdate, conn: sqlite3.Connection = Depends(get_db)):
+    existing = _get_msg(conn, msg_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Message not found")
+    processed_at = _now() if body.status in (MsgStatus.done, MsgStatus.failed) else None
+    conn.execute(
+        "UPDATE message_queue SET status = ?, processed_at = COALESCE(?, processed_at) WHERE id = ?",
+        (body.status.value, processed_at, msg_id),
+    )
+    conn.commit()
+    return _get_msg(conn, msg_id)
+
+
+def _get_msg(conn: sqlite3.Connection, msg_id: int) -> dict | None:
+    cursor = conn.execute(
+        "SELECT id, message, source, status, created_at, processed_at FROM message_queue WHERE id = ?",
+        (msg_id,),
+    )
+    row = cursor.fetchone()
+    return dict(row) if row else None

--- a/bede-data/src/bede_data/api/retention.py
+++ b/bede-data/src/bede_data/api/retention.py
@@ -1,0 +1,72 @@
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from bede_data.db.connection import get_db
+
+router = APIRouter(prefix="/api/retention", tags=["retention"])
+
+RETAINABLE_TABLES = {
+    "health_metrics": "date",
+    "sleep_phases": "date",
+    "workouts": "date",
+    "state_of_mind": "date",
+    "medications": "date",
+    "screen_time": "date",
+    "safari_history": "date",
+    "youtube_history": "date",
+    "podcasts": "date",
+    "claude_sessions": "date",
+    "bede_sessions": "date",
+    "music_listens": "date",
+    "task_executions": "created_at",
+    "analytics_flags": "computed_at",
+    "daily_scratchpads": "date",
+}
+
+
+class RetentionPolicy(BaseModel):
+    retention_days: int
+
+
+@router.post("/cleanup")
+def run_cleanup(conn: sqlite3.Connection = Depends(get_db)):
+    cursor = conn.execute("SELECT data_type, retention_days FROM retention_policies")
+    policies = {row["data_type"]: row["retention_days"] for row in cursor.fetchall()}
+
+    total_deleted = 0
+    for table, date_col in RETAINABLE_TABLES.items():
+        days = policies.get(table)
+        if days is None:
+            continue
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d")
+        result = conn.execute(f"DELETE FROM [{table}] WHERE [{date_col}] < ?", (cutoff,))
+        total_deleted += result.rowcount
+
+    conn.commit()
+    return {"status": "ok", "rows_deleted": total_deleted}
+
+
+@router.put("/policies/{data_type}")
+def set_policy(
+    data_type: str,
+    body: RetentionPolicy,
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    conn.execute(
+        "INSERT OR REPLACE INTO retention_policies (data_type, retention_days, updated_at) VALUES (?, ?, ?)",
+        (data_type, body.retention_days, now),
+    )
+    conn.commit()
+    return {"data_type": data_type, "retention_days": body.retention_days}
+
+
+@router.get("/policies")
+def list_policies(conn: sqlite3.Connection = Depends(get_db)):
+    cursor = conn.execute(
+        "SELECT data_type, retention_days, updated_at FROM retention_policies ORDER BY data_type"
+    )
+    return {"policies": [dict(r) for r in cursor.fetchall()]}

--- a/bede-data/src/bede_data/api/retention.py
+++ b/bede-data/src/bede_data/api/retention.py
@@ -8,6 +8,7 @@ from bede_data.db.connection import get_db
 
 router = APIRouter(prefix="/api/retention", tags=["retention"])
 
+# Maps table name → date column used for age-based deletion. Only tables listed here can have retention policies applied.
 RETAINABLE_TABLES = {
     "health_metrics": "date",
     "sleep_phases": "date",
@@ -33,6 +34,7 @@ class RetentionPolicy(BaseModel):
 
 @router.post("/cleanup")
 def run_cleanup(conn: sqlite3.Connection = Depends(get_db)):
+    """Delete rows older than each table's configured retention period. Only acts on tables in RETAINABLE_TABLES that have a policy set."""
     cursor = conn.execute("SELECT data_type, retention_days FROM retention_policies")
     policies = {row["data_type"]: row["retention_days"] for row in cursor.fetchall()}
 
@@ -41,8 +43,12 @@ def run_cleanup(conn: sqlite3.Connection = Depends(get_db)):
         days = policies.get(table)
         if days is None:
             continue
-        cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%d")
-        result = conn.execute(f"DELETE FROM [{table}] WHERE [{date_col}] < ?", (cutoff,))
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=days)).strftime(
+            "%Y-%m-%d"
+        )
+        result = conn.execute(
+            f"DELETE FROM [{table}] WHERE [{date_col}] < ?", (cutoff,)
+        )
         total_deleted += result.rowcount
 
     conn.commit()

--- a/bede-data/src/bede_data/api/sessions.py
+++ b/bede-data/src/bede_data/api/sessions.py
@@ -1,0 +1,72 @@
+import sqlite3
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from bede_data.db.connection import get_db
+
+router = APIRouter(prefix="/api", tags=["sessions"])
+
+
+class DailySessionCreate(BaseModel):
+    date: str
+    session_id: str
+
+
+class ScratchpadEntry(BaseModel):
+    date: str
+    entry_time: str
+    content: str
+
+
+@router.post("/sessions/daily", status_code=201)
+def store_daily_session(
+    body: DailySessionCreate,
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    conn.execute(
+        "INSERT OR REPLACE INTO daily_sessions (date, session_id, created_at) VALUES (?, ?, datetime('now'))",
+        (body.date, body.session_id),
+    )
+    conn.commit()
+    return {"date": body.date, "session_id": body.session_id}
+
+
+@router.get("/sessions/daily")
+def get_daily_session(
+    date: str = Query(...),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    cursor = conn.execute(
+        "SELECT date, session_id, created_at FROM daily_sessions WHERE date = ?",
+        (date,),
+    )
+    row = cursor.fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="No session for this date")
+    return dict(row)
+
+
+@router.post("/scratchpad", status_code=201)
+def append_scratchpad(
+    body: ScratchpadEntry,
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    conn.execute(
+        "INSERT OR REPLACE INTO daily_scratchpads (date, entry_time, content) VALUES (?, ?, ?)",
+        (body.date, body.entry_time, body.content),
+    )
+    conn.commit()
+    return {"status": "ok"}
+
+
+@router.get("/scratchpad")
+def get_scratchpad(
+    date: str = Query(...),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    cursor = conn.execute(
+        "SELECT date, entry_time, content FROM daily_scratchpads WHERE date = ? ORDER BY entry_time",
+        (date,),
+    )
+    return {"date": date, "entries": [dict(r) for r in cursor.fetchall()]}

--- a/bede-data/src/bede_data/api/storage.py
+++ b/bede-data/src/bede_data/api/storage.py
@@ -1,0 +1,27 @@
+import os
+import sqlite3
+
+from fastapi import APIRouter, Depends
+
+from bede_data.config import settings
+from bede_data.db.connection import get_db
+
+router = APIRouter(prefix="/api/storage", tags=["storage"])
+
+
+@router.get("")
+def get_storage(conn: sqlite3.Connection = Depends(get_db)):
+    db_path = settings.sqlite_db_path
+    db_size = os.path.getsize(db_path) if os.path.exists(db_path) else 0
+
+    cursor = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+    )
+    tables = []
+    for row in cursor.fetchall():
+        table_name = row["name"]
+        count_cursor = conn.execute(f"SELECT COUNT(*) as cnt FROM [{table_name}]")
+        count = count_cursor.fetchone()["cnt"]
+        tables.append({"name": table_name, "row_count": count})
+
+    return {"db_size_bytes": db_size, "tables": tables}

--- a/bede-data/src/bede_data/api/task_log.py
+++ b/bede-data/src/bede_data/api/task_log.py
@@ -1,0 +1,99 @@
+import sqlite3
+from enum import Enum
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from bede_data.db.connection import get_db
+
+router = APIRouter(prefix="/api/tasks", tags=["tasks"])
+
+
+class TaskStatus(str, Enum):
+    running = "running"
+    success = "success"
+    failure = "failure"
+    timeout = "timeout"
+
+
+class TaskLogCreate(BaseModel):
+    task_name: str
+    start_time: str
+    status: TaskStatus
+
+
+class TaskLogUpdate(BaseModel):
+    status: TaskStatus | None = None
+    end_time: str | None = None
+    duration_seconds: float | None = None
+    error_detail: str | None = None
+
+
+@router.post("/log", status_code=201)
+def log_task(
+    body: TaskLogCreate,
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    cursor = conn.execute(
+        "INSERT INTO task_executions (task_name, start_time, status) VALUES (?, ?, ?)",
+        (body.task_name, body.start_time, body.status.value),
+    )
+    conn.commit()
+    return _get_execution(conn, cursor.lastrowid)
+
+
+@router.put("/log/{execution_id}")
+def update_task_log(
+    execution_id: int,
+    body: TaskLogUpdate,
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    existing = _get_execution(conn, execution_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Execution not found")
+
+    updates = {}
+    if body.status is not None:
+        updates["status"] = body.status.value
+    if body.end_time is not None:
+        updates["end_time"] = body.end_time
+    if body.duration_seconds is not None:
+        updates["duration_seconds"] = body.duration_seconds
+    if body.error_detail is not None:
+        updates["error_detail"] = body.error_detail
+
+    if updates:
+        set_clause = ", ".join(f"{k} = ?" for k in updates)
+        conn.execute(
+            f"UPDATE task_executions SET {set_clause} WHERE id = ?",
+            [*updates.values(), execution_id],
+        )
+        conn.commit()
+
+    return _get_execution(conn, execution_id)
+
+
+@router.get("/history")
+def get_task_history(
+    task_name: str | None = Query(None),
+    limit: int = Query(50, ge=1, le=500),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    query = "SELECT id, task_name, start_time, end_time, duration_seconds, status, error_detail, created_at FROM task_executions"
+    params: list = []
+    if task_name:
+        query += " WHERE task_name = ?"
+        params.append(task_name)
+    query += " ORDER BY start_time DESC LIMIT ?"
+    params.append(limit)
+    cursor = conn.execute(query, params)
+    return {"executions": [dict(row) for row in cursor.fetchall()]}
+
+
+def _get_execution(conn: sqlite3.Connection, exec_id: int) -> dict | None:
+    cursor = conn.execute(
+        "SELECT id, task_name, start_time, end_time, duration_seconds, status, error_detail, created_at FROM task_executions WHERE id = ?",
+        (exec_id,),
+    )
+    row = cursor.fetchone()
+    return dict(row) if row else None

--- a/bede-data/src/bede_data/api/vault_data.py
+++ b/bede-data/src/bede_data/api/vault_data.py
@@ -1,0 +1,122 @@
+import sqlite3
+from datetime import date, timedelta
+
+from fastapi import APIRouter, Depends, Query
+
+from bede_data.db.connection import get_db
+
+router = APIRouter(prefix="/api/vault", tags=["vault"])
+
+
+def _resolve_date(date_str: str) -> str:
+    if date_str == "today":
+        return date.today().isoformat()
+    if date_str == "yesterday":
+        return (date.today() - timedelta(days=1)).isoformat()
+    return date_str
+
+
+@router.get("/screen-time")
+def get_screen_time(
+    date: str = Query(...),
+    device: str | None = Query(None),
+    top_n: int | None = Query(None),
+    timezone: str = Query("Australia/Sydney"),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    d = _resolve_date(date)
+    query = "SELECT device, entry_type, name, seconds FROM screen_time WHERE date = ?"
+    params: list = [d]
+    if device:
+        query += " AND device = ?"
+        params.append(device)
+    query += " ORDER BY seconds DESC"
+    if top_n:
+        query += " LIMIT ?"
+        params.append(top_n)
+
+    cursor = conn.execute(query, params)
+    return {"date": d, "entries": [dict(row) for row in cursor.fetchall()]}
+
+
+@router.get("/safari")
+def get_safari(
+    date: str = Query(...),
+    device: str | None = Query(None),
+    domain: str | None = Query(None),
+    top_n: int | None = Query(None),
+    timezone: str = Query("Australia/Sydney"),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    d = _resolve_date(date)
+    query = "SELECT device, domain, title, url, visited_at FROM safari_history WHERE date = ?"
+    params: list = [d]
+    if device:
+        query += " AND device = ?"
+        params.append(device)
+    if domain:
+        query += " AND domain = ?"
+        params.append(domain)
+    query += " ORDER BY visited_at DESC"
+    if top_n:
+        query += " LIMIT ?"
+        params.append(top_n)
+
+    cursor = conn.execute(query, params)
+    return {"date": d, "entries": [dict(row) for row in cursor.fetchall()]}
+
+
+@router.get("/youtube")
+def get_youtube(
+    date: str = Query(...),
+    timezone: str = Query("Australia/Sydney"),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    d = _resolve_date(date)
+    cursor = conn.execute(
+        "SELECT title, url, visited_at FROM youtube_history WHERE date = ? ORDER BY visited_at DESC",
+        (d,),
+    )
+    return {"date": d, "entries": [dict(row) for row in cursor.fetchall()]}
+
+
+@router.get("/podcasts")
+def get_podcasts(
+    date: str = Query(...),
+    timezone: str = Query("Australia/Sydney"),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    d = _resolve_date(date)
+    cursor = conn.execute(
+        "SELECT podcast, episode, duration_seconds, played_at FROM podcasts WHERE date = ? ORDER BY played_at DESC",
+        (d,),
+    )
+    return {"date": d, "entries": [dict(row) for row in cursor.fetchall()]}
+
+
+@router.get("/claude-sessions")
+def get_claude_sessions(
+    date: str = Query(...),
+    timezone: str = Query("Australia/Sydney"),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    d = _resolve_date(date)
+    cursor = conn.execute(
+        "SELECT project, start_time, end_time, duration_min, turns, summary FROM claude_sessions WHERE date = ? ORDER BY start_time",
+        (d,),
+    )
+    return {"date": d, "sessions": [dict(row) for row in cursor.fetchall()]}
+
+
+@router.get("/bede-sessions")
+def get_bede_sessions(
+    date: str = Query(...),
+    timezone: str = Query("Australia/Sydney"),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    d = _resolve_date(date)
+    cursor = conn.execute(
+        "SELECT task_name, start_time, end_time, duration_min, turns, summary FROM bede_sessions WHERE date = ? ORDER BY start_time",
+        (d,),
+    )
+    return {"date": d, "sessions": [dict(row) for row in cursor.fetchall()]}

--- a/bede-data/src/bede_data/api/vault_queue.py
+++ b/bede-data/src/bede_data/api/vault_queue.py
@@ -1,0 +1,86 @@
+import sqlite3
+from datetime import datetime, timezone
+from enum import Enum
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from bede_data.db.connection import get_db
+
+router = APIRouter(prefix="/api/vault-queue", tags=["vault-queue"])
+
+
+class QueueStatus(str, Enum):
+    pending = "pending"
+    published = "published"
+    failed = "failed"
+
+
+class QueueItemCreate(BaseModel):
+    content_type: str
+    content: str
+    vault_path: str | None = None
+
+
+class QueueItemUpdate(BaseModel):
+    status: QueueStatus
+    error_detail: str | None = None
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@router.post("", status_code=201)
+def enqueue(body: QueueItemCreate, conn: sqlite3.Connection = Depends(get_db)):
+    cursor = conn.execute(
+        "INSERT INTO vault_publish_queue (content_type, content, vault_path, created_at) VALUES (?, ?, ?, ?)",
+        (body.content_type, body.content, body.vault_path, _now()),
+    )
+    conn.commit()
+    return _get_item(conn, cursor.lastrowid)
+
+
+@router.get("")
+def list_queue(
+    status: QueueStatus | None = Query(None),
+    limit: int = Query(50),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    query = "SELECT id, content_type, content, vault_path, status, error_detail, created_at, published_at FROM vault_publish_queue"
+    params: list = []
+    if status:
+        query += " WHERE status = ?"
+        params.append(status.value)
+    query += " ORDER BY created_at DESC LIMIT ?"
+    params.append(limit)
+    cursor = conn.execute(query, params)
+    return {"items": [dict(r) for r in cursor.fetchall()]}
+
+
+@router.put("/{item_id}")
+def update_queue_item(
+    item_id: int,
+    body: QueueItemUpdate,
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    existing = _get_item(conn, item_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Queue item not found")
+
+    published_at = _now() if body.status == QueueStatus.published else None
+    conn.execute(
+        "UPDATE vault_publish_queue SET status = ?, error_detail = ?, published_at = COALESCE(?, published_at) WHERE id = ?",
+        (body.status.value, body.error_detail, published_at, item_id),
+    )
+    conn.commit()
+    return _get_item(conn, item_id)
+
+
+def _get_item(conn: sqlite3.Connection, item_id: int) -> dict | None:
+    cursor = conn.execute(
+        "SELECT id, content_type, content, vault_path, status, error_detail, created_at, published_at FROM vault_publish_queue WHERE id = ?",
+        (item_id,),
+    )
+    row = cursor.fetchone()
+    return dict(row) if row else None

--- a/bede-data/src/bede_data/api/weather.py
+++ b/bede-data/src/bede_data/api/weather.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter
+
+from bede_data.live.air_quality import fetch_air_quality
+from bede_data.live.weather import fetch_weather
+
+router = APIRouter(prefix="/api", tags=["weather"])
+
+
+@router.get("/weather")
+async def get_weather():
+    return await fetch_weather()
+
+
+@router.get("/air-quality")
+async def get_air_quality(site_id: str | None = None):
+    return await fetch_air_quality(site_id)

--- a/bede-data/src/bede_data/app.py
+++ b/bede-data/src/bede_data/app.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from bede_data.api.analytics import router as analytics_router
+from bede_data.api.conversations import router as conversations_router
 from bede_data.api.config_api import router as config_router
 from bede_data.api.freshness import router as freshness_router
 from bede_data.api.goals import router as goals_router
@@ -43,6 +44,7 @@ def create_app() -> FastAPI:
     app.include_router(freshness_router)
     app.include_router(storage_router)
     app.include_router(retention_router)
+    app.include_router(conversations_router)
 
     @app.get("/health")
     def health_check():

--- a/bede-data/src/bede_data/app.py
+++ b/bede-data/src/bede_data/app.py
@@ -1,0 +1,21 @@
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+
+from bede_data.db.connection import init_db
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    init_db()
+    yield
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="bede-data", lifespan=lifespan)
+
+    @app.get("/health")
+    def health_check():
+        return {"status": "ok"}
+
+    return app

--- a/bede-data/src/bede_data/app.py
+++ b/bede-data/src/bede_data/app.py
@@ -8,8 +8,10 @@ from bede_data.api.goals import router as goals_router
 from bede_data.api.health import router as health_router
 from bede_data.api.location import router as location_router
 from bede_data.api.memories import router as memories_router
+from bede_data.api.sessions import router as sessions_router
 from bede_data.api.task_log import router as task_log_router
 from bede_data.api.vault_data import router as vault_data_router
+from bede_data.api.vault_queue import router as vault_queue_router
 from bede_data.api.weather import router as weather_router
 from bede_data.db.connection import init_db
 from bede_data.ingest.router import router as ingest_router
@@ -33,6 +35,8 @@ def create_app() -> FastAPI:
     app.include_router(task_log_router)
     app.include_router(config_router)
     app.include_router(analytics_router)
+    app.include_router(sessions_router)
+    app.include_router(vault_queue_router)
 
     @app.get("/health")
     def health_check():

--- a/bede-data/src/bede_data/app.py
+++ b/bede-data/src/bede_data/app.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from bede_data.api.health import router as health_router
+from bede_data.api.vault_data import router as vault_data_router
 from bede_data.db.connection import init_db
 from bede_data.ingest.router import router as ingest_router
 
@@ -17,6 +18,7 @@ def create_app() -> FastAPI:
     app = FastAPI(title="bede-data", lifespan=lifespan)
     app.include_router(ingest_router)
     app.include_router(health_router)
+    app.include_router(vault_data_router)
 
     @app.get("/health")
     def health_check():

--- a/bede-data/src/bede_data/app.py
+++ b/bede-data/src/bede_data/app.py
@@ -4,11 +4,14 @@ from fastapi import FastAPI
 
 from bede_data.api.analytics import router as analytics_router
 from bede_data.api.config_api import router as config_router
+from bede_data.api.freshness import router as freshness_router
 from bede_data.api.goals import router as goals_router
 from bede_data.api.health import router as health_router
 from bede_data.api.location import router as location_router
 from bede_data.api.memories import router as memories_router
+from bede_data.api.retention import router as retention_router
 from bede_data.api.sessions import router as sessions_router
+from bede_data.api.storage import router as storage_router
 from bede_data.api.task_log import router as task_log_router
 from bede_data.api.vault_data import router as vault_data_router
 from bede_data.api.vault_queue import router as vault_queue_router
@@ -37,6 +40,9 @@ def create_app() -> FastAPI:
     app.include_router(analytics_router)
     app.include_router(sessions_router)
     app.include_router(vault_queue_router)
+    app.include_router(freshness_router)
+    app.include_router(storage_router)
+    app.include_router(retention_router)
 
     @app.get("/health")
     def health_check():

--- a/bede-data/src/bede_data/app.py
+++ b/bede-data/src/bede_data/app.py
@@ -2,6 +2,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
+from bede_data.api.analytics import router as analytics_router
 from bede_data.api.config_api import router as config_router
 from bede_data.api.goals import router as goals_router
 from bede_data.api.health import router as health_router
@@ -31,6 +32,7 @@ def create_app() -> FastAPI:
     app.include_router(goals_router)
     app.include_router(task_log_router)
     app.include_router(config_router)
+    app.include_router(analytics_router)
 
     @app.get("/health")
     def health_check():

--- a/bede-data/src/bede_data/app.py
+++ b/bede-data/src/bede_data/app.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from bede_data.api.health import router as health_router
 from bede_data.api.location import router as location_router
 from bede_data.api.vault_data import router as vault_data_router
+from bede_data.api.weather import router as weather_router
 from bede_data.db.connection import init_db
 from bede_data.ingest.router import router as ingest_router
 
@@ -21,6 +22,7 @@ def create_app() -> FastAPI:
     app.include_router(health_router)
     app.include_router(vault_data_router)
     app.include_router(location_router)
+    app.include_router(weather_router)
 
     @app.get("/health")
     def health_check():

--- a/bede-data/src/bede_data/app.py
+++ b/bede-data/src/bede_data/app.py
@@ -6,6 +6,7 @@ from fastapi.responses import JSONResponse
 
 from bede_data.api.analytics import router as analytics_router
 from bede_data.api.conversations import router as conversations_router
+from bede_data.api.message_queue import router as message_queue_router
 from bede_data.api.config_api import router as config_router
 from bede_data.api.freshness import router as freshness_router
 from bede_data.api.goals import router as goals_router
@@ -48,6 +49,7 @@ def create_app() -> FastAPI:
     app.include_router(storage_router)
     app.include_router(retention_router)
     app.include_router(conversations_router)
+    app.include_router(message_queue_router)
 
     @app.get("/health")
     def health_check(conn: sqlite3.Connection = Depends(get_db)):

--- a/bede-data/src/bede_data/app.py
+++ b/bede-data/src/bede_data/app.py
@@ -2,10 +2,12 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
+from bede_data.api.config_api import router as config_router
 from bede_data.api.goals import router as goals_router
 from bede_data.api.health import router as health_router
 from bede_data.api.location import router as location_router
 from bede_data.api.memories import router as memories_router
+from bede_data.api.task_log import router as task_log_router
 from bede_data.api.vault_data import router as vault_data_router
 from bede_data.api.weather import router as weather_router
 from bede_data.db.connection import init_db
@@ -27,6 +29,8 @@ def create_app() -> FastAPI:
     app.include_router(weather_router)
     app.include_router(memories_router)
     app.include_router(goals_router)
+    app.include_router(task_log_router)
+    app.include_router(config_router)
 
     @app.get("/health")
     def health_check():

--- a/bede-data/src/bede_data/app.py
+++ b/bede-data/src/bede_data/app.py
@@ -2,6 +2,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
+from bede_data.api.goals import router as goals_router
 from bede_data.api.health import router as health_router
 from bede_data.api.location import router as location_router
 from bede_data.api.memories import router as memories_router
@@ -25,6 +26,7 @@ def create_app() -> FastAPI:
     app.include_router(location_router)
     app.include_router(weather_router)
     app.include_router(memories_router)
+    app.include_router(goals_router)
 
     @app.get("/health")
     def health_check():

--- a/bede-data/src/bede_data/app.py
+++ b/bede-data/src/bede_data/app.py
@@ -1,6 +1,8 @@
+import sqlite3
 from contextlib import asynccontextmanager
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI
+from fastapi.responses import JSONResponse
 
 from bede_data.api.analytics import router as analytics_router
 from bede_data.api.conversations import router as conversations_router
@@ -17,7 +19,7 @@ from bede_data.api.task_log import router as task_log_router
 from bede_data.api.vault_data import router as vault_data_router
 from bede_data.api.vault_queue import router as vault_queue_router
 from bede_data.api.weather import router as weather_router
-from bede_data.db.connection import init_db
+from bede_data.db.connection import get_db, init_db
 from bede_data.ingest.router import router as ingest_router
 
 
@@ -29,6 +31,7 @@ async def lifespan(app: FastAPI):
 
 def create_app() -> FastAPI:
     app = FastAPI(title="bede-data", lifespan=lifespan)
+
     app.include_router(ingest_router)
     app.include_router(health_router)
     app.include_router(vault_data_router)
@@ -47,7 +50,15 @@ def create_app() -> FastAPI:
     app.include_router(conversations_router)
 
     @app.get("/health")
-    def health_check():
-        return {"status": "ok"}
+    def health_check(conn: sqlite3.Connection = Depends(get_db)):
+        try:
+            cursor = conn.execute("SELECT MAX(version) FROM schema_version")
+            version = cursor.fetchone()[0]
+            return {"status": "ok", "schema_version": version}
+        except Exception as e:
+            return JSONResponse(
+                status_code=503,
+                content={"status": "unhealthy", "detail": str(e)},
+            )
 
     return app

--- a/bede-data/src/bede_data/app.py
+++ b/bede-data/src/bede_data/app.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 
 from bede_data.api.health import router as health_router
 from bede_data.api.location import router as location_router
+from bede_data.api.memories import router as memories_router
 from bede_data.api.vault_data import router as vault_data_router
 from bede_data.api.weather import router as weather_router
 from bede_data.db.connection import init_db
@@ -23,6 +24,7 @@ def create_app() -> FastAPI:
     app.include_router(vault_data_router)
     app.include_router(location_router)
     app.include_router(weather_router)
+    app.include_router(memories_router)
 
     @app.get("/health")
     def health_check():

--- a/bede-data/src/bede_data/app.py
+++ b/bede-data/src/bede_data/app.py
@@ -2,6 +2,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
+from bede_data.api.health import router as health_router
 from bede_data.db.connection import init_db
 from bede_data.ingest.router import router as ingest_router
 
@@ -15,6 +16,7 @@ async def lifespan(app: FastAPI):
 def create_app() -> FastAPI:
     app = FastAPI(title="bede-data", lifespan=lifespan)
     app.include_router(ingest_router)
+    app.include_router(health_router)
 
     @app.get("/health")
     def health_check():

--- a/bede-data/src/bede_data/app.py
+++ b/bede-data/src/bede_data/app.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from bede_data.db.connection import init_db
+from bede_data.ingest.router import router as ingest_router
 
 
 @asynccontextmanager
@@ -13,6 +14,7 @@ async def lifespan(app: FastAPI):
 
 def create_app() -> FastAPI:
     app = FastAPI(title="bede-data", lifespan=lifespan)
+    app.include_router(ingest_router)
 
     @app.get("/health")
     def health_check():

--- a/bede-data/src/bede_data/app.py
+++ b/bede-data/src/bede_data/app.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from bede_data.api.health import router as health_router
+from bede_data.api.location import router as location_router
 from bede_data.api.vault_data import router as vault_data_router
 from bede_data.db.connection import init_db
 from bede_data.ingest.router import router as ingest_router
@@ -19,6 +20,7 @@ def create_app() -> FastAPI:
     app.include_router(ingest_router)
     app.include_router(health_router)
     app.include_router(vault_data_router)
+    app.include_router(location_router)
 
     @app.get("/health")
     def health_check():

--- a/bede-data/src/bede_data/config.py
+++ b/bede-data/src/bede_data/config.py
@@ -1,0 +1,21 @@
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    sqlite_db_path: str = "/data/sqlite/bede.db"
+    ingest_write_token: str = ""
+    timezone: str = "Australia/Sydney"
+    owntracks_url: str = "http://owntracks-recorder:8083"
+    owntracks_user: str = ""
+    owntracks_device: str = ""
+    homepage_api_url: str = "http://homepage-api:5000"
+    nominatim_url: str = "https://nominatim.openstreetmap.org/reverse"
+    bom_location: str = ""
+    claude_sessions_dir: str = "/data/bede/claude-sessions"
+    host: str = "0.0.0.0"
+    port: int = 8001
+
+    model_config = {"env_prefix": "", "case_sensitive": False}
+
+
+settings = Settings()

--- a/bede-data/src/bede_data/db/connection.py
+++ b/bede-data/src/bede_data/db/connection.py
@@ -2,23 +2,34 @@ import sqlite3
 from collections.abc import Generator
 
 from bede_data.config import settings
+from bede_data.db.schema import SCHEMA_SQL, SCHEMA_VERSION
+
+
+def get_connection() -> sqlite3.Connection:
+    conn = sqlite3.connect(settings.sqlite_db_path)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
 
 
 def init_db() -> None:
-    """Initialise the SQLite database, creating the file if it doesn't exist."""
-    import os
-    db_path = settings.sqlite_db_path
-    parent = os.path.dirname(db_path)
-    if parent:
-        os.makedirs(parent, exist_ok=True)
-    conn = sqlite3.connect(db_path)
-    conn.close()
+    conn = get_connection()
+    try:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.executescript(SCHEMA_SQL)
+        existing = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()[0]
+        if existing is None or existing < SCHEMA_VERSION:
+            conn.execute(
+                "INSERT OR REPLACE INTO schema_version (version) VALUES (?)",
+                (SCHEMA_VERSION,),
+            )
+            conn.commit()
+    finally:
+        conn.close()
 
 
 def get_db() -> Generator[sqlite3.Connection, None, None]:
-    """Yield a SQLite connection and close it on teardown."""
-    conn = sqlite3.connect(settings.sqlite_db_path)
-    conn.row_factory = sqlite3.Row
+    conn = get_connection()
     try:
         yield conn
     finally:

--- a/bede-data/src/bede_data/db/connection.py
+++ b/bede-data/src/bede_data/db/connection.py
@@ -1,0 +1,25 @@
+import sqlite3
+from collections.abc import Generator
+
+from bede_data.config import settings
+
+
+def init_db() -> None:
+    """Initialise the SQLite database, creating the file if it doesn't exist."""
+    import os
+    db_path = settings.sqlite_db_path
+    parent = os.path.dirname(db_path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.close()
+
+
+def get_db() -> Generator[sqlite3.Connection, None, None]:
+    """Yield a SQLite connection and close it on teardown."""
+    conn = sqlite3.connect(settings.sqlite_db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        yield conn
+    finally:
+        conn.close()

--- a/bede-data/src/bede_data/db/connection.py
+++ b/bede-data/src/bede_data/db/connection.py
@@ -19,6 +19,12 @@ def init_db() -> None:
         conn.execute("PRAGMA journal_mode=WAL")
         for table in tables_needing_reset(conn):
             conn.execute(f"DROP TABLE IF EXISTS [{table}]")
+        try:
+            existing = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()[0]
+        except sqlite3.OperationalError:
+            existing = None
+        if existing is not None and existing < 3:
+            conn.execute("DROP TABLE IF EXISTS health_metrics")
         conn.commit()
         conn.executescript(SCHEMA_SQL)
         existing = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()[0]

--- a/bede-data/src/bede_data/db/connection.py
+++ b/bede-data/src/bede_data/db/connection.py
@@ -2,7 +2,7 @@ import sqlite3
 from collections.abc import Generator
 
 from bede_data.config import settings
-from bede_data.db.schema import SCHEMA_SQL, SCHEMA_VERSION
+from bede_data.db.schema import SCHEMA_SQL, SCHEMA_VERSION, tables_needing_reset
 
 
 def get_connection() -> sqlite3.Connection:
@@ -17,6 +17,9 @@ def init_db() -> None:
     conn = get_connection()
     try:
         conn.execute("PRAGMA journal_mode=WAL")
+        for table in tables_needing_reset(conn):
+            conn.execute(f"DROP TABLE IF EXISTS [{table}]")
+        conn.commit()
         conn.executescript(SCHEMA_SQL)
         existing = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()[0]
         if existing is None or existing < SCHEMA_VERSION:

--- a/bede-data/src/bede_data/db/connection.py
+++ b/bede-data/src/bede_data/db/connection.py
@@ -13,6 +13,7 @@ def get_connection() -> sqlite3.Connection:
 
 
 def init_db() -> None:
+    """Create all tables (idempotent) and set WAL mode for concurrent read access."""
     conn = get_connection()
     try:
         conn.execute("PRAGMA journal_mode=WAL")
@@ -29,6 +30,7 @@ def init_db() -> None:
 
 
 def get_db() -> Generator[sqlite3.Connection, None, None]:
+    """FastAPI dependency that yields a DB connection and closes it after the request."""
     conn = get_connection()
     try:
         yield conn

--- a/bede-data/src/bede_data/db/connection.py
+++ b/bede-data/src/bede_data/db/connection.py
@@ -20,7 +20,9 @@ def init_db() -> None:
         for table in tables_needing_reset(conn):
             conn.execute(f"DROP TABLE IF EXISTS [{table}]")
         try:
-            existing = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()[0]
+            existing = conn.execute(
+                "SELECT MAX(version) FROM schema_version"
+            ).fetchone()[0]
         except sqlite3.OperationalError:
             existing = None
         if existing is not None and existing < 3:

--- a/bede-data/src/bede_data/db/schema.py
+++ b/bede-data/src/bede_data/db/schema.py
@@ -1,0 +1,262 @@
+SCHEMA_VERSION = 1
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS schema_version (
+    version     INTEGER PRIMARY KEY,
+    applied_at  TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS health_metrics (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    date        TEXT NOT NULL,
+    metric      TEXT NOT NULL,
+    value       REAL NOT NULL,
+    source      TEXT,
+    recorded_at TEXT,
+    UNIQUE (date, metric, source)
+);
+
+CREATE TABLE IF NOT EXISTS sleep_phases (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    date        TEXT NOT NULL,
+    phase       TEXT NOT NULL,
+    hours       REAL NOT NULL,
+    start_time  TEXT,
+    end_time    TEXT,
+    source      TEXT,
+    UNIQUE (date, phase, source)
+);
+
+CREATE TABLE IF NOT EXISTS workouts (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    date                TEXT NOT NULL,
+    workout_type        TEXT NOT NULL,
+    duration_minutes    REAL,
+    active_energy_kj    REAL,
+    avg_heart_rate      REAL,
+    max_heart_rate      REAL,
+    start_time          TEXT,
+    UNIQUE (date, start_time)
+);
+
+CREATE TABLE IF NOT EXISTS state_of_mind (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    date        TEXT NOT NULL,
+    valence     REAL,
+    labels      TEXT,
+    context     TEXT,
+    associations TEXT,
+    recorded_at TEXT,
+    UNIQUE (date, recorded_at)
+);
+
+CREATE TABLE IF NOT EXISTS medications (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    date        TEXT NOT NULL,
+    medication  TEXT NOT NULL,
+    quantity    REAL,
+    unit        TEXT,
+    recorded_at TEXT,
+    UNIQUE (date, medication, recorded_at)
+);
+
+CREATE TABLE IF NOT EXISTS screen_time (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    date        TEXT NOT NULL,
+    device      TEXT NOT NULL,
+    entry_type  TEXT NOT NULL,
+    name        TEXT NOT NULL,
+    seconds     INTEGER NOT NULL,
+    UNIQUE (date, device, entry_type, name)
+);
+
+CREATE TABLE IF NOT EXISTS safari_history (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    date        TEXT NOT NULL,
+    device      TEXT NOT NULL,
+    domain      TEXT,
+    title       TEXT,
+    url         TEXT NOT NULL,
+    visited_at  TEXT NOT NULL,
+    UNIQUE (url, visited_at)
+);
+
+CREATE TABLE IF NOT EXISTS youtube_history (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    date        TEXT NOT NULL,
+    title       TEXT,
+    url         TEXT NOT NULL,
+    visited_at  TEXT NOT NULL,
+    UNIQUE (url, visited_at)
+);
+
+CREATE TABLE IF NOT EXISTS podcasts (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    date             TEXT NOT NULL,
+    podcast          TEXT NOT NULL,
+    episode          TEXT NOT NULL,
+    duration_seconds INTEGER,
+    played_at        TEXT NOT NULL,
+    UNIQUE (episode, played_at)
+);
+
+CREATE TABLE IF NOT EXISTS claude_sessions (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    date         TEXT NOT NULL,
+    project      TEXT,
+    start_time   TEXT,
+    end_time     TEXT,
+    duration_min REAL,
+    turns        INTEGER,
+    summary      TEXT,
+    UNIQUE (project, start_time)
+);
+
+CREATE TABLE IF NOT EXISTS bede_sessions (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    date         TEXT NOT NULL,
+    task_name    TEXT,
+    start_time   TEXT,
+    end_time     TEXT,
+    duration_min REAL,
+    turns        INTEGER,
+    summary      TEXT,
+    UNIQUE (task_name, start_time)
+);
+
+CREATE TABLE IF NOT EXISTS music_listens (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    date        TEXT NOT NULL,
+    track       TEXT NOT NULL,
+    artist      TEXT NOT NULL,
+    album       TEXT,
+    listened_at TEXT NOT NULL,
+    UNIQUE (track, artist, listened_at)
+);
+
+CREATE TABLE IF NOT EXISTS memories (
+    id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+    content              TEXT NOT NULL,
+    type                 TEXT NOT NULL CHECK (type IN ('fact', 'preference', 'correction', 'commitment')),
+    created_at           TEXT NOT NULL DEFAULT (datetime('now')),
+    last_referenced_at   TEXT,
+    source_conversation  TEXT,
+    superseded_by        INTEGER REFERENCES memories(id),
+    active               INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE TABLE IF NOT EXISTS goals (
+    id                   INTEGER PRIMARY KEY AUTOINCREMENT,
+    name                 TEXT NOT NULL,
+    description          TEXT,
+    deadline             TEXT,
+    measurable_indicators TEXT,
+    status               TEXT NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'completed', 'dropped')),
+    created_at           TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at           TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS task_executions (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_name        TEXT NOT NULL,
+    start_time       TEXT NOT NULL,
+    end_time         TEXT,
+    duration_seconds REAL,
+    status           TEXT NOT NULL CHECK (status IN ('running', 'success', 'failure', 'timeout')),
+    error_detail     TEXT,
+    created_at       TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS analytics_flags (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    signal       TEXT NOT NULL,
+    severity     TEXT NOT NULL CHECK (severity IN ('info', 'nudge', 'concern', 'alert')),
+    detail       TEXT,
+    data         TEXT,
+    computed_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    acknowledged INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS analytics_thresholds (
+    id      INTEGER PRIMARY KEY AUTOINCREMENT,
+    signal  TEXT NOT NULL UNIQUE,
+    config  TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS schedules (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_name        TEXT NOT NULL UNIQUE,
+    cron_expression  TEXT NOT NULL,
+    prompt           TEXT NOT NULL,
+    model            TEXT,
+    timeout_seconds  INTEGER DEFAULT 300,
+    interactive      INTEGER NOT NULL DEFAULT 0,
+    enabled          INTEGER NOT NULL DEFAULT 1,
+    created_at       TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at       TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS monitored_items (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    category   TEXT NOT NULL,
+    name       TEXT NOT NULL,
+    config     TEXT NOT NULL,
+    enabled    INTEGER NOT NULL DEFAULT 1,
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS settings (
+    key        TEXT PRIMARY KEY,
+    value      TEXT NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS daily_scratchpads (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    date       TEXT NOT NULL,
+    entry_time TEXT NOT NULL,
+    content    TEXT NOT NULL,
+    UNIQUE (date, entry_time)
+);
+
+CREATE TABLE IF NOT EXISTS daily_sessions (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    date       TEXT NOT NULL UNIQUE,
+    session_id TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS vault_publish_queue (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    content_type TEXT NOT NULL,
+    content      TEXT NOT NULL,
+    vault_path   TEXT,
+    status       TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'published', 'failed')),
+    error_detail TEXT,
+    created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+    published_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS message_queue (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    message      TEXT NOT NULL,
+    source       TEXT NOT NULL,
+    status       TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'processing', 'done', 'failed')),
+    created_at   TEXT NOT NULL DEFAULT (datetime('now')),
+    processed_at TEXT
+);
+
+CREATE TABLE IF NOT EXISTS data_freshness (
+    source                   TEXT PRIMARY KEY,
+    last_received_at         TEXT NOT NULL,
+    expected_interval_seconds INTEGER NOT NULL,
+    updated_at               TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS retention_policies (
+    data_type      TEXT PRIMARY KEY,
+    retention_days INTEGER NOT NULL,
+    updated_at     TEXT NOT NULL DEFAULT (datetime('now'))
+);
+"""

--- a/bede-data/src/bede_data/db/schema.py
+++ b/bede-data/src/bede_data/db/schema.py
@@ -1,4 +1,4 @@
-SCHEMA_VERSION = 2
+SCHEMA_VERSION = 3
 
 # Tables whose column names changed from the prototype bede schema.
 # init_db drops these if they have old-style columns, then SCHEMA_SQL recreates them.
@@ -43,7 +43,7 @@ CREATE TABLE IF NOT EXISTS health_metrics (
     value       REAL NOT NULL,
     source      TEXT,
     recorded_at TEXT,
-    UNIQUE (date, metric, source)
+    UNIQUE (date, metric, source, recorded_at)
 );
 
 CREATE TABLE IF NOT EXISTS sleep_phases (

--- a/bede-data/src/bede_data/db/schema.py
+++ b/bede-data/src/bede_data/db/schema.py
@@ -1,4 +1,34 @@
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
+
+# Tables whose column names changed from the prototype bede schema.
+# init_db drops these if they have old-style columns, then SCHEMA_SQL recreates them.
+_PROTOTYPE_COLUMNS = {
+    "sleep_phases": "stage",
+    "workouts": "workout_name",
+    "screen_time": "identifier",
+    "medications": "name",
+    "bede_sessions": "project",
+    "state_of_mind": "associations",  # missing in prototype — presence means new schema
+}
+
+
+def tables_needing_reset(conn) -> list[str]:
+    """Return table names that still have the prototype schema."""
+    to_reset = []
+    for table, marker_col in _PROTOTYPE_COLUMNS.items():
+        cols = {
+            row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()
+        }
+        if not cols:
+            continue
+        if table == "state_of_mind":
+            if marker_col not in cols:
+                to_reset.append(table)
+        else:
+            if marker_col in cols:
+                to_reset.append(table)
+    return to_reset
+
 
 SCHEMA_SQL = """
 CREATE TABLE IF NOT EXISTS schema_version (

--- a/bede-data/src/bede_data/ingest/auth.py
+++ b/bede-data/src/bede_data/ingest/auth.py
@@ -1,0 +1,17 @@
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from bede_data.config import settings
+
+bearer_scheme = HTTPBearer()
+
+
+def verify_ingest_token(
+    credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
+) -> str:
+    if credentials.credentials != settings.ingest_write_token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid bearer token",
+        )
+    return credentials.credentials

--- a/bede-data/src/bede_data/ingest/auth.py
+++ b/bede-data/src/bede_data/ingest/auth.py
@@ -9,7 +9,7 @@ bearer_scheme = HTTPBearer()
 def verify_ingest_token(
     credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
 ) -> str:
-    if credentials.credentials != settings.ingest_write_token:
+    if not settings.ingest_write_token or credentials.credentials != settings.ingest_write_token:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid bearer token",

--- a/bede-data/src/bede_data/ingest/auth.py
+++ b/bede-data/src/bede_data/ingest/auth.py
@@ -9,7 +9,10 @@ bearer_scheme = HTTPBearer()
 def verify_ingest_token(
     credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme),
 ) -> str:
-    if not settings.ingest_write_token or credentials.credentials != settings.ingest_write_token:
+    if (
+        not settings.ingest_write_token
+        or credentials.credentials != settings.ingest_write_token
+    ):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Invalid bearer token",

--- a/bede-data/src/bede_data/ingest/health_parser.py
+++ b/bede-data/src/bede_data/ingest/health_parser.py
@@ -1,59 +1,183 @@
-from datetime import datetime
+import json
+import re
+from datetime import datetime, timezone
+
+_MEDICATION_RE = re.compile(r"medication", re.IGNORECASE)
+
+_TS_PATTERNS = [
+    r"(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}) ([+-]\d{4})",
+    r"(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})([+-]\d{2}:\d{2})",
+]
+
+
+def _parse_timestamp(ts_str: str) -> tuple[str, str] | None:
+    """Parse HAE timestamp to (local_date, utc_iso8601). HAE sends timestamps
+    as 'YYYY-MM-DD HH:MM:SS +HHMM' (local with offset)."""
+    if not ts_str:
+        return None
+    for pattern in _TS_PATTERNS:
+        m = re.match(pattern, ts_str.strip())
+        if m:
+            date_part, time_part, offset = m.groups()
+            if ":" not in offset:
+                offset = offset[:3] + ":" + offset[3:]
+            iso_str = f"{date_part}T{time_part}{offset}"
+            try:
+                dt = datetime.fromisoformat(iso_str)
+                local_date = dt.strftime("%Y-%m-%d")
+                utc_iso = dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+                return local_date, utc_iso
+            except ValueError:
+                continue
+    try:
+        dt = datetime.fromisoformat(ts_str.strip())
+        local_date = dt.strftime("%Y-%m-%d")
+        utc_iso = dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        return local_date, utc_iso
+    except ValueError:
+        return None
 
 
 def _parse_date(date_str: str) -> str:
-    for fmt in ("%Y-%m-%d %H:%M:%S %z", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d"):
-        try:
-            dt = datetime.strptime(date_str, fmt)
-            return dt.strftime("%Y-%m-%d")
-        except ValueError:
-            continue
-    return date_str[:10]
+    parsed = _parse_timestamp(date_str)
+    if parsed:
+        return parsed[0]
+    return date_str[:10] if len(date_str) >= 10 else date_str
 
 
 def _parse_datetime(date_str: str) -> str:
-    for fmt in ("%Y-%m-%d %H:%M:%S %z", "%Y-%m-%d %H:%M:%S"):
-        try:
-            dt = datetime.strptime(date_str, fmt)
-            return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
-        except ValueError:
-            continue
+    parsed = _parse_timestamp(date_str)
+    if parsed:
+        return parsed[1]
     return date_str
 
 
-def _parse_sleep_phase(value: str) -> str:
-    """Strip Apple Health's HKCategoryValueSleepAnalysis prefix to get just the phase name (e.g. 'inBed', 'asleep')."""
-    prefix = "HKCategoryValueSleepAnalysis."
-    if value.startswith(prefix):
-        return value[len(prefix) :]
-    return value
-
-
 def _hours_between(start_str: str, end_str: str) -> float:
-    for fmt in ("%Y-%m-%d %H:%M:%S %z", "%Y-%m-%d %H:%M:%S"):
+    s = _parse_timestamp(start_str)
+    e = _parse_timestamp(end_str)
+    if s and e:
         try:
-            start = datetime.strptime(start_str, fmt)
-            end = datetime.strptime(end_str, fmt)
+            start = datetime.fromisoformat(s[1].replace("Z", "+00:00"))
+            end = datetime.fromisoformat(e[1].replace("Z", "+00:00"))
             return (end - start).total_seconds() / 3600
         except ValueError:
-            continue
+            pass
     return 0.0
 
 
 def _extract_qty(value) -> float | None:
-    """Extract qty from a Health Export field that may be a dict, a list of dicts, or None."""
+    """Extract qty from a field that may be a dict, list of dicts, or a scalar."""
+    if isinstance(value, (int, float)):
+        return float(value)
     if isinstance(value, dict):
         return value.get("qty")
     if isinstance(value, list) and value:
-        return value[0].get("qty")
+        return value[0].get("qty") if isinstance(value[0], dict) else None
     return None
 
 
-SPECIAL_METRICS = {"sleep_analysis", "medication_record", "state_of_mind"}
+def _process_sleep(metric: dict) -> list[dict]:
+    """Process sleep data from all HAE formats: aggregatedSleepAnalyses,
+    sleepAnalyses, and inline data[].sleepAnalysis."""
+    rows = []
+
+    analyses = metric.get("aggregatedSleepAnalyses", [])
+    if not analyses:
+        analyses = metric.get("sleepAnalyses", [])
+
+    for analysis in analyses:
+        end_ts = _parse_timestamp(
+            analysis.get("sleepEnd", "") or analysis.get("endDate", "")
+        )
+        start_ts = _parse_timestamp(
+            analysis.get("sleepStart", "") or analysis.get("startDate", "")
+        )
+        date = end_ts[0] if end_ts else (start_ts[0] if start_ts else None)
+        if not date:
+            continue
+        source = analysis.get("source") or analysis.get("sleepSource", "")
+        start_utc = start_ts[1] if start_ts else None
+        end_utc = end_ts[1] if end_ts else None
+
+        for stage in ("core", "deep", "rem", "awake", "inBed", "asleep"):
+            val = analysis.get(stage)
+            if val is not None and val != 0:
+                try:
+                    rows.append(
+                        {
+                            "date": date,
+                            "phase": stage,
+                            "hours": float(val),
+                            "start_time": start_utc,
+                            "end_time": end_utc,
+                            "source": source or None,
+                        }
+                    )
+                except (ValueError, TypeError):
+                    pass
+
+    for entry in metric.get("data", []):
+        date = _parse_date(entry.get("date", ""))
+        source = entry.get("source", "")
+
+        for phase_entry in entry.get("sleepAnalysis", []):
+            phase = phase_entry.get("value", "")
+            prefix = "HKCategoryValueSleepAnalysis."
+            if phase.startswith(prefix):
+                phase = phase[len(prefix) :]
+
+            hours = _hours_between(
+                phase_entry.get("startDate", ""), phase_entry.get("endDate", "")
+            )
+            rows.append(
+                {
+                    "date": date,
+                    "phase": phase,
+                    "hours": hours,
+                    "start_time": _parse_datetime(phase_entry.get("startDate", "")),
+                    "end_time": _parse_datetime(phase_entry.get("endDate", "")),
+                    "source": source or None,
+                }
+            )
+
+    return rows
+
+
+def _process_state_of_mind(entries: list) -> list[dict]:
+    """Process data.stateOfMind top-level array from HAE."""
+    rows = []
+    for entry in entries:
+        parsed = _parse_timestamp(entry.get("start", ""))
+        if not parsed:
+            continue
+        date, utc_iso = parsed
+        labels = entry.get("labels")
+        if isinstance(labels, list):
+            labels = json.dumps(labels) if labels else None
+        associations = entry.get("associations")
+        if isinstance(associations, list):
+            associations = json.dumps(associations) if associations else None
+        context = entry.get("context")
+        if isinstance(context, list):
+            context = json.dumps(context) if context else None
+        rows.append(
+            {
+                "date": date,
+                "valence": entry.get("valence"),
+                "labels": labels,
+                "context": context,
+                "associations": associations,
+                "recorded_at": utc_iso,
+            }
+        )
+    return rows
 
 
 def parse_health_payload(payload: dict) -> dict:
-    """Parse an Apple Health Export JSON payload into table-ready row dicts. Special metrics (sleep, medications, state of mind) are routed to dedicated tables; everything else goes to health_metrics as a generic name/value pair."""
+    """Parse an Apple Health Export JSON payload into table-ready row dicts.
+    Handles all HAE formats: aggregated sleep, inline sleep phases,
+    top-level stateOfMind, regex-matched medications, and list-typed
+    workout fields."""
     result = {
         "health_metrics": [],
         "sleep_phases": [],
@@ -66,58 +190,43 @@ def parse_health_payload(payload: dict) -> dict:
 
     for metric in data.get("metrics", []):
         name = metric.get("name", "")
+        units = metric.get("units", "")
 
-        for entry in metric.get("data", []):
-            date = _parse_date(entry.get("date", ""))
-            source = entry.get("source", "")
-
-            if name == "sleep_analysis":
-                for phase_entry in entry.get("sleepAnalysis", []):
-                    phase = _parse_sleep_phase(phase_entry.get("value", ""))
-                    hours = _hours_between(
-                        phase_entry.get("startDate", ""),
-                        phase_entry.get("endDate", ""),
-                    )
-                    result["sleep_phases"].append(
-                        {
-                            "date": date,
-                            "phase": phase,
-                            "hours": hours,
-                            "start_time": _parse_datetime(
-                                phase_entry.get("startDate", "")
-                            ),
-                            "end_time": _parse_datetime(phase_entry.get("endDate", "")),
-                            "source": source,
-                        }
-                    )
-            elif name == "medication_record":
+        if (
+            name == "sleep_analysis"
+            or metric.get("aggregatedSleepAnalyses")
+            or metric.get("sleepAnalyses")
+        ):
+            result["sleep_phases"].extend(_process_sleep(metric))
+        elif _MEDICATION_RE.search(name):
+            for entry in metric.get("data", []):
+                date = _parse_date(entry.get("date", ""))
                 result["medications"].append(
                     {
                         "date": date,
-                        "medication": entry.get("medication", ""),
+                        "medication": name,
                         "quantity": entry.get("qty"),
-                        "unit": entry.get("unit"),
+                        "unit": units or None,
                         "recorded_at": _parse_datetime(entry.get("date", "")),
                     }
                 )
-            elif name == "state_of_mind":
-                result["state_of_mind"].append(
-                    {
-                        "date": date,
-                        "valence": entry.get("valence"),
-                        "labels": entry.get("labels"),
-                        "context": entry.get("context"),
-                        "associations": entry.get("associations"),
-                        "recorded_at": _parse_datetime(entry.get("date", "")),
-                    }
-                )
-            else:
+        else:
+            for entry in metric.get("data", []):
+                date = _parse_date(entry.get("date", ""))
+                source = entry.get("source", "")
+                qty = entry.get("qty")
+                if qty is None:
+                    continue
+                try:
+                    value = float(qty)
+                except (ValueError, TypeError):
+                    continue
                 result["health_metrics"].append(
                     {
                         "date": date,
                         "metric": name,
-                        "value": entry.get("qty", 0),
-                        "source": source,
+                        "value": value,
+                        "source": source or None,
                         "recorded_at": _parse_datetime(entry.get("date", "")),
                     }
                 )
@@ -131,11 +240,15 @@ def parse_health_payload(payload: dict) -> dict:
                 "date": _parse_date(start_str),
                 "workout_type": workout.get("name", ""),
                 "duration_minutes": round(duration, 1),
-                "active_energy_kj": _extract_qty(workout.get("activeEnergy")),
+                "active_energy_kj": _extract_qty(
+                    workout.get("activeEnergy") or workout.get("activeEnergyBurned")
+                ),
                 "avg_heart_rate": _extract_qty(workout.get("avgHeartRate")),
                 "max_heart_rate": _extract_qty(workout.get("maxHeartRate")),
                 "start_time": _parse_datetime(start_str),
             }
         )
+
+    result["state_of_mind"].extend(_process_state_of_mind(data.get("stateOfMind", [])))
 
     return result

--- a/bede-data/src/bede_data/ingest/health_parser.py
+++ b/bede-data/src/bede_data/ingest/health_parser.py
@@ -40,6 +40,15 @@ def _hours_between(start_str: str, end_str: str) -> float:
     return 0.0
 
 
+def _extract_qty(value) -> float | None:
+    """Extract qty from a Health Export field that may be a dict, a list of dicts, or None."""
+    if isinstance(value, dict):
+        return value.get("qty")
+    if isinstance(value, list) and value:
+        return value[0].get("qty")
+    return None
+
+
 SPECIAL_METRICS = {"sleep_analysis", "medication_record", "state_of_mind"}
 
 
@@ -122,9 +131,9 @@ def parse_health_payload(payload: dict) -> dict:
                 "date": _parse_date(start_str),
                 "workout_type": workout.get("name", ""),
                 "duration_minutes": round(duration, 1),
-                "active_energy_kj": (workout.get("activeEnergy") or {}).get("qty"),
-                "avg_heart_rate": (workout.get("avgHeartRate") or {}).get("qty"),
-                "max_heart_rate": (workout.get("maxHeartRate") or {}).get("qty"),
+                "active_energy_kj": _extract_qty(workout.get("activeEnergy")),
+                "avg_heart_rate": _extract_qty(workout.get("avgHeartRate")),
+                "max_heart_rate": _extract_qty(workout.get("maxHeartRate")),
                 "start_time": _parse_datetime(start_str),
             }
         )

--- a/bede-data/src/bede_data/ingest/health_parser.py
+++ b/bede-data/src/bede_data/ingest/health_parser.py
@@ -259,9 +259,8 @@ def parse_health_payload(payload: dict) -> dict:
             for entry in metric.get("data", []):
                 date = _parse_date(entry.get("date", ""))
                 source = entry.get("source", "")
-                qty = entry.get("qty")
-                if qty is None:
-                    qty = entry.get("Avg")
+                avg = entry.get("Avg")
+                qty = avg if avg is not None else entry.get("qty")
                 if qty is None:
                     continue
                 try:

--- a/bede-data/src/bede_data/ingest/health_parser.py
+++ b/bede-data/src/bede_data/ingest/health_parser.py
@@ -76,11 +76,44 @@ def _extract_qty(value) -> float | None:
     return None
 
 
+def _extract_named_stages(analysis: dict, date: str, source: str) -> list[dict]:
+    """Extract named sleep stage fields (core, deep, rem, etc.) from an analysis entry."""
+    rows = []
+    start_ts = _parse_timestamp(
+        analysis.get("sleepStart", "") or analysis.get("startDate", "")
+    )
+    end_ts = _parse_timestamp(
+        analysis.get("sleepEnd", "") or analysis.get("endDate", "")
+    )
+    start_utc = start_ts[1] if start_ts else None
+    end_utc = end_ts[1] if end_ts else None
+
+    for stage in ("core", "deep", "rem", "awake", "inBed", "asleep"):
+        val = analysis.get(stage)
+        if val is not None and val != 0:
+            try:
+                rows.append(
+                    {
+                        "date": date,
+                        "phase": stage,
+                        "hours": float(val),
+                        "start_time": start_utc,
+                        "end_time": end_utc,
+                        "source": source or None,
+                    }
+                )
+            except (ValueError, TypeError):
+                pass
+    return rows
+
+
 def _process_sleep(metric: dict) -> list[dict]:
     """Process sleep data from all HAE formats: aggregatedSleepAnalyses,
-    sleepAnalyses, and inline data[].sleepAnalysis."""
+    sleepAnalyses, data[] as analyses (named stage fields), and
+    data[].sleepAnalysis (inline HK phase entries)."""
     rows = []
 
+    # Format 1: top-level aggregated or non-aggregated analyses
     analyses = metric.get("aggregatedSleepAnalyses", [])
     if not analyses:
         analyses = metric.get("sleepAnalyses", [])
@@ -96,30 +129,15 @@ def _process_sleep(metric: dict) -> list[dict]:
         if not date:
             continue
         source = analysis.get("source") or analysis.get("sleepSource", "")
-        start_utc = start_ts[1] if start_ts else None
-        end_utc = end_ts[1] if end_ts else None
+        rows.extend(_extract_named_stages(analysis, date, source))
 
-        for stage in ("core", "deep", "rem", "awake", "inBed", "asleep"):
-            val = analysis.get(stage)
-            if val is not None and val != 0:
-                try:
-                    rows.append(
-                        {
-                            "date": date,
-                            "phase": stage,
-                            "hours": float(val),
-                            "start_time": start_utc,
-                            "end_time": end_utc,
-                            "source": source or None,
-                        }
-                    )
-                except (ValueError, TypeError):
-                    pass
-
+    # Format 2: data[] entries — may have sleepAnalysis sub-arrays (inline HK phases)
+    # or be analyses themselves with named stage fields (fallback when no top-level analyses)
     for entry in metric.get("data", []):
         date = _parse_date(entry.get("date", ""))
         source = entry.get("source", "")
 
+        # Inline HK sleep phases
         for phase_entry in entry.get("sleepAnalysis", []):
             phase = phase_entry.get("value", "")
             prefix = "HKCategoryValueSleepAnalysis."
@@ -139,6 +157,10 @@ def _process_sleep(metric: dict) -> list[dict]:
                     "source": source or None,
                 }
             )
+
+        # Fallback: data[] entries as analyses with named stage fields
+        if not analyses:
+            rows.extend(_extract_named_stages(entry, date, source))
 
     return rows
 

--- a/bede-data/src/bede_data/ingest/health_parser.py
+++ b/bede-data/src/bede_data/ingest/health_parser.py
@@ -22,9 +22,10 @@ def _parse_datetime(date_str: str) -> str:
 
 
 def _parse_sleep_phase(value: str) -> str:
+    """Strip Apple Health's HKCategoryValueSleepAnalysis prefix to get just the phase name (e.g. 'inBed', 'asleep')."""
     prefix = "HKCategoryValueSleepAnalysis."
     if value.startswith(prefix):
-        return value[len(prefix):]
+        return value[len(prefix) :]
     return value
 
 
@@ -43,6 +44,7 @@ SPECIAL_METRICS = {"sleep_analysis", "medication_record", "state_of_mind"}
 
 
 def parse_health_payload(payload: dict) -> dict:
+    """Parse an Apple Health Export JSON payload into table-ready row dicts. Special metrics (sleep, medications, state of mind) are routed to dedicated tables; everything else goes to health_metrics as a generic name/value pair."""
     result = {
         "health_metrics": [],
         "sleep_phases": [],
@@ -75,9 +77,7 @@ def parse_health_payload(payload: dict) -> dict:
                             "start_time": _parse_datetime(
                                 phase_entry.get("startDate", "")
                             ),
-                            "end_time": _parse_datetime(
-                                phase_entry.get("endDate", "")
-                            ),
+                            "end_time": _parse_datetime(phase_entry.get("endDate", "")),
                             "source": source,
                         }
                     )

--- a/bede-data/src/bede_data/ingest/health_parser.py
+++ b/bede-data/src/bede_data/ingest/health_parser.py
@@ -1,0 +1,132 @@
+from datetime import datetime
+
+
+def _parse_date(date_str: str) -> str:
+    for fmt in ("%Y-%m-%d %H:%M:%S %z", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d"):
+        try:
+            dt = datetime.strptime(date_str, fmt)
+            return dt.strftime("%Y-%m-%d")
+        except ValueError:
+            continue
+    return date_str[:10]
+
+
+def _parse_datetime(date_str: str) -> str:
+    for fmt in ("%Y-%m-%d %H:%M:%S %z", "%Y-%m-%d %H:%M:%S"):
+        try:
+            dt = datetime.strptime(date_str, fmt)
+            return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+        except ValueError:
+            continue
+    return date_str
+
+
+def _parse_sleep_phase(value: str) -> str:
+    prefix = "HKCategoryValueSleepAnalysis."
+    if value.startswith(prefix):
+        return value[len(prefix):]
+    return value
+
+
+def _hours_between(start_str: str, end_str: str) -> float:
+    for fmt in ("%Y-%m-%d %H:%M:%S %z", "%Y-%m-%d %H:%M:%S"):
+        try:
+            start = datetime.strptime(start_str, fmt)
+            end = datetime.strptime(end_str, fmt)
+            return (end - start).total_seconds() / 3600
+        except ValueError:
+            continue
+    return 0.0
+
+
+SPECIAL_METRICS = {"sleep_analysis", "medication_record", "state_of_mind"}
+
+
+def parse_health_payload(payload: dict) -> dict:
+    result = {
+        "health_metrics": [],
+        "sleep_phases": [],
+        "workouts": [],
+        "medications": [],
+        "state_of_mind": [],
+    }
+
+    data = payload.get("data", {})
+
+    for metric in data.get("metrics", []):
+        name = metric.get("name", "")
+
+        for entry in metric.get("data", []):
+            date = _parse_date(entry.get("date", ""))
+            source = entry.get("source", "")
+
+            if name == "sleep_analysis":
+                for phase_entry in entry.get("sleepAnalysis", []):
+                    phase = _parse_sleep_phase(phase_entry.get("value", ""))
+                    hours = _hours_between(
+                        phase_entry.get("startDate", ""),
+                        phase_entry.get("endDate", ""),
+                    )
+                    result["sleep_phases"].append(
+                        {
+                            "date": date,
+                            "phase": phase,
+                            "hours": hours,
+                            "start_time": _parse_datetime(
+                                phase_entry.get("startDate", "")
+                            ),
+                            "end_time": _parse_datetime(
+                                phase_entry.get("endDate", "")
+                            ),
+                            "source": source,
+                        }
+                    )
+            elif name == "medication_record":
+                result["medications"].append(
+                    {
+                        "date": date,
+                        "medication": entry.get("medication", ""),
+                        "quantity": entry.get("qty"),
+                        "unit": entry.get("unit"),
+                        "recorded_at": _parse_datetime(entry.get("date", "")),
+                    }
+                )
+            elif name == "state_of_mind":
+                result["state_of_mind"].append(
+                    {
+                        "date": date,
+                        "valence": entry.get("valence"),
+                        "labels": entry.get("labels"),
+                        "context": entry.get("context"),
+                        "associations": entry.get("associations"),
+                        "recorded_at": _parse_datetime(entry.get("date", "")),
+                    }
+                )
+            else:
+                result["health_metrics"].append(
+                    {
+                        "date": date,
+                        "metric": name,
+                        "value": entry.get("qty", 0),
+                        "source": source,
+                        "recorded_at": _parse_datetime(entry.get("date", "")),
+                    }
+                )
+
+    for workout in data.get("workouts", []):
+        start_str = workout.get("start", "")
+        end_str = workout.get("end", "")
+        duration = _hours_between(start_str, end_str) * 60
+        result["workouts"].append(
+            {
+                "date": _parse_date(start_str),
+                "workout_type": workout.get("name", ""),
+                "duration_minutes": round(duration, 1),
+                "active_energy_kj": (workout.get("activeEnergy") or {}).get("qty"),
+                "avg_heart_rate": (workout.get("avgHeartRate") or {}).get("qty"),
+                "max_heart_rate": (workout.get("maxHeartRate") or {}).get("qty"),
+                "start_time": _parse_datetime(start_str),
+            }
+        )
+
+    return result

--- a/bede-data/src/bede_data/ingest/health_parser.py
+++ b/bede-data/src/bede_data/ingest/health_parser.py
@@ -131,13 +131,12 @@ def _process_sleep(metric: dict) -> list[dict]:
         source = analysis.get("source") or analysis.get("sleepSource", "")
         rows.extend(_extract_named_stages(analysis, date, source))
 
-    # Format 2: data[] entries — may have sleepAnalysis sub-arrays (inline HK phases)
-    # or be analyses themselves with named stage fields (fallback when no top-level analyses)
+    # Format 2: data[] entries
     for entry in metric.get("data", []):
         date = _parse_date(entry.get("date", ""))
         source = entry.get("source", "")
 
-        # Inline HK sleep phases
+        # 2a: entries with sleepAnalysis sub-arrays (summarised inline HK phases)
         for phase_entry in entry.get("sleepAnalysis", []):
             phase = phase_entry.get("value", "")
             prefix = "HKCategoryValueSleepAnalysis."
@@ -158,7 +157,31 @@ def _process_sleep(metric: dict) -> list[dict]:
                 }
             )
 
-        # Fallback: data[] entries as analyses with named stage fields
+        # 2b: entries that ARE phase records (unsummarised — value/qty/startDate/endDate)
+        phase_value = entry.get("value", "")
+        if phase_value and entry.get("startDate"):
+            prefix = "HKCategoryValueSleepAnalysis."
+            if phase_value.startswith(prefix):
+                phase_value = phase_value[len(prefix) :]
+            hours = entry.get("qty")
+            if hours is None:
+                hours = _hours_between(
+                    entry.get("startDate", ""), entry.get("endDate", "")
+                )
+            else:
+                hours = float(hours)
+            rows.append(
+                {
+                    "date": date,
+                    "phase": phase_value,
+                    "hours": hours,
+                    "start_time": _parse_datetime(entry.get("startDate", "")),
+                    "end_time": _parse_datetime(entry.get("endDate", "")),
+                    "source": source or None,
+                }
+            )
+
+        # 2c: entries with named stage fields (e.g. core, deep, rem as keys)
         if not analyses:
             rows.extend(_extract_named_stages(entry, date, source))
 
@@ -237,6 +260,8 @@ def parse_health_payload(payload: dict) -> dict:
                 date = _parse_date(entry.get("date", ""))
                 source = entry.get("source", "")
                 qty = entry.get("qty")
+                if qty is None:
+                    qty = entry.get("Avg")
                 if qty is None:
                     continue
                 try:

--- a/bede-data/src/bede_data/ingest/router.py
+++ b/bede-data/src/bede_data/ingest/router.py
@@ -85,6 +85,7 @@ def ingest_vault(
     total += _upsert_rows(conn, "podcasts", parsed["podcasts"])
     total += _upsert_rows(conn, "claude_sessions", parsed["claude_sessions"])
     total += _upsert_rows(conn, "bede_sessions", parsed["bede_sessions"])
+    total += _upsert_rows(conn, "music_listens", parsed.get("music_listens", []))
 
     _update_freshness(conn, "vault", 86400)
     return {"status": "ok", "records": total}

--- a/bede-data/src/bede_data/ingest/router.py
+++ b/bede-data/src/bede_data/ingest/router.py
@@ -1,10 +1,12 @@
 import sqlite3
+from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends
 
 from bede_data.db.connection import get_db
 from bede_data.ingest.auth import verify_ingest_token
 from bede_data.ingest.health_parser import parse_health_payload
+from bede_data.ingest.vault_parser import parse_vault_payload
 
 router = APIRouter(prefix="/ingest", tags=["ingest"])
 
@@ -22,6 +24,29 @@ def _upsert_rows(conn: sqlite3.Connection, table: str, rows: list[dict]) -> int:
     return len(rows)
 
 
+def _replace_daily(conn: sqlite3.Connection, table: str, date: str, device: str | None, rows: list[dict]) -> int:
+    if not rows:
+        return 0
+    if device:
+        conn.execute(f"DELETE FROM {table} WHERE date = ? AND device = ?", (date, device))
+    else:
+        conn.execute(f"DELETE FROM {table} WHERE date = ?", (date,))
+    return _upsert_rows(conn, table, rows)
+
+
+def _update_freshness(conn: sqlite3.Connection, source: str, expected_interval: int):
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    conn.execute(
+        """INSERT OR REPLACE INTO data_freshness (source, last_received_at, expected_interval_seconds, updated_at)
+           VALUES (?, ?, ?, ?)""",
+        (source, now, expected_interval, now),
+    )
+    conn.commit()
+
+
+VAULT_DAILY_REPLACE_TABLES = {"screen_time"}
+
+
 @router.post("/health")
 def ingest_health(
     payload: dict,
@@ -35,4 +60,31 @@ def ingest_health(
     total += _upsert_rows(conn, "workouts", parsed["workouts"])
     total += _upsert_rows(conn, "medications", parsed["medications"])
     total += _upsert_rows(conn, "state_of_mind", parsed["state_of_mind"])
+    _update_freshness(conn, "health", 86400)
+    return {"status": "ok", "records": total}
+
+
+@router.post("/vault")
+def ingest_vault(
+    payload: dict,
+    _token: str = Depends(verify_ingest_token),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    parsed = parse_vault_payload(payload)
+    date = payload.get("date", "")
+    total = 0
+
+    if parsed["screen_time"]:
+        devices = {r["device"] for r in parsed["screen_time"]}
+        for device in devices:
+            device_rows = [r for r in parsed["screen_time"] if r["device"] == device]
+            total += _replace_daily(conn, "screen_time", date, device, device_rows)
+
+    total += _upsert_rows(conn, "safari_history", parsed["safari_history"])
+    total += _upsert_rows(conn, "youtube_history", parsed["youtube_history"])
+    total += _upsert_rows(conn, "podcasts", parsed["podcasts"])
+    total += _upsert_rows(conn, "claude_sessions", parsed["claude_sessions"])
+    total += _upsert_rows(conn, "bede_sessions", parsed["bede_sessions"])
+
+    _update_freshness(conn, "vault", 86400)
     return {"status": "ok", "records": total}

--- a/bede-data/src/bede_data/ingest/router.py
+++ b/bede-data/src/bede_data/ingest/router.py
@@ -12,6 +12,7 @@ router = APIRouter(prefix="/ingest", tags=["ingest"])
 
 
 def _upsert_rows(conn: sqlite3.Connection, table: str, rows: list[dict]) -> int:
+    """INSERT OR REPLACE rows into the given table. Column names come from the first row's keys. Does not commit — caller is responsible for committing the transaction."""
     if not rows:
         return 0
     columns = list(rows[0].keys())
@@ -23,11 +24,20 @@ def _upsert_rows(conn: sqlite3.Connection, table: str, rows: list[dict]) -> int:
     return len(rows)
 
 
-def _replace_daily(conn: sqlite3.Connection, table: str, date: str, device: str | None, rows: list[dict]) -> int:
+def _replace_daily(
+    conn: sqlite3.Connection,
+    table: str,
+    date: str,
+    device: str | None,
+    rows: list[dict],
+) -> int:
+    """Delete all existing rows for the date (and device, if given) then insert the new rows. Used for data sources like screen time where each export is a complete daily snapshot."""
     if not rows:
         return 0
     if device:
-        conn.execute(f"DELETE FROM [{table}] WHERE date = ? AND device = ?", (date, device))
+        conn.execute(
+            f"DELETE FROM [{table}] WHERE date = ? AND device = ?", (date, device)
+        )
     else:
         conn.execute(f"DELETE FROM [{table}] WHERE date = ?", (date,))
     return _upsert_rows(conn, table, rows)

--- a/bede-data/src/bede_data/ingest/router.py
+++ b/bede-data/src/bede_data/ingest/router.py
@@ -1,0 +1,38 @@
+import sqlite3
+
+from fastapi import APIRouter, Depends
+
+from bede_data.db.connection import get_db
+from bede_data.ingest.auth import verify_ingest_token
+from bede_data.ingest.health_parser import parse_health_payload
+
+router = APIRouter(prefix="/ingest", tags=["ingest"])
+
+
+def _upsert_rows(conn: sqlite3.Connection, table: str, rows: list[dict]) -> int:
+    if not rows:
+        return 0
+    columns = list(rows[0].keys())
+    placeholders = ", ".join("?" for _ in columns)
+    col_names = ", ".join(columns)
+    sql = f"INSERT OR REPLACE INTO {table} ({col_names}) VALUES ({placeholders})"
+    for row in rows:
+        conn.execute(sql, [row[c] for c in columns])
+    conn.commit()
+    return len(rows)
+
+
+@router.post("/health")
+def ingest_health(
+    payload: dict,
+    _token: str = Depends(verify_ingest_token),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    parsed = parse_health_payload(payload)
+    total = 0
+    total += _upsert_rows(conn, "health_metrics", parsed["health_metrics"])
+    total += _upsert_rows(conn, "sleep_phases", parsed["sleep_phases"])
+    total += _upsert_rows(conn, "workouts", parsed["workouts"])
+    total += _upsert_rows(conn, "medications", parsed["medications"])
+    total += _upsert_rows(conn, "state_of_mind", parsed["state_of_mind"])
+    return {"status": "ok", "records": total}

--- a/bede-data/src/bede_data/ingest/router.py
+++ b/bede-data/src/bede_data/ingest/router.py
@@ -17,10 +17,9 @@ def _upsert_rows(conn: sqlite3.Connection, table: str, rows: list[dict]) -> int:
     columns = list(rows[0].keys())
     placeholders = ", ".join("?" for _ in columns)
     col_names = ", ".join(columns)
-    sql = f"INSERT OR REPLACE INTO {table} ({col_names}) VALUES ({placeholders})"
+    sql = f"INSERT OR REPLACE INTO [{table}] ({col_names}) VALUES ({placeholders})"
     for row in rows:
         conn.execute(sql, [row[c] for c in columns])
-    conn.commit()
     return len(rows)
 
 
@@ -28,9 +27,9 @@ def _replace_daily(conn: sqlite3.Connection, table: str, date: str, device: str 
     if not rows:
         return 0
     if device:
-        conn.execute(f"DELETE FROM {table} WHERE date = ? AND device = ?", (date, device))
+        conn.execute(f"DELETE FROM [{table}] WHERE date = ? AND device = ?", (date, device))
     else:
-        conn.execute(f"DELETE FROM {table} WHERE date = ?", (date,))
+        conn.execute(f"DELETE FROM [{table}] WHERE date = ?", (date,))
     return _upsert_rows(conn, table, rows)
 
 
@@ -41,10 +40,6 @@ def _update_freshness(conn: sqlite3.Connection, source: str, expected_interval: 
            VALUES (?, ?, ?, ?)""",
         (source, now, expected_interval, now),
     )
-    conn.commit()
-
-
-VAULT_DAILY_REPLACE_TABLES = {"screen_time"}
 
 
 @router.post("/health")
@@ -61,6 +56,7 @@ def ingest_health(
     total += _upsert_rows(conn, "medications", parsed["medications"])
     total += _upsert_rows(conn, "state_of_mind", parsed["state_of_mind"])
     _update_freshness(conn, "health", 86400)
+    conn.commit()
     return {"status": "ok", "records": total}
 
 
@@ -86,6 +82,6 @@ def ingest_vault(
     total += _upsert_rows(conn, "claude_sessions", parsed["claude_sessions"])
     total += _upsert_rows(conn, "bede_sessions", parsed["bede_sessions"])
     total += _upsert_rows(conn, "music_listens", parsed.get("music_listens", []))
-
     _update_freshness(conn, "vault", 86400)
+    conn.commit()
     return {"status": "ok", "records": total}

--- a/bede-data/src/bede_data/ingest/vault_parser.py
+++ b/bede-data/src/bede_data/ingest/vault_parser.py
@@ -67,6 +67,21 @@ def _parse_youtube(date: str, content: str) -> list[dict]:
     ]
 
 
+def _parse_music(date: str, content: str) -> list[dict]:
+    rows = _parse_csv(content)
+    return [
+        {
+            "date": date,
+            "track": row.get("track", ""),
+            "artist": row.get("artist", ""),
+            "album": row.get("album"),
+            "listened_at": row.get("listened_at", ""),
+        }
+        for row in rows
+        if row.get("track") and row.get("artist")
+    ]
+
+
 def _parse_podcasts(date: str, content: str) -> list[dict]:
     rows = _parse_csv(content)
     return [
@@ -137,6 +152,7 @@ def parse_vault_payload(payload: dict) -> dict:
         "podcasts": [],
         "claude_sessions": [],
         "bede_sessions": [],
+        "music_listens": [],
     }
 
     for filename, content in files.items():
@@ -156,5 +172,7 @@ def parse_vault_payload(payload: dict) -> dict:
             result["bede_sessions"].extend(
                 _parse_sessions(date, content, "task_name")
             )
+        elif filename.startswith("music"):
+            result["music_listens"].extend(_parse_music(date, content))
 
     return result

--- a/bede-data/src/bede_data/ingest/vault_parser.py
+++ b/bede-data/src/bede_data/ingest/vault_parser.py
@@ -1,0 +1,160 @@
+import csv
+import io
+import re
+
+
+def _parse_csv(content: str) -> list[dict]:
+    reader = csv.DictReader(io.StringIO(content))
+    return list(reader)
+
+
+def _parse_csv_int(value: str, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return default
+
+
+def _parse_csv_float(value: str, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (ValueError, TypeError):
+        return default
+
+
+def _parse_screen_time(date: str, content: str) -> list[dict]:
+    rows = _parse_csv(content)
+    return [
+        {
+            "date": date,
+            "device": row.get("device", ""),
+            "entry_type": row.get("entry_type", ""),
+            "name": row.get("name", ""),
+            "seconds": _parse_csv_int(row.get("seconds", "0")),
+        }
+        for row in rows
+        if row.get("name")
+    ]
+
+
+def _parse_safari(date: str, content: str) -> list[dict]:
+    rows = _parse_csv(content)
+    return [
+        {
+            "date": date,
+            "device": row.get("device", ""),
+            "domain": row.get("domain", ""),
+            "title": row.get("title", ""),
+            "url": row.get("url", ""),
+            "visited_at": row.get("visited_at", ""),
+        }
+        for row in rows
+        if row.get("url")
+    ]
+
+
+def _parse_youtube(date: str, content: str) -> list[dict]:
+    rows = _parse_csv(content)
+    return [
+        {
+            "date": date,
+            "title": row.get("title", ""),
+            "url": row.get("url", ""),
+            "visited_at": row.get("visited_at", ""),
+        }
+        for row in rows
+        if row.get("url")
+    ]
+
+
+def _parse_podcasts(date: str, content: str) -> list[dict]:
+    rows = _parse_csv(content)
+    return [
+        {
+            "date": date,
+            "podcast": row.get("podcast", ""),
+            "episode": row.get("episode", ""),
+            "duration_seconds": _parse_csv_int(row.get("duration_seconds", "0")),
+            "played_at": row.get("played_at", ""),
+        }
+        for row in rows
+        if row.get("episode")
+    ]
+
+
+SESSION_HEADER_RE = re.compile(r"^## (.+)$")
+SESSION_META_RE = re.compile(r"^- (\w+): (.+)$")
+
+
+def _parse_sessions(date: str, content: str, name_field: str) -> list[dict]:
+    sessions = []
+    current = None
+
+    for line in content.splitlines():
+        header_match = SESSION_HEADER_RE.match(line)
+        if header_match:
+            if current:
+                sessions.append(current)
+            current = {"date": date, name_field: header_match.group(1), "summary": ""}
+            continue
+
+        if current is None:
+            continue
+
+        meta_match = SESSION_META_RE.match(line)
+        if meta_match:
+            key = meta_match.group(1).lower()
+            val = meta_match.group(2).strip()
+            if key == "start":
+                current["start_time"] = val
+            elif key == "end":
+                current["end_time"] = val
+            elif key == "duration":
+                current["duration_min"] = _parse_csv_float(val.split()[0])
+            elif key == "turns":
+                current["turns"] = _parse_csv_int(val)
+        elif line.strip():
+            if current.get("summary"):
+                current["summary"] += " " + line.strip()
+            else:
+                current["summary"] = line.strip()
+
+    if current:
+        sessions.append(current)
+    return sessions
+
+
+SCREEN_TIME_FILES = {"screentime.csv", "iphone-screentime.csv"}
+
+
+def parse_vault_payload(payload: dict) -> dict:
+    date = payload.get("date", "")
+    files = payload.get("files", {})
+    result = {
+        "screen_time": [],
+        "safari_history": [],
+        "youtube_history": [],
+        "podcasts": [],
+        "claude_sessions": [],
+        "bede_sessions": [],
+    }
+
+    for filename, content in files.items():
+        if filename in SCREEN_TIME_FILES:
+            result["screen_time"].extend(_parse_screen_time(date, content))
+        elif filename.startswith("safari"):
+            result["safari_history"].extend(_parse_safari(date, content))
+        elif filename.startswith("youtube"):
+            result["youtube_history"].extend(_parse_youtube(date, content))
+        elif filename.startswith("podcasts"):
+            result["podcasts"].extend(_parse_podcasts(date, content))
+        elif filename.startswith("claude-sessions"):
+            result["claude_sessions"].extend(
+                _parse_sessions(date, content, "project")
+            )
+        elif filename.startswith("bede-sessions"):
+            result["bede_sessions"].extend(
+                _parse_sessions(date, content, "task_name")
+            )
+
+    return result

--- a/bede-data/src/bede_data/ingest/vault_parser.py
+++ b/bede-data/src/bede_data/ingest/vault_parser.py
@@ -102,6 +102,7 @@ SESSION_META_RE = re.compile(r"^- (\w+): (.+)$")
 
 
 def _parse_sessions(date: str, content: str, name_field: str) -> list[dict]:
+    """Parse markdown session summaries (## Header / - Key: Value / body text). name_field controls whether the header maps to 'project' (claude) or 'task_name' (bede)."""
     sessions = []
     current = None
 
@@ -143,6 +144,7 @@ SCREEN_TIME_FILES = {"screentime.csv", "iphone-screentime.csv"}
 
 
 def parse_vault_payload(payload: dict) -> dict:
+    """Parse a vault ingest payload containing {date, files: {filename: content}}. Files are routed by filename prefix to the appropriate CSV or markdown parser."""
     date = payload.get("date", "")
     files = payload.get("files", {})
     result = {
@@ -165,13 +167,9 @@ def parse_vault_payload(payload: dict) -> dict:
         elif filename.startswith("podcasts"):
             result["podcasts"].extend(_parse_podcasts(date, content))
         elif filename.startswith("claude-sessions"):
-            result["claude_sessions"].extend(
-                _parse_sessions(date, content, "project")
-            )
+            result["claude_sessions"].extend(_parse_sessions(date, content, "project"))
         elif filename.startswith("bede-sessions"):
-            result["bede_sessions"].extend(
-                _parse_sessions(date, content, "task_name")
-            )
+            result["bede_sessions"].extend(_parse_sessions(date, content, "task_name"))
         elif filename.startswith("music"):
             result["music_listens"].extend(_parse_music(date, content))
 

--- a/bede-data/src/bede_data/live/air_quality.py
+++ b/bede-data/src/bede_data/live/air_quality.py
@@ -1,0 +1,12 @@
+import httpx
+
+from bede_data.config import settings
+
+AIR_QUALITY_URL = "https://data.airquality.nsw.gov.au/api/Data/get_SiteDetails"
+
+
+async def fetch_air_quality(site_id: str | None = None) -> dict:
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.get(AIR_QUALITY_URL)
+        resp.raise_for_status()
+        return resp.json()

--- a/bede-data/src/bede_data/live/air_quality.py
+++ b/bede-data/src/bede_data/live/air_quality.py
@@ -1,6 +1,5 @@
 import httpx
 
-from bede_data.config import settings
 
 AIR_QUALITY_URL = "https://data.airquality.nsw.gov.au/api/Data/get_SiteDetails"
 

--- a/bede-data/src/bede_data/live/location.py
+++ b/bede-data/src/bede_data/live/location.py
@@ -8,14 +8,20 @@ EARTH_RADIUS_M = 6_371_000
 
 
 def haversine_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    """Great-circle distance in metres between two lat/lon points."""
     rlat1, rlon1, rlat2, rlon2 = map(math.radians, [lat1, lon1, lat2, lon2])
     dlat = rlat2 - rlat1
     dlon = rlon2 - rlon1
-    a = math.sin(dlat / 2) ** 2 + math.cos(rlat1) * math.cos(rlat2) * math.sin(dlon / 2) ** 2
+    a = (
+        math.sin(dlat / 2) ** 2
+        + math.cos(rlat1) * math.cos(rlat2) * math.sin(dlon / 2) ** 2
+    )
     return 2 * EARTH_RADIUS_M * math.asin(math.sqrt(a))
 
 
 class GeoCache:
+    """In-memory cache for reverse geocode results, keyed by coordinates rounded to `precision` decimal places. Avoids redundant Nominatim calls for nearby points."""
+
     def __init__(self, precision: int = 3):
         self._cache: dict[tuple[float, float], str] = {}
         self._precision = precision
@@ -38,6 +44,7 @@ def cluster_points(
     radius_m: float = 200,
     gap_seconds: int = 300,
 ) -> list[dict]:
+    """Group OwnTracks location points into stops. A new cluster starts when a point is more than radius_m from the current centroid or more than gap_seconds after the last point. The centroid is a running average of all points in the cluster."""
     if not points:
         return []
 
@@ -105,6 +112,7 @@ async def fetch_owntracks_points(from_ts: int, to_ts: int) -> list[dict]:
 
 
 async def reverse_geocode(lat: float, lon: float) -> str:
+    """Resolve lat/lon to a place name via Nominatim, with GeoCache to deduplicate nearby lookups."""
     cached = _geocache.get(lat, lon)
     if cached:
         return cached

--- a/bede-data/src/bede_data/live/location.py
+++ b/bede-data/src/bede_data/live/location.py
@@ -1,0 +1,121 @@
+import math
+
+import httpx
+
+from bede_data.config import settings
+
+EARTH_RADIUS_M = 6_371_000
+
+
+def haversine_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    rlat1, rlon1, rlat2, rlon2 = map(math.radians, [lat1, lon1, lat2, lon2])
+    dlat = rlat2 - rlat1
+    dlon = rlon2 - rlon1
+    a = math.sin(dlat / 2) ** 2 + math.cos(rlat1) * math.cos(rlat2) * math.sin(dlon / 2) ** 2
+    return 2 * EARTH_RADIUS_M * math.asin(math.sqrt(a))
+
+
+class GeoCache:
+    def __init__(self, precision: int = 3):
+        self._cache: dict[tuple[float, float], str] = {}
+        self._precision = precision
+
+    def _key(self, lat: float, lon: float) -> tuple[float, float]:
+        return (round(lat, self._precision), round(lon, self._precision))
+
+    def get(self, lat: float, lon: float) -> str | None:
+        return self._cache.get(self._key(lat, lon))
+
+    def put(self, lat: float, lon: float, name: str) -> None:
+        self._cache[self._key(lat, lon)] = name
+
+
+_geocache = GeoCache()
+
+
+def cluster_points(
+    points: list[dict],
+    radius_m: float = 200,
+    gap_seconds: int = 300,
+) -> list[dict]:
+    if not points:
+        return []
+
+    sorted_pts = sorted(points, key=lambda p: p["tst"])
+    clusters: list[dict] = []
+    current = {
+        "lat": sorted_pts[0]["lat"],
+        "lon": sorted_pts[0]["lon"],
+        "arrived_tst": sorted_pts[0]["tst"],
+        "departed_tst": sorted_pts[0]["tst"],
+        "point_count": 1,
+        "lats": [sorted_pts[0]["lat"]],
+        "lons": [sorted_pts[0]["lon"]],
+    }
+
+    for pt in sorted_pts[1:]:
+        dist = haversine_m(current["lat"], current["lon"], pt["lat"], pt["lon"])
+        time_gap = pt["tst"] - current["departed_tst"]
+
+        if dist <= radius_m and time_gap <= gap_seconds:
+            current["departed_tst"] = pt["tst"]
+            current["point_count"] += 1
+            current["lats"].append(pt["lat"])
+            current["lons"].append(pt["lon"])
+            current["lat"] = sum(current["lats"]) / len(current["lats"])
+            current["lon"] = sum(current["lons"]) / len(current["lons"])
+        else:
+            clusters.append(_finish_cluster(current))
+            current = {
+                "lat": pt["lat"],
+                "lon": pt["lon"],
+                "arrived_tst": pt["tst"],
+                "departed_tst": pt["tst"],
+                "point_count": 1,
+                "lats": [pt["lat"]],
+                "lons": [pt["lon"]],
+            }
+
+    clusters.append(_finish_cluster(current))
+    return clusters
+
+
+def _finish_cluster(c: dict) -> dict:
+    return {
+        "lat": c["lat"],
+        "lon": c["lon"],
+        "arrived_tst": c["arrived_tst"],
+        "departed_tst": c["departed_tst"],
+        "point_count": c["point_count"],
+    }
+
+
+async def fetch_owntracks_points(from_ts: int, to_ts: int) -> list[dict]:
+    url = f"{settings.owntracks_url}/api/0/locations"
+    params = {
+        "user": settings.owntracks_user,
+        "device": settings.owntracks_device,
+        "from": from_ts,
+        "to": to_ts,
+    }
+    async with httpx.AsyncClient(timeout=15) as client:
+        resp = await client.get(url, params=params)
+        resp.raise_for_status()
+        return resp.json().get("data", [])
+
+
+async def reverse_geocode(lat: float, lon: float) -> str:
+    cached = _geocache.get(lat, lon)
+    if cached:
+        return cached
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.get(
+            settings.nominatim_url,
+            params={"lat": lat, "lon": lon, "format": "json", "zoom": 18},
+            headers={"User-Agent": "bede-data/1.0"},
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    name = data.get("display_name", f"{lat:.4f}, {lon:.4f}")
+    _geocache.put(lat, lon, name)
+    return name

--- a/bede-data/src/bede_data/live/weather.py
+++ b/bede-data/src/bede_data/live/weather.py
@@ -4,6 +4,7 @@ from bede_data.config import settings
 
 
 async def fetch_weather() -> dict:
+    """Proxy weather data from Homepage API's weather widget (which itself fetches from BOM)."""
     url = f"{settings.homepage_api_url}/api/widgets/weather"
     params = {"location": settings.bom_location} if settings.bom_location else {}
     async with httpx.AsyncClient(timeout=10) as client:

--- a/bede-data/src/bede_data/live/weather.py
+++ b/bede-data/src/bede_data/live/weather.py
@@ -1,0 +1,12 @@
+import httpx
+
+from bede_data.config import settings
+
+
+async def fetch_weather() -> dict:
+    url = f"{settings.homepage_api_url}/api/widgets/weather"
+    params = {"location": settings.bom_location} if settings.bom_location else {}
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.get(url, params=params)
+        resp.raise_for_status()
+        return resp.json()

--- a/bede-data/tests/conftest.py
+++ b/bede-data/tests/conftest.py
@@ -7,7 +7,7 @@ from fastapi.testclient import TestClient
 
 from bede_data.app import create_app
 from bede_data.config import settings
-from bede_data.db.connection import get_db, init_db
+from bede_data.db.connection import init_db
 
 
 @pytest.fixture(autouse=True)

--- a/bede-data/tests/conftest.py
+++ b/bede-data/tests/conftest.py
@@ -1,0 +1,35 @@
+import sqlite3
+import tempfile
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from bede_data.app import create_app
+from bede_data.config import settings
+from bede_data.db.connection import get_db, init_db
+
+
+@pytest.fixture(autouse=True)
+def tmp_db(tmp_path: Path) -> Generator[Path, None, None]:
+    db_path = tmp_path / "test.db"
+    settings.sqlite_db_path = str(db_path)
+    init_db()
+    yield db_path
+
+
+@pytest.fixture
+def db(tmp_db: Path) -> Generator[sqlite3.Connection, None, None]:
+    conn = sqlite3.connect(str(tmp_db))
+    conn.row_factory = sqlite3.Row
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def client() -> TestClient:
+    app = create_app()
+    return TestClient(app)

--- a/bede-data/tests/conftest.py
+++ b/bede-data/tests/conftest.py
@@ -1,5 +1,4 @@
 import sqlite3
-import tempfile
 from collections.abc import Generator
 from pathlib import Path
 

--- a/bede-data/tests/test_analytics_engine.py
+++ b/bede-data/tests/test_analytics_engine.py
@@ -1,7 +1,5 @@
 import sqlite3
 
-import pytest
-
 
 def _seed_sleep_data(db: sqlite3.Connection, days: list[tuple[str, float]]):
     for date, hours in days:
@@ -33,12 +31,17 @@ def _seed_workout_data(db: sqlite3.Connection, dates: list[str]):
 def test_sleep_declining_signal(db):
     from bede_data.analytics.signals import compute_sleep_flags
 
-    _seed_sleep_data(db, [
-        ("2026-04-26", 5.0),
-        ("2026-04-27", 4.5),
-        ("2026-04-28", 5.2),
-    ])
-    flags = compute_sleep_flags(db, target_hours=7.0, window_days=3, reference_date="2026-04-28")
+    _seed_sleep_data(
+        db,
+        [
+            ("2026-04-26", 5.0),
+            ("2026-04-27", 4.5),
+            ("2026-04-28", 5.2),
+        ],
+    )
+    flags = compute_sleep_flags(
+        db, target_hours=7.0, window_days=3, reference_date="2026-04-28"
+    )
     assert len(flags) == 1
     assert flags[0]["signal"] == "sleep_declining"
     assert flags[0]["severity"] == "concern"
@@ -47,12 +50,17 @@ def test_sleep_declining_signal(db):
 def test_sleep_ok_no_flag(db):
     from bede_data.analytics.signals import compute_sleep_flags
 
-    _seed_sleep_data(db, [
-        ("2026-04-26", 7.5),
-        ("2026-04-27", 7.0),
-        ("2026-04-28", 8.0),
-    ])
-    flags = compute_sleep_flags(db, target_hours=7.0, window_days=3, reference_date="2026-04-28")
+    _seed_sleep_data(
+        db,
+        [
+            ("2026-04-26", 7.5),
+            ("2026-04-27", 7.0),
+            ("2026-04-28", 8.0),
+        ],
+    )
+    flags = compute_sleep_flags(
+        db, target_hours=7.0, window_days=3, reference_date="2026-04-28"
+    )
     assert len(flags) == 0
 
 
@@ -60,7 +68,9 @@ def test_exercise_gap_signal(db):
     from bede_data.analytics.signals import compute_activity_flags
 
     _seed_workout_data(db, ["2026-04-20"])
-    flags = compute_activity_flags(db, gap_threshold_days=5, reference_date="2026-04-29")
+    flags = compute_activity_flags(
+        db, gap_threshold_days=5, reference_date="2026-04-29"
+    )
     assert len(flags) == 1
     assert flags[0]["signal"] == "exercise_gap"
     assert flags[0]["severity"] == "nudge"
@@ -70,7 +80,9 @@ def test_exercise_recent_no_flag(db):
     from bede_data.analytics.signals import compute_activity_flags
 
     _seed_workout_data(db, ["2026-04-28"])
-    flags = compute_activity_flags(db, gap_threshold_days=5, reference_date="2026-04-29")
+    flags = compute_activity_flags(
+        db, gap_threshold_days=5, reference_date="2026-04-29"
+    )
     assert len(flags) == 0
 
 
@@ -102,24 +114,44 @@ def test_goal_recently_updated_no_flag(db):
 def test_screen_time_spike_signal(db):
     from bede_data.analytics.signals import compute_screen_time_flags
 
-    db.execute("INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES ('2026-04-22', 'iphone', 'app', 'YouTube', 3600)")
-    db.execute("INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES ('2026-04-23', 'iphone', 'app', 'YouTube', 3600)")
-    db.execute("INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES ('2026-04-24', 'iphone', 'app', 'YouTube', 3600)")
-    db.execute("INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES ('2026-04-25', 'iphone', 'app', 'YouTube', 3600)")
-    db.execute("INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES ('2026-04-26', 'iphone', 'app', 'YouTube', 3600)")
-    db.execute("INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES ('2026-04-27', 'iphone', 'app', 'YouTube', 3600)")
-    db.execute("INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES ('2026-04-28', 'iphone', 'app', 'YouTube', 7200)")
-    db.execute("INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES ('2026-04-29', 'iphone', 'app', 'YouTube', 7200)")
+    db.execute(
+        "INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES ('2026-04-22', 'iphone', 'app', 'YouTube', 3600)"
+    )
+    db.execute(
+        "INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES ('2026-04-23', 'iphone', 'app', 'YouTube', 3600)"
+    )
+    db.execute(
+        "INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES ('2026-04-24', 'iphone', 'app', 'YouTube', 3600)"
+    )
+    db.execute(
+        "INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES ('2026-04-25', 'iphone', 'app', 'YouTube', 3600)"
+    )
+    db.execute(
+        "INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES ('2026-04-26', 'iphone', 'app', 'YouTube', 3600)"
+    )
+    db.execute(
+        "INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES ('2026-04-27', 'iphone', 'app', 'YouTube', 3600)"
+    )
+    db.execute(
+        "INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES ('2026-04-28', 'iphone', 'app', 'YouTube', 7200)"
+    )
+    db.execute(
+        "INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES ('2026-04-29', 'iphone', 'app', 'YouTube', 7200)"
+    )
     db.commit()
 
-    flags = compute_screen_time_flags(db, spike_threshold_pct=40, window_days=7, reference_date="2026-04-29")
+    flags = compute_screen_time_flags(
+        db, spike_threshold_pct=40, window_days=7, reference_date="2026-04-29"
+    )
     assert any(f["signal"] == "passive_screen_up" for f in flags)
 
 
 def test_medication_missed_signal(db):
     from bede_data.analytics.signals import compute_medication_flags
 
-    db.execute("INSERT INTO medications (date, medication, quantity, unit, recorded_at) VALUES ('2026-04-27', 'Lexapro', 1, 'tablet', '2026-04-27T08:00:00Z')")
+    db.execute(
+        "INSERT INTO medications (date, medication, quantity, unit, recorded_at) VALUES ('2026-04-27', 'Lexapro', 1, 'tablet', '2026-04-27T08:00:00Z')"
+    )
     db.commit()
 
     flags = compute_medication_flags(db, reference_date="2026-04-29")
@@ -132,7 +164,17 @@ def test_bedtime_drift_signal(db):
     from bede_data.analytics.signals import compute_bedtime_flags
 
     _seed_sleep_data(db, [])
-    for i, date in enumerate(["2026-04-22", "2026-04-23", "2026-04-24", "2026-04-25", "2026-04-26", "2026-04-27", "2026-04-28"]):
+    for i, date in enumerate(
+        [
+            "2026-04-22",
+            "2026-04-23",
+            "2026-04-24",
+            "2026-04-25",
+            "2026-04-26",
+            "2026-04-27",
+            "2026-04-28",
+        ]
+    ):
         bedtime_hour = 23 if i < 4 else 0
         db.execute(
             "INSERT OR REPLACE INTO sleep_phases (date, phase, hours, start_time, end_time, source) VALUES (?, 'inBed', 8, ?, ?, 'test')",
@@ -149,7 +191,13 @@ def test_goal_drifting_signal(db):
 
     db.execute(
         "INSERT INTO goals (name, description, deadline, status, created_at, updated_at) VALUES (?, ?, ?, 'active', ?, ?)",
-        ("Read 2 books", "Read 2 fiction books in May", "2026-05-10", "2026-04-01T00:00:00Z", "2026-04-01T00:00:00Z"),
+        (
+            "Read 2 books",
+            "Read 2 fiction books in May",
+            "2026-05-10",
+            "2026-04-01T00:00:00Z",
+            "2026-04-01T00:00:00Z",
+        ),
     )
     db.commit()
     flags = compute_goal_flags(db, stale_threshold_days=14, reference_date="2026-04-29")

--- a/bede-data/tests/test_analytics_engine.py
+++ b/bede-data/tests/test_analytics_engine.py
@@ -142,3 +142,17 @@ def test_bedtime_drift_signal(db):
 
     flags = compute_bedtime_flags(db, drift_threshold_minutes=30, window_days=7)
     assert any(f["signal"] == "bedtime_drifting" for f in flags)
+
+
+def test_goal_drifting_signal(db):
+    from bede_data.analytics.signals import compute_goal_flags
+
+    db.execute(
+        "INSERT INTO goals (name, description, deadline, status, created_at, updated_at) VALUES (?, ?, ?, 'active', ?, ?)",
+        ("Read 2 books", "Read 2 fiction books in May", "2026-05-10", "2026-04-01T00:00:00Z", "2026-04-01T00:00:00Z"),
+    )
+    db.commit()
+    flags = compute_goal_flags(db, stale_threshold_days=14, reference_date="2026-04-29")
+    drifting = [f for f in flags if f["signal"] == "goal_drifting"]
+    assert len(drifting) == 1
+    assert "11 days" in drifting[0]["detail"]

--- a/bede-data/tests/test_analytics_engine.py
+++ b/bede-data/tests/test_analytics_engine.py
@@ -1,0 +1,144 @@
+import sqlite3
+
+import pytest
+
+
+def _seed_sleep_data(db: sqlite3.Connection, days: list[tuple[str, float]]):
+    for date, hours in days:
+        db.execute(
+            "INSERT INTO sleep_phases (date, phase, hours, source) VALUES (?, 'total', ?, 'test')",
+            (date, hours),
+        )
+    db.commit()
+
+
+def _seed_activity_data(db: sqlite3.Connection, days: list[tuple[str, float]]):
+    for date, steps in days:
+        db.execute(
+            "INSERT INTO health_metrics (date, metric, value, source) VALUES (?, 'step_count', ?, 'test')",
+            (date, steps),
+        )
+    db.commit()
+
+
+def _seed_workout_data(db: sqlite3.Connection, dates: list[str]):
+    for date in dates:
+        db.execute(
+            "INSERT INTO workouts (date, workout_type, duration_minutes, start_time) VALUES (?, 'Running', 30, ?)",
+            (date, f"{date}T07:00:00Z"),
+        )
+    db.commit()
+
+
+def test_sleep_declining_signal(db):
+    from bede_data.analytics.signals import compute_sleep_flags
+
+    _seed_sleep_data(db, [
+        ("2026-04-26", 5.0),
+        ("2026-04-27", 4.5),
+        ("2026-04-28", 5.2),
+    ])
+    flags = compute_sleep_flags(db, target_hours=7.0, window_days=3, reference_date="2026-04-28")
+    assert len(flags) == 1
+    assert flags[0]["signal"] == "sleep_declining"
+    assert flags[0]["severity"] == "concern"
+
+
+def test_sleep_ok_no_flag(db):
+    from bede_data.analytics.signals import compute_sleep_flags
+
+    _seed_sleep_data(db, [
+        ("2026-04-26", 7.5),
+        ("2026-04-27", 7.0),
+        ("2026-04-28", 8.0),
+    ])
+    flags = compute_sleep_flags(db, target_hours=7.0, window_days=3, reference_date="2026-04-28")
+    assert len(flags) == 0
+
+
+def test_exercise_gap_signal(db):
+    from bede_data.analytics.signals import compute_activity_flags
+
+    _seed_workout_data(db, ["2026-04-20"])
+    flags = compute_activity_flags(db, gap_threshold_days=5, reference_date="2026-04-29")
+    assert len(flags) == 1
+    assert flags[0]["signal"] == "exercise_gap"
+    assert flags[0]["severity"] == "nudge"
+
+
+def test_exercise_recent_no_flag(db):
+    from bede_data.analytics.signals import compute_activity_flags
+
+    _seed_workout_data(db, ["2026-04-28"])
+    flags = compute_activity_flags(db, gap_threshold_days=5, reference_date="2026-04-29")
+    assert len(flags) == 0
+
+
+def test_goal_stale_signal(db):
+    from bede_data.analytics.signals import compute_goal_flags
+
+    db.execute(
+        "INSERT INTO goals (name, status, created_at, updated_at) VALUES (?, 'active', ?, ?)",
+        ("AWS cert", "2026-04-01T00:00:00Z", "2026-04-01T00:00:00Z"),
+    )
+    db.commit()
+    flags = compute_goal_flags(db, stale_threshold_days=14, reference_date="2026-04-29")
+    assert len(flags) == 1
+    assert flags[0]["signal"] == "goal_stale"
+
+
+def test_goal_recently_updated_no_flag(db):
+    from bede_data.analytics.signals import compute_goal_flags
+
+    db.execute(
+        "INSERT INTO goals (name, status, created_at, updated_at) VALUES (?, 'active', ?, ?)",
+        ("AWS cert", "2026-04-01T00:00:00Z", "2026-04-28T00:00:00Z"),
+    )
+    db.commit()
+    flags = compute_goal_flags(db, stale_threshold_days=14, reference_date="2026-04-29")
+    assert len(flags) == 0
+
+
+def test_screen_time_spike_signal(db):
+    from bede_data.analytics.signals import compute_screen_time_flags
+
+    db.execute("INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES ('2026-04-22', 'iphone', 'app', 'YouTube', 3600)")
+    db.execute("INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES ('2026-04-23', 'iphone', 'app', 'YouTube', 3600)")
+    db.execute("INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES ('2026-04-24', 'iphone', 'app', 'YouTube', 3600)")
+    db.execute("INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES ('2026-04-25', 'iphone', 'app', 'YouTube', 3600)")
+    db.execute("INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES ('2026-04-26', 'iphone', 'app', 'YouTube', 3600)")
+    db.execute("INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES ('2026-04-27', 'iphone', 'app', 'YouTube', 3600)")
+    db.execute("INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES ('2026-04-28', 'iphone', 'app', 'YouTube', 7200)")
+    db.execute("INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES ('2026-04-29', 'iphone', 'app', 'YouTube', 7200)")
+    db.commit()
+
+    flags = compute_screen_time_flags(db, spike_threshold_pct=40, window_days=7, reference_date="2026-04-29")
+    assert any(f["signal"] == "passive_screen_up" for f in flags)
+
+
+def test_medication_missed_signal(db):
+    from bede_data.analytics.signals import compute_medication_flags
+
+    db.execute("INSERT INTO medications (date, medication, quantity, unit, recorded_at) VALUES ('2026-04-27', 'Lexapro', 1, 'tablet', '2026-04-27T08:00:00Z')")
+    db.commit()
+
+    flags = compute_medication_flags(db, reference_date="2026-04-29")
+    assert len(flags) == 1
+    assert flags[0]["signal"] == "medication_missed"
+    assert flags[0]["severity"] == "alert"
+
+
+def test_bedtime_drift_signal(db):
+    from bede_data.analytics.signals import compute_bedtime_flags
+
+    _seed_sleep_data(db, [])
+    for i, date in enumerate(["2026-04-22", "2026-04-23", "2026-04-24", "2026-04-25", "2026-04-26", "2026-04-27", "2026-04-28"]):
+        bedtime_hour = 23 if i < 4 else 0
+        db.execute(
+            "INSERT OR REPLACE INTO sleep_phases (date, phase, hours, start_time, end_time, source) VALUES (?, 'inBed', 8, ?, ?, 'test')",
+            (date, f"{date}T{bedtime_hour:02d}:00:00Z", f"{date}T07:00:00Z"),
+        )
+    db.commit()
+
+    flags = compute_bedtime_flags(db, drift_threshold_minutes=30, window_days=7)
+    assert any(f["signal"] == "bedtime_drifting" for f in flags)

--- a/bede-data/tests/test_api_analytics.py
+++ b/bede-data/tests/test_api_analytics.py
@@ -1,0 +1,40 @@
+def test_get_analytics_flags_empty(client):
+    response = client.get("/api/analytics/flags")
+    assert response.status_code == 200
+    assert response.json()["flags"] == []
+
+
+def test_run_analytics_and_get_flags(client, db):
+    db.execute("INSERT INTO sleep_phases (date, phase, hours, source) VALUES ('2026-04-27', 'total', 4.0, 'test')")
+    db.execute("INSERT INTO sleep_phases (date, phase, hours, source) VALUES ('2026-04-28', 'total', 5.0, 'test')")
+    db.execute("INSERT INTO sleep_phases (date, phase, hours, source) VALUES ('2026-04-29', 'total', 4.5, 'test')")
+    db.commit()
+
+    response = client.post("/api/analytics/run")
+    assert response.status_code == 200
+    assert response.json()["flags_stored"] > 0
+
+    response = client.get("/api/analytics/flags")
+    flags = response.json()["flags"]
+    assert any(f["signal"] == "sleep_declining" for f in flags)
+
+
+def test_get_flags_filter_severity(client, db):
+    db.execute("INSERT INTO analytics_flags (signal, severity, detail, data, computed_at) VALUES ('test_info', 'info', 'test', '{}', '2026-04-29T00:00:00Z')")
+    db.execute("INSERT INTO analytics_flags (signal, severity, detail, data, computed_at) VALUES ('test_alert', 'alert', 'test', '{}', '2026-04-29T00:00:00Z')")
+    db.commit()
+
+    response = client.get("/api/analytics/flags", params={"severity": "alert"})
+    flags = response.json()["flags"]
+    assert len(flags) == 1
+    assert flags[0]["severity"] == "alert"
+
+
+def test_acknowledge_flag(client, db):
+    db.execute("INSERT INTO analytics_flags (signal, severity, detail, data, computed_at) VALUES ('test', 'info', 'test', '{}', '2026-04-29T00:00:00Z')")
+    db.commit()
+    flag_id = db.execute("SELECT id FROM analytics_flags").fetchone()["id"]
+
+    response = client.put(f"/api/analytics/flags/{flag_id}/acknowledge")
+    assert response.status_code == 200
+    assert response.json()["acknowledged"] is True

--- a/bede-data/tests/test_api_analytics.py
+++ b/bede-data/tests/test_api_analytics.py
@@ -5,9 +5,15 @@ def test_get_analytics_flags_empty(client):
 
 
 def test_run_analytics_and_get_flags(client, db):
-    db.execute("INSERT INTO sleep_phases (date, phase, hours, source) VALUES ('2026-04-27', 'total', 4.0, 'test')")
-    db.execute("INSERT INTO sleep_phases (date, phase, hours, source) VALUES ('2026-04-28', 'total', 5.0, 'test')")
-    db.execute("INSERT INTO sleep_phases (date, phase, hours, source) VALUES ('2026-04-29', 'total', 4.5, 'test')")
+    from datetime import date, timedelta
+
+    today = date.today()
+    for offset in range(3):
+        d = (today - timedelta(days=2 - offset)).isoformat()
+        db.execute(
+            "INSERT INTO sleep_phases (date, phase, hours, source) VALUES (?, 'total', 4.0, 'test')",
+            (d,),
+        )
     db.commit()
 
     response = client.post("/api/analytics/run")
@@ -20,8 +26,12 @@ def test_run_analytics_and_get_flags(client, db):
 
 
 def test_get_flags_filter_severity(client, db):
-    db.execute("INSERT INTO analytics_flags (signal, severity, detail, data, computed_at) VALUES ('test_info', 'info', 'test', '{}', '2026-04-29T00:00:00Z')")
-    db.execute("INSERT INTO analytics_flags (signal, severity, detail, data, computed_at) VALUES ('test_alert', 'alert', 'test', '{}', '2026-04-29T00:00:00Z')")
+    db.execute(
+        "INSERT INTO analytics_flags (signal, severity, detail, data, computed_at) VALUES ('test_info', 'info', 'test', '{}', '2026-04-29T00:00:00Z')"
+    )
+    db.execute(
+        "INSERT INTO analytics_flags (signal, severity, detail, data, computed_at) VALUES ('test_alert', 'alert', 'test', '{}', '2026-04-29T00:00:00Z')"
+    )
     db.commit()
 
     response = client.get("/api/analytics/flags", params={"severity": "alert"})
@@ -31,7 +41,9 @@ def test_get_flags_filter_severity(client, db):
 
 
 def test_acknowledge_flag(client, db):
-    db.execute("INSERT INTO analytics_flags (signal, severity, detail, data, computed_at) VALUES ('test', 'info', 'test', '{}', '2026-04-29T00:00:00Z')")
+    db.execute(
+        "INSERT INTO analytics_flags (signal, severity, detail, data, computed_at) VALUES ('test', 'info', 'test', '{}', '2026-04-29T00:00:00Z')"
+    )
     db.commit()
     flag_id = db.execute("SELECT id FROM analytics_flags").fetchone()["id"]
 

--- a/bede-data/tests/test_api_config.py
+++ b/bede-data/tests/test_api_config.py
@@ -17,16 +17,27 @@ def test_create_schedule(client):
 
 
 def test_list_schedules(client):
-    client.post("/api/config/schedules", json={"task_name": "Task A", "cron_expression": "0 8 * * *", "prompt": "A"})
-    client.post("/api/config/schedules", json={"task_name": "Task B", "cron_expression": "0 21 * * *", "prompt": "B"})
+    client.post(
+        "/api/config/schedules",
+        json={"task_name": "Task A", "cron_expression": "0 8 * * *", "prompt": "A"},
+    )
+    client.post(
+        "/api/config/schedules",
+        json={"task_name": "Task B", "cron_expression": "0 21 * * *", "prompt": "B"},
+    )
     response = client.get("/api/config/schedules")
     assert len(response.json()["schedules"]) == 2
 
 
 def test_update_schedule(client):
-    resp = client.post("/api/config/schedules", json={"task_name": "Briefing", "cron_expression": "0 8 * * *", "prompt": "Old"})
+    resp = client.post(
+        "/api/config/schedules",
+        json={"task_name": "Briefing", "cron_expression": "0 8 * * *", "prompt": "Old"},
+    )
     sid = resp.json()["id"]
-    response = client.put(f"/api/config/schedules/{sid}", json={"cron_expression": "30 7 * * *"})
+    response = client.put(
+        f"/api/config/schedules/{sid}", json={"cron_expression": "30 7 * * *"}
+    )
     assert response.status_code == 200
     assert response.json()["cron_expression"] == "30 7 * * *"
 
@@ -59,14 +70,23 @@ def test_create_monitored_item(client):
 
 
 def test_list_monitored_items_filter_category(client):
-    client.post("/api/config/monitored-items", json={"category": "deal", "name": "Camping", "config": "{}"})
-    client.post("/api/config/monitored-items", json={"category": "content_source", "name": "Hacker News", "config": "{}"})
+    client.post(
+        "/api/config/monitored-items",
+        json={"category": "deal", "name": "Camping", "config": "{}"},
+    )
+    client.post(
+        "/api/config/monitored-items",
+        json={"category": "content_source", "name": "Hacker News", "config": "{}"},
+    )
     response = client.get("/api/config/monitored-items", params={"category": "deal"})
     assert len(response.json()["items"]) == 1
 
 
 def test_delete_monitored_item(client):
-    resp = client.post("/api/config/monitored-items", json={"category": "deal", "name": "Old", "config": "{}"})
+    resp = client.post(
+        "/api/config/monitored-items",
+        json={"category": "deal", "name": "Old", "config": "{}"},
+    )
     item_id = resp.json()["id"]
     response = client.delete(f"/api/config/monitored-items/{item_id}")
     assert response.status_code == 200

--- a/bede-data/tests/test_api_config.py
+++ b/bede-data/tests/test_api_config.py
@@ -1,0 +1,73 @@
+def test_create_schedule(client):
+    response = client.post(
+        "/api/config/schedules",
+        json={
+            "task_name": "Morning Briefing",
+            "cron_expression": "0 8 * * 1-5",
+            "prompt": "Deliver the morning briefing",
+            "model": "sonnet",
+            "timeout_seconds": 300,
+            "interactive": True,
+        },
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["task_name"] == "Morning Briefing"
+    assert data["interactive"] is True
+
+
+def test_list_schedules(client):
+    client.post("/api/config/schedules", json={"task_name": "Task A", "cron_expression": "0 8 * * *", "prompt": "A"})
+    client.post("/api/config/schedules", json={"task_name": "Task B", "cron_expression": "0 21 * * *", "prompt": "B"})
+    response = client.get("/api/config/schedules")
+    assert len(response.json()["schedules"]) == 2
+
+
+def test_update_schedule(client):
+    resp = client.post("/api/config/schedules", json={"task_name": "Briefing", "cron_expression": "0 8 * * *", "prompt": "Old"})
+    sid = resp.json()["id"]
+    response = client.put(f"/api/config/schedules/{sid}", json={"cron_expression": "30 7 * * *"})
+    assert response.status_code == 200
+    assert response.json()["cron_expression"] == "30 7 * * *"
+
+
+def test_set_and_get_setting(client):
+    client.put("/api/config/settings/quiet_hours_start", json={"value": "22:00"})
+    response = client.get("/api/config/settings/quiet_hours_start")
+    assert response.status_code == 200
+    assert response.json()["value"] == "22:00"
+
+
+def test_list_settings(client):
+    client.put("/api/config/settings/quiet_hours_start", json={"value": "22:00"})
+    client.put("/api/config/settings/quiet_hours_end", json={"value": "07:00"})
+    response = client.get("/api/config/settings")
+    assert len(response.json()["settings"]) == 2
+
+
+def test_create_monitored_item(client):
+    response = client.post(
+        "/api/config/monitored-items",
+        json={
+            "category": "deal",
+            "name": "Camping Gear",
+            "config": '{"retailers": ["anaconda.com.au"], "check_cadence": "weekly"}',
+        },
+    )
+    assert response.status_code == 201
+    assert response.json()["category"] == "deal"
+
+
+def test_list_monitored_items_filter_category(client):
+    client.post("/api/config/monitored-items", json={"category": "deal", "name": "Camping", "config": "{}"})
+    client.post("/api/config/monitored-items", json={"category": "content_source", "name": "Hacker News", "config": "{}"})
+    response = client.get("/api/config/monitored-items", params={"category": "deal"})
+    assert len(response.json()["items"]) == 1
+
+
+def test_delete_monitored_item(client):
+    resp = client.post("/api/config/monitored-items", json={"category": "deal", "name": "Old", "config": "{}"})
+    item_id = resp.json()["id"]
+    response = client.delete(f"/api/config/monitored-items/{item_id}")
+    assert response.status_code == 200
+    assert len(client.get("/api/config/monitored-items").json()["items"]) == 0

--- a/bede-data/tests/test_api_conversations.py
+++ b/bede-data/tests/test_api_conversations.py
@@ -1,0 +1,51 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from bede_data.config import settings
+
+
+@pytest.fixture
+def sessions_dir(tmp_path):
+    settings.claude_sessions_dir = str(tmp_path)
+
+    session_dir = tmp_path / "abc-123"
+    session_dir.mkdir()
+    jsonl_file = session_dir / "session.jsonl"
+    lines = [
+        json.dumps({"type": "human", "message": "Hello Bede", "timestamp": "2026-04-29T08:00:00Z"}),
+        json.dumps({"type": "assistant", "message": "Good morning!", "timestamp": "2026-04-29T08:00:05Z"}),
+    ]
+    jsonl_file.write_text("\n".join(lines))
+
+    session_dir2 = tmp_path / "def-456"
+    session_dir2.mkdir()
+    jsonl_file2 = session_dir2 / "session.jsonl"
+    lines2 = [
+        json.dumps({"type": "human", "message": "What's the weather?", "timestamp": "2026-04-29T14:00:00Z"}),
+    ]
+    jsonl_file2.write_text("\n".join(lines2))
+
+    return tmp_path
+
+
+def test_list_conversations(client, sessions_dir):
+    response = client.get("/api/conversations")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["sessions"]) == 2
+
+
+def test_get_conversation(client, sessions_dir):
+    response = client.get("/api/conversations/abc-123")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["session_id"] == "abc-123"
+    assert len(data["messages"]) == 2
+    assert data["messages"][0]["message"] == "Hello Bede"
+
+
+def test_get_conversation_not_found(client, sessions_dir):
+    response = client.get("/api/conversations/nonexistent")
+    assert response.status_code == 404

--- a/bede-data/tests/test_api_conversations.py
+++ b/bede-data/tests/test_api_conversations.py
@@ -1,5 +1,4 @@
 import json
-from pathlib import Path
 
 import pytest
 
@@ -14,8 +13,20 @@ def sessions_dir(tmp_path):
     session_dir.mkdir()
     jsonl_file = session_dir / "session.jsonl"
     lines = [
-        json.dumps({"type": "human", "message": "Hello Bede", "timestamp": "2026-04-29T08:00:00Z"}),
-        json.dumps({"type": "assistant", "message": "Good morning!", "timestamp": "2026-04-29T08:00:05Z"}),
+        json.dumps(
+            {
+                "type": "human",
+                "message": "Hello Bede",
+                "timestamp": "2026-04-29T08:00:00Z",
+            }
+        ),
+        json.dumps(
+            {
+                "type": "assistant",
+                "message": "Good morning!",
+                "timestamp": "2026-04-29T08:00:05Z",
+            }
+        ),
     ]
     jsonl_file.write_text("\n".join(lines))
 
@@ -23,7 +34,13 @@ def sessions_dir(tmp_path):
     session_dir2.mkdir()
     jsonl_file2 = session_dir2 / "session.jsonl"
     lines2 = [
-        json.dumps({"type": "human", "message": "What's the weather?", "timestamp": "2026-04-29T14:00:00Z"}),
+        json.dumps(
+            {
+                "type": "human",
+                "message": "What's the weather?",
+                "timestamp": "2026-04-29T14:00:00Z",
+            }
+        ),
     ]
     jsonl_file2.write_text("\n".join(lines2))
 

--- a/bede-data/tests/test_api_freshness.py
+++ b/bede-data/tests/test_api_freshness.py
@@ -1,0 +1,21 @@
+def test_get_freshness_empty(client):
+    response = client.get("/api/freshness")
+    assert response.status_code == 200
+    assert response.json()["sources"] == []
+
+
+def test_get_freshness_with_data(client, db):
+    db.execute(
+        "INSERT INTO data_freshness (source, last_received_at, expected_interval_seconds) VALUES (?, ?, ?)",
+        ("health", "2026-04-29T08:00:00Z", 86400),
+    )
+    db.execute(
+        "INSERT INTO data_freshness (source, last_received_at, expected_interval_seconds) VALUES (?, ?, ?)",
+        ("vault", "2026-04-29T06:00:00Z", 86400),
+    )
+    db.commit()
+
+    response = client.get("/api/freshness")
+    data = response.json()
+    assert len(data["sources"]) == 2
+    assert all("source" in s and "last_received_at" in s for s in data["sources"])

--- a/bede-data/tests/test_api_goals.py
+++ b/bede-data/tests/test_api_goals.py
@@ -1,0 +1,66 @@
+def test_create_goal(client):
+    response = client.post(
+        "/api/goals",
+        json={
+            "name": "AWS Solutions Architect cert",
+            "description": "Pass the SAA-C03 exam",
+            "deadline": "2026-09-01",
+            "measurable_indicators": "Complete all practice exams with 80%+",
+        },
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["id"] is not None
+    assert data["name"] == "AWS Solutions Architect cert"
+    assert data["status"] == "active"
+
+
+def test_list_goals(client):
+    client.post("/api/goals", json={"name": "Goal 1"})
+    client.post("/api/goals", json={"name": "Goal 2"})
+    response = client.get("/api/goals")
+    assert response.status_code == 200
+    assert len(response.json()["goals"]) == 2
+
+
+def test_list_goals_filter_status(client):
+    resp = client.post("/api/goals", json={"name": "Active goal"})
+    gid = resp.json()["id"]
+    client.post("/api/goals", json={"name": "Another goal"})
+    client.put(f"/api/goals/{gid}", json={"status": "completed"})
+
+    response = client.get("/api/goals", params={"status": "active"})
+    assert len(response.json()["goals"]) == 1
+    assert response.json()["goals"][0]["name"] == "Another goal"
+
+
+def test_update_goal(client):
+    resp = client.post("/api/goals", json={"name": "Read 2 books"})
+    gid = resp.json()["id"]
+    response = client.put(
+        f"/api/goals/{gid}",
+        json={"description": "Read 2 fiction books in May", "status": "active"},
+    )
+    assert response.status_code == 200
+    assert response.json()["description"] == "Read 2 fiction books in May"
+
+
+def test_complete_goal(client):
+    resp = client.post("/api/goals", json={"name": "Run 5k"})
+    gid = resp.json()["id"]
+    response = client.put(f"/api/goals/{gid}", json={"status": "completed"})
+    assert response.status_code == 200
+    assert response.json()["status"] == "completed"
+
+
+def test_drop_goal(client):
+    resp = client.post("/api/goals", json={"name": "Dropped goal"})
+    gid = resp.json()["id"]
+    response = client.put(f"/api/goals/{gid}", json={"status": "dropped"})
+    assert response.status_code == 200
+    assert response.json()["status"] == "dropped"
+
+
+def test_get_goal_not_found(client):
+    response = client.get("/api/goals/999")
+    assert response.status_code == 404

--- a/bede-data/tests/test_api_health.py
+++ b/bede-data/tests/test_api_health.py
@@ -17,15 +17,36 @@ def _seed_health_data(db):
     )
     db.execute(
         "INSERT INTO sleep_phases (date, phase, hours, start_time, end_time, source) VALUES (?, ?, ?, ?, ?, ?)",
-        ("2026-04-29", "asleepCore", 3.5, "2026-04-28T23:00:00Z", "2026-04-29T02:30:00Z", "Apple Watch"),
+        (
+            "2026-04-29",
+            "asleepCore",
+            3.5,
+            "2026-04-28T23:00:00Z",
+            "2026-04-29T02:30:00Z",
+            "Apple Watch",
+        ),
     )
     db.execute(
         "INSERT INTO sleep_phases (date, phase, hours, start_time, end_time, source) VALUES (?, ?, ?, ?, ?, ?)",
-        ("2026-04-29", "asleepDeep", 1.5, "2026-04-29T02:30:00Z", "2026-04-29T04:00:00Z", "Apple Watch"),
+        (
+            "2026-04-29",
+            "asleepDeep",
+            1.5,
+            "2026-04-29T02:30:00Z",
+            "2026-04-29T04:00:00Z",
+            "Apple Watch",
+        ),
     )
     db.execute(
         "INSERT INTO sleep_phases (date, phase, hours, start_time, end_time, source) VALUES (?, ?, ?, ?, ?, ?)",
-        ("2026-04-29", "asleepREM", 2.0, "2026-04-29T04:00:00Z", "2026-04-29T06:00:00Z", "Apple Watch"),
+        (
+            "2026-04-29",
+            "asleepREM",
+            2.0,
+            "2026-04-29T04:00:00Z",
+            "2026-04-29T06:00:00Z",
+            "Apple Watch",
+        ),
     )
     db.execute(
         "INSERT INTO workouts (date, workout_type, duration_minutes, active_energy_kj, avg_heart_rate, max_heart_rate, start_time) VALUES (?, ?, ?, ?, ?, ?, ?)",
@@ -45,7 +66,14 @@ def _seed_health_data(db):
     )
     db.execute(
         "INSERT INTO state_of_mind (date, valence, labels, context, associations, recorded_at) VALUES (?, ?, ?, ?, ?, ?)",
-        ("2026-04-29", 0.7, "Happy,Calm", "Work", "Productivity", "2026-04-29T14:00:00Z"),
+        (
+            "2026-04-29",
+            0.7,
+            "Happy,Calm",
+            "Work",
+            "Productivity",
+            "2026-04-29T14:00:00Z",
+        ),
     )
     db.execute(
         "INSERT INTO medications (date, medication, quantity, unit, recorded_at) VALUES (?, ?, ?, ?, ?)",

--- a/bede-data/tests/test_api_health.py
+++ b/bede-data/tests/test_api_health.py
@@ -1,0 +1,122 @@
+def _seed_health_data(db):
+    db.execute(
+        "INSERT INTO health_metrics (date, metric, value, source) VALUES (?, ?, ?, ?)",
+        ("2026-04-29", "step_count", 8500, "iPhone"),
+    )
+    db.execute(
+        "INSERT INTO health_metrics (date, metric, value, source) VALUES (?, ?, ?, ?)",
+        ("2026-04-29", "active_energy", 2100.5, "Apple Watch"),
+    )
+    db.execute(
+        "INSERT INTO health_metrics (date, metric, value, source) VALUES (?, ?, ?, ?)",
+        ("2026-04-29", "apple_exercise_time", 35, "Apple Watch"),
+    )
+    db.execute(
+        "INSERT INTO health_metrics (date, metric, value, source) VALUES (?, ?, ?, ?)",
+        ("2026-04-29", "apple_stand_hour", 10, "Apple Watch"),
+    )
+    db.execute(
+        "INSERT INTO sleep_phases (date, phase, hours, start_time, end_time, source) VALUES (?, ?, ?, ?, ?, ?)",
+        ("2026-04-29", "asleepCore", 3.5, "2026-04-28T23:00:00Z", "2026-04-29T02:30:00Z", "Apple Watch"),
+    )
+    db.execute(
+        "INSERT INTO sleep_phases (date, phase, hours, start_time, end_time, source) VALUES (?, ?, ?, ?, ?, ?)",
+        ("2026-04-29", "asleepDeep", 1.5, "2026-04-29T02:30:00Z", "2026-04-29T04:00:00Z", "Apple Watch"),
+    )
+    db.execute(
+        "INSERT INTO sleep_phases (date, phase, hours, start_time, end_time, source) VALUES (?, ?, ?, ?, ?, ?)",
+        ("2026-04-29", "asleepREM", 2.0, "2026-04-29T04:00:00Z", "2026-04-29T06:00:00Z", "Apple Watch"),
+    )
+    db.execute(
+        "INSERT INTO workouts (date, workout_type, duration_minutes, active_energy_kj, avg_heart_rate, max_heart_rate, start_time) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("2026-04-29", "Running", 45.0, 1800, 155, 178, "2026-04-29T07:00:00Z"),
+    )
+    db.execute(
+        "INSERT INTO health_metrics (date, metric, value, source) VALUES (?, ?, ?, ?)",
+        ("2026-04-29", "resting_heart_rate", 62, "Apple Watch"),
+    )
+    db.execute(
+        "INSERT INTO health_metrics (date, metric, value, source) VALUES (?, ?, ?, ?)",
+        ("2026-04-29", "heart_rate_variability", 45, "Apple Watch"),
+    )
+    db.execute(
+        "INSERT INTO health_metrics (date, metric, value, source) VALUES (?, ?, ?, ?)",
+        ("2026-04-29", "mindful_minutes", 15, "iPhone"),
+    )
+    db.execute(
+        "INSERT INTO state_of_mind (date, valence, labels, context, associations, recorded_at) VALUES (?, ?, ?, ?, ?, ?)",
+        ("2026-04-29", 0.7, "Happy,Calm", "Work", "Productivity", "2026-04-29T14:00:00Z"),
+    )
+    db.execute(
+        "INSERT INTO medications (date, medication, quantity, unit, recorded_at) VALUES (?, ?, ?, ?, ?)",
+        ("2026-04-29", "Lexapro", 1, "tablet", "2026-04-29T08:00:00Z"),
+    )
+    db.commit()
+
+
+def test_get_sleep(client, db):
+    _seed_health_data(db)
+    response = client.get("/api/health/sleep", params={"date": "2026-04-29"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["date"] == "2026-04-29"
+    assert data["total_hours"] == 7.0
+    assert len(data["phases"]) == 3
+
+
+def test_get_activity(client, db):
+    _seed_health_data(db)
+    response = client.get("/api/health/activity", params={"date": "2026-04-29"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["date"] == "2026-04-29"
+    assert data["steps"] == 8500
+    assert data["active_energy"] == 2100.5
+    assert data["exercise_minutes"] == 35
+    assert data["stand_hours"] == 10
+
+
+def test_get_workouts(client, db):
+    _seed_health_data(db)
+    response = client.get("/api/health/workouts", params={"date": "2026-04-29"})
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["workouts"]) == 1
+    assert data["workouts"][0]["workout_type"] == "Running"
+    assert data["workouts"][0]["duration_minutes"] == 45.0
+
+
+def test_get_heart_rate(client, db):
+    _seed_health_data(db)
+    response = client.get("/api/health/heart-rate", params={"date": "2026-04-29"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["resting_heart_rate"] == 62
+    assert data["heart_rate_variability"] == 45
+
+
+def test_get_wellbeing(client, db):
+    _seed_health_data(db)
+    response = client.get("/api/health/wellbeing", params={"date": "2026-04-29"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["mindful_minutes"] == 15
+    assert len(data["state_of_mind"]) == 1
+    assert data["state_of_mind"][0]["valence"] == 0.7
+
+
+def test_get_medications(client, db):
+    _seed_health_data(db)
+    response = client.get("/api/health/medications", params={"date": "2026-04-29"})
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["medications"]) == 1
+    assert data["medications"][0]["medication"] == "Lexapro"
+
+
+def test_get_sleep_no_data(client, db):
+    response = client.get("/api/health/sleep", params={"date": "2026-04-29"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_hours"] == 0
+    assert data["phases"] == []

--- a/bede-data/tests/test_api_memories.py
+++ b/bede-data/tests/test_api_memories.py
@@ -43,8 +43,13 @@ def test_list_memories_filter_type(client):
 
 
 def test_list_memories_search(client):
-    client.post("/api/memories", json={"content": "Training for a half marathon", "type": "fact"})
-    client.post("/api/memories", json={"content": "Likes Thai food", "type": "preference"})
+    client.post(
+        "/api/memories",
+        json={"content": "Training for a half marathon", "type": "fact"},
+    )
+    client.post(
+        "/api/memories", json={"content": "Likes Thai food", "type": "preference"}
+    )
     response = client.get("/api/memories", params={"search": "marathon"})
     assert response.status_code == 200
     data = response.json()
@@ -52,9 +57,13 @@ def test_list_memories_search(client):
 
 
 def test_update_memory(client):
-    resp = client.post("/api/memories", json={"content": "Training for 10k", "type": "fact"})
+    resp = client.post(
+        "/api/memories", json={"content": "Training for 10k", "type": "fact"}
+    )
     mem_id = resp.json()["id"]
-    response = client.put(f"/api/memories/{mem_id}", json={"content": "Training for half marathon"})
+    response = client.put(
+        f"/api/memories/{mem_id}", json={"content": "Training for half marathon"}
+    )
     assert response.status_code == 200
     assert response.json()["content"] == "Training for half marathon"
 
@@ -70,11 +79,17 @@ def test_delete_memory(client):
 
 
 def test_correction_supersedes_previous(client):
-    resp1 = client.post("/api/memories", json={"content": "Favourite colour is blue", "type": "fact"})
+    resp1 = client.post(
+        "/api/memories", json={"content": "Favourite colour is blue", "type": "fact"}
+    )
     old_id = resp1.json()["id"]
     resp2 = client.post(
         "/api/memories",
-        json={"content": "Favourite colour is green", "type": "correction", "supersedes": old_id},
+        json={
+            "content": "Favourite colour is green",
+            "type": "correction",
+            "supersedes": old_id,
+        },
     )
     assert resp2.status_code == 201
 
@@ -85,7 +100,9 @@ def test_correction_supersedes_previous(client):
 
 
 def test_reference_memory(client):
-    resp = client.post("/api/memories", json={"content": "Likes camping", "type": "fact"})
+    resp = client.post(
+        "/api/memories", json={"content": "Likes camping", "type": "fact"}
+    )
     mem_id = resp.json()["id"]
     response = client.post(f"/api/memories/{mem_id}/reference")
     assert response.status_code == 200

--- a/bede-data/tests/test_api_memories.py
+++ b/bede-data/tests/test_api_memories.py
@@ -1,0 +1,99 @@
+def test_create_memory(client):
+    response = client.post(
+        "/api/memories",
+        json={
+            "content": "Training for a half marathon",
+            "type": "fact",
+            "source_conversation": "session-123",
+        },
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["id"] is not None
+    assert data["content"] == "Training for a half marathon"
+    assert data["type"] == "fact"
+    assert data["active"] is True
+
+
+def test_create_memory_invalid_type(client):
+    response = client.post(
+        "/api/memories",
+        json={"content": "test", "type": "invalid"},
+    )
+    assert response.status_code == 422
+
+
+def test_list_memories(client):
+    client.post("/api/memories", json={"content": "Fact one", "type": "fact"})
+    client.post("/api/memories", json={"content": "Pref one", "type": "preference"})
+    response = client.get("/api/memories")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["memories"]) == 2
+
+
+def test_list_memories_filter_type(client):
+    client.post("/api/memories", json={"content": "Fact one", "type": "fact"})
+    client.post("/api/memories", json={"content": "Pref one", "type": "preference"})
+    response = client.get("/api/memories", params={"type": "fact"})
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["memories"]) == 1
+    assert data["memories"][0]["type"] == "fact"
+
+
+def test_list_memories_search(client):
+    client.post("/api/memories", json={"content": "Training for a half marathon", "type": "fact"})
+    client.post("/api/memories", json={"content": "Likes Thai food", "type": "preference"})
+    response = client.get("/api/memories", params={"search": "marathon"})
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["memories"]) == 1
+
+
+def test_update_memory(client):
+    resp = client.post("/api/memories", json={"content": "Training for 10k", "type": "fact"})
+    mem_id = resp.json()["id"]
+    response = client.put(f"/api/memories/{mem_id}", json={"content": "Training for half marathon"})
+    assert response.status_code == 200
+    assert response.json()["content"] == "Training for half marathon"
+
+
+def test_delete_memory(client):
+    resp = client.post("/api/memories", json={"content": "Old info", "type": "fact"})
+    mem_id = resp.json()["id"]
+    response = client.delete(f"/api/memories/{mem_id}")
+    assert response.status_code == 200
+
+    listing = client.get("/api/memories")
+    assert len(listing.json()["memories"]) == 0
+
+
+def test_correction_supersedes_previous(client):
+    resp1 = client.post("/api/memories", json={"content": "Favourite colour is blue", "type": "fact"})
+    old_id = resp1.json()["id"]
+    resp2 = client.post(
+        "/api/memories",
+        json={"content": "Favourite colour is green", "type": "correction", "supersedes": old_id},
+    )
+    assert resp2.status_code == 201
+
+    listing = client.get("/api/memories")
+    active = [m for m in listing.json()["memories"] if m["active"]]
+    assert len(active) == 1
+    assert active[0]["content"] == "Favourite colour is green"
+
+
+def test_reference_memory(client):
+    resp = client.post("/api/memories", json={"content": "Likes camping", "type": "fact"})
+    mem_id = resp.json()["id"]
+    response = client.post(f"/api/memories/{mem_id}/reference")
+    assert response.status_code == 200
+    assert response.json()["last_referenced_at"] is not None
+
+
+def test_list_memories_respects_limit(client):
+    for i in range(10):
+        client.post("/api/memories", json={"content": f"Memory {i}", "type": "fact"})
+    response = client.get("/api/memories", params={"limit": 5})
+    assert len(response.json()["memories"]) == 5

--- a/bede-data/tests/test_api_message_queue.py
+++ b/bede-data/tests/test_api_message_queue.py
@@ -1,0 +1,23 @@
+def test_enqueue_message(client):
+    response = client.post(
+        "/api/message-queue",
+        json={"message": "What's the weather?", "source": "telegram"},
+    )
+    assert response.status_code == 201
+    assert response.json()["status"] == "pending"
+
+
+def test_list_pending_messages(client):
+    client.post("/api/message-queue", json={"message": "Msg 1", "source": "telegram"})
+    client.post("/api/message-queue", json={"message": "Msg 2", "source": "scheduler"})
+    response = client.get("/api/message-queue", params={"status": "pending"})
+    assert len(response.json()["messages"]) == 2
+
+
+def test_process_message(client):
+    resp = client.post("/api/message-queue", json={"message": "Hello", "source": "telegram"})
+    msg_id = resp.json()["id"]
+    response = client.put(f"/api/message-queue/{msg_id}", json={"status": "done"})
+    assert response.status_code == 200
+    assert response.json()["status"] == "done"
+    assert response.json()["processed_at"] is not None

--- a/bede-data/tests/test_api_message_queue.py
+++ b/bede-data/tests/test_api_message_queue.py
@@ -15,7 +15,9 @@ def test_list_pending_messages(client):
 
 
 def test_process_message(client):
-    resp = client.post("/api/message-queue", json={"message": "Hello", "source": "telegram"})
+    resp = client.post(
+        "/api/message-queue", json={"message": "Hello", "source": "telegram"}
+    )
     msg_id = resp.json()["id"]
     response = client.put(f"/api/message-queue/{msg_id}", json={"status": "done"})
     assert response.status_code == 200

--- a/bede-data/tests/test_api_sessions.py
+++ b/bede-data/tests/test_api_sessions.py
@@ -1,0 +1,56 @@
+def test_store_daily_session(client):
+    response = client.post(
+        "/api/sessions/daily",
+        json={"date": "2026-04-29", "session_id": "abc-123"},
+    )
+    assert response.status_code == 201
+    assert response.json()["session_id"] == "abc-123"
+
+
+def test_get_daily_session(client):
+    client.post("/api/sessions/daily", json={"date": "2026-04-29", "session_id": "abc-123"})
+    response = client.get("/api/sessions/daily", params={"date": "2026-04-29"})
+    assert response.status_code == 200
+    assert response.json()["session_id"] == "abc-123"
+
+
+def test_get_daily_session_not_found(client):
+    response = client.get("/api/sessions/daily", params={"date": "2026-04-29"})
+    assert response.status_code == 404
+
+
+def test_upsert_daily_session(client):
+    client.post("/api/sessions/daily", json={"date": "2026-04-29", "session_id": "old-session"})
+    client.post("/api/sessions/daily", json={"date": "2026-04-29", "session_id": "new-session"})
+    response = client.get("/api/sessions/daily", params={"date": "2026-04-29"})
+    assert response.json()["session_id"] == "new-session"
+
+
+def test_append_scratchpad(client):
+    response = client.post(
+        "/api/scratchpad",
+        json={
+            "date": "2026-04-29",
+            "entry_time": "08:00",
+            "content": "[08:00] Morning Briefing: 2 calendar events, flagged poor sleep.",
+        },
+    )
+    assert response.status_code == 201
+
+
+def test_get_scratchpad(client):
+    client.post("/api/scratchpad", json={"date": "2026-04-29", "entry_time": "08:00", "content": "Morning entry"})
+    client.post("/api/scratchpad", json={"date": "2026-04-29", "entry_time": "12:30", "content": "Midday entry"})
+
+    response = client.get("/api/scratchpad", params={"date": "2026-04-29"})
+    assert response.status_code == 200
+    entries = response.json()["entries"]
+    assert len(entries) == 2
+    assert entries[0]["entry_time"] == "08:00"
+    assert entries[1]["entry_time"] == "12:30"
+
+
+def test_get_scratchpad_empty(client):
+    response = client.get("/api/scratchpad", params={"date": "2026-04-29"})
+    assert response.status_code == 200
+    assert response.json()["entries"] == []

--- a/bede-data/tests/test_api_sessions.py
+++ b/bede-data/tests/test_api_sessions.py
@@ -8,7 +8,9 @@ def test_store_daily_session(client):
 
 
 def test_get_daily_session(client):
-    client.post("/api/sessions/daily", json={"date": "2026-04-29", "session_id": "abc-123"})
+    client.post(
+        "/api/sessions/daily", json={"date": "2026-04-29", "session_id": "abc-123"}
+    )
     response = client.get("/api/sessions/daily", params={"date": "2026-04-29"})
     assert response.status_code == 200
     assert response.json()["session_id"] == "abc-123"
@@ -20,8 +22,12 @@ def test_get_daily_session_not_found(client):
 
 
 def test_upsert_daily_session(client):
-    client.post("/api/sessions/daily", json={"date": "2026-04-29", "session_id": "old-session"})
-    client.post("/api/sessions/daily", json={"date": "2026-04-29", "session_id": "new-session"})
+    client.post(
+        "/api/sessions/daily", json={"date": "2026-04-29", "session_id": "old-session"}
+    )
+    client.post(
+        "/api/sessions/daily", json={"date": "2026-04-29", "session_id": "new-session"}
+    )
     response = client.get("/api/sessions/daily", params={"date": "2026-04-29"})
     assert response.json()["session_id"] == "new-session"
 
@@ -39,8 +45,14 @@ def test_append_scratchpad(client):
 
 
 def test_get_scratchpad(client):
-    client.post("/api/scratchpad", json={"date": "2026-04-29", "entry_time": "08:00", "content": "Morning entry"})
-    client.post("/api/scratchpad", json={"date": "2026-04-29", "entry_time": "12:30", "content": "Midday entry"})
+    client.post(
+        "/api/scratchpad",
+        json={"date": "2026-04-29", "entry_time": "08:00", "content": "Morning entry"},
+    )
+    client.post(
+        "/api/scratchpad",
+        json={"date": "2026-04-29", "entry_time": "12:30", "content": "Midday entry"},
+    )
 
     response = client.get("/api/scratchpad", params={"date": "2026-04-29"})
     assert response.status_code == 200

--- a/bede-data/tests/test_api_storage.py
+++ b/bede-data/tests/test_api_storage.py
@@ -1,0 +1,11 @@
+def test_get_storage_stats(client, db):
+    db.execute("INSERT INTO health_metrics (date, metric, value, source) VALUES ('2026-04-29', 'steps', 8000, 'test')")
+    db.execute("INSERT INTO memories (content, type) VALUES ('test', 'fact')")
+    db.commit()
+
+    response = client.get("/api/storage")
+    assert response.status_code == 200
+    data = response.json()
+    assert "db_size_bytes" in data
+    assert "tables" in data
+    assert any(t["name"] == "health_metrics" for t in data["tables"])

--- a/bede-data/tests/test_api_storage.py
+++ b/bede-data/tests/test_api_storage.py
@@ -1,5 +1,7 @@
 def test_get_storage_stats(client, db):
-    db.execute("INSERT INTO health_metrics (date, metric, value, source) VALUES ('2026-04-29', 'steps', 8000, 'test')")
+    db.execute(
+        "INSERT INTO health_metrics (date, metric, value, source) VALUES ('2026-04-29', 'steps', 8000, 'test')"
+    )
     db.execute("INSERT INTO memories (content, type) VALUES ('test', 'fact')")
     db.commit()
 

--- a/bede-data/tests/test_api_task_log.py
+++ b/bede-data/tests/test_api_task_log.py
@@ -1,0 +1,72 @@
+def test_log_task_start(client):
+    response = client.post(
+        "/api/tasks/log",
+        json={
+            "task_name": "Morning Briefing",
+            "start_time": "2026-04-29T08:00:00Z",
+            "status": "running",
+        },
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["id"] is not None
+    assert data["status"] == "running"
+
+
+def test_update_task_completion(client):
+    resp = client.post(
+        "/api/tasks/log",
+        json={
+            "task_name": "Morning Briefing",
+            "start_time": "2026-04-29T08:00:00Z",
+            "status": "running",
+        },
+    )
+    task_id = resp.json()["id"]
+    response = client.put(
+        f"/api/tasks/log/{task_id}",
+        json={
+            "status": "success",
+            "end_time": "2026-04-29T08:05:00Z",
+            "duration_seconds": 300,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "success"
+    assert response.json()["duration_seconds"] == 300
+
+
+def test_log_task_failure(client):
+    resp = client.post(
+        "/api/tasks/log",
+        json={
+            "task_name": "Deal Scout",
+            "start_time": "2026-04-29T14:00:00Z",
+            "status": "running",
+        },
+    )
+    task_id = resp.json()["id"]
+    response = client.put(
+        f"/api/tasks/log/{task_id}",
+        json={"status": "failure", "error_detail": "Claude session timeout"},
+    )
+    assert response.status_code == 200
+    assert response.json()["error_detail"] == "Claude session timeout"
+
+
+def test_get_task_history(client):
+    client.post("/api/tasks/log", json={"task_name": "Morning Briefing", "start_time": "2026-04-29T08:00:00Z", "status": "success"})
+    client.post("/api/tasks/log", json={"task_name": "Evening Reflection", "start_time": "2026-04-29T21:00:00Z", "status": "success"})
+    client.post("/api/tasks/log", json={"task_name": "Morning Briefing", "start_time": "2026-04-30T08:00:00Z", "status": "failure"})
+
+    response = client.get("/api/tasks/history")
+    assert response.status_code == 200
+    assert len(response.json()["executions"]) == 3
+
+
+def test_get_task_history_filter_name(client):
+    client.post("/api/tasks/log", json={"task_name": "Morning Briefing", "start_time": "2026-04-29T08:00:00Z", "status": "success"})
+    client.post("/api/tasks/log", json={"task_name": "Evening Reflection", "start_time": "2026-04-29T21:00:00Z", "status": "success"})
+
+    response = client.get("/api/tasks/history", params={"task_name": "Morning Briefing"})
+    assert len(response.json()["executions"]) == 1

--- a/bede-data/tests/test_api_task_log.py
+++ b/bede-data/tests/test_api_task_log.py
@@ -55,9 +55,30 @@ def test_log_task_failure(client):
 
 
 def test_get_task_history(client):
-    client.post("/api/tasks/log", json={"task_name": "Morning Briefing", "start_time": "2026-04-29T08:00:00Z", "status": "success"})
-    client.post("/api/tasks/log", json={"task_name": "Evening Reflection", "start_time": "2026-04-29T21:00:00Z", "status": "success"})
-    client.post("/api/tasks/log", json={"task_name": "Morning Briefing", "start_time": "2026-04-30T08:00:00Z", "status": "failure"})
+    client.post(
+        "/api/tasks/log",
+        json={
+            "task_name": "Morning Briefing",
+            "start_time": "2026-04-29T08:00:00Z",
+            "status": "success",
+        },
+    )
+    client.post(
+        "/api/tasks/log",
+        json={
+            "task_name": "Evening Reflection",
+            "start_time": "2026-04-29T21:00:00Z",
+            "status": "success",
+        },
+    )
+    client.post(
+        "/api/tasks/log",
+        json={
+            "task_name": "Morning Briefing",
+            "start_time": "2026-04-30T08:00:00Z",
+            "status": "failure",
+        },
+    )
 
     response = client.get("/api/tasks/history")
     assert response.status_code == 200
@@ -65,8 +86,24 @@ def test_get_task_history(client):
 
 
 def test_get_task_history_filter_name(client):
-    client.post("/api/tasks/log", json={"task_name": "Morning Briefing", "start_time": "2026-04-29T08:00:00Z", "status": "success"})
-    client.post("/api/tasks/log", json={"task_name": "Evening Reflection", "start_time": "2026-04-29T21:00:00Z", "status": "success"})
+    client.post(
+        "/api/tasks/log",
+        json={
+            "task_name": "Morning Briefing",
+            "start_time": "2026-04-29T08:00:00Z",
+            "status": "success",
+        },
+    )
+    client.post(
+        "/api/tasks/log",
+        json={
+            "task_name": "Evening Reflection",
+            "start_time": "2026-04-29T21:00:00Z",
+            "status": "success",
+        },
+    )
 
-    response = client.get("/api/tasks/history", params={"task_name": "Morning Briefing"})
+    response = client.get(
+        "/api/tasks/history", params={"task_name": "Morning Briefing"}
+    )
     assert len(response.json()["executions"]) == 1

--- a/bede-data/tests/test_api_vault_data.py
+++ b/bede-data/tests/test_api_vault_data.py
@@ -1,0 +1,121 @@
+def _seed_vault_data(db):
+    db.execute(
+        "INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES (?, ?, ?, ?, ?)",
+        ("2026-04-29", "mac", "app", "Safari", 3600),
+    )
+    db.execute(
+        "INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES (?, ?, ?, ?, ?)",
+        ("2026-04-29", "mac", "app", "Terminal", 1800),
+    )
+    db.execute(
+        "INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES (?, ?, ?, ?, ?)",
+        ("2026-04-29", "mac", "web", "github.com", 900),
+    )
+    db.execute(
+        "INSERT INTO screen_time (date, device, entry_type, name, seconds) VALUES (?, ?, ?, ?, ?)",
+        ("2026-04-29", "iphone", "app", "Instagram", 2400),
+    )
+    db.execute(
+        "INSERT INTO safari_history (date, device, domain, title, url, visited_at) VALUES (?, ?, ?, ?, ?, ?)",
+        ("2026-04-29", "mac", "github.com", "GitHub", "https://github.com", "2026-04-29T10:00:00Z"),
+    )
+    db.execute(
+        "INSERT INTO safari_history (date, device, domain, title, url, visited_at) VALUES (?, ?, ?, ?, ?, ?)",
+        ("2026-04-29", "mac", "docs.python.org", "Python Docs", "https://docs.python.org/3/", "2026-04-29T11:00:00Z"),
+    )
+    db.execute(
+        "INSERT INTO youtube_history (date, title, url, visited_at) VALUES (?, ?, ?, ?)",
+        ("2026-04-29", "Cool Video", "https://youtube.com/watch?v=abc", "2026-04-29T14:00:00Z"),
+    )
+    db.execute(
+        "INSERT INTO podcasts (date, podcast, episode, duration_seconds, played_at) VALUES (?, ?, ?, ?, ?)",
+        ("2026-04-29", "The Daily", "Episode 123", 1800, "2026-04-29T08:00:00Z"),
+    )
+    db.execute(
+        "INSERT INTO claude_sessions (date, project, start_time, end_time, duration_min, turns, summary) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("2026-04-29", "home-server-stack", "2026-04-29 09:00", "2026-04-29 10:30", 90, 25, "Worked on Bede plan"),
+    )
+    db.execute(
+        "INSERT INTO bede_sessions (date, task_name, start_time, end_time, duration_min, turns, summary) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("2026-04-29", "Morning Briefing", "2026-04-29 08:00", "2026-04-29 08:05", 5, 3, "Delivered briefing"),
+    )
+    db.commit()
+
+
+def test_get_screen_time(client, db):
+    _seed_vault_data(db)
+    response = client.get("/api/vault/screen-time", params={"date": "2026-04-29"})
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["entries"]) == 4
+
+
+def test_get_screen_time_filter_device(client, db):
+    _seed_vault_data(db)
+    response = client.get("/api/vault/screen-time", params={"date": "2026-04-29", "device": "mac"})
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["entries"]) == 3
+    assert all(e["device"] == "mac" for e in data["entries"])
+
+
+def test_get_screen_time_top_n(client, db):
+    _seed_vault_data(db)
+    response = client.get("/api/vault/screen-time", params={"date": "2026-04-29", "device": "mac", "top_n": 2})
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["entries"]) == 2
+    assert data["entries"][0]["seconds"] >= data["entries"][1]["seconds"]
+
+
+def test_get_safari(client, db):
+    _seed_vault_data(db)
+    response = client.get("/api/vault/safari", params={"date": "2026-04-29"})
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["entries"]) == 2
+
+
+def test_get_safari_filter_domain(client, db):
+    _seed_vault_data(db)
+    response = client.get("/api/vault/safari", params={"date": "2026-04-29", "domain": "github.com"})
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["entries"]) == 1
+    assert data["entries"][0]["domain"] == "github.com"
+
+
+def test_get_youtube(client, db):
+    _seed_vault_data(db)
+    response = client.get("/api/vault/youtube", params={"date": "2026-04-29"})
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["entries"]) == 1
+    assert data["entries"][0]["title"] == "Cool Video"
+
+
+def test_get_podcasts(client, db):
+    _seed_vault_data(db)
+    response = client.get("/api/vault/podcasts", params={"date": "2026-04-29"})
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["entries"]) == 1
+    assert data["entries"][0]["podcast"] == "The Daily"
+
+
+def test_get_claude_sessions(client, db):
+    _seed_vault_data(db)
+    response = client.get("/api/vault/claude-sessions", params={"date": "2026-04-29"})
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["sessions"]) == 1
+    assert data["sessions"][0]["project"] == "home-server-stack"
+
+
+def test_get_bede_sessions(client, db):
+    _seed_vault_data(db)
+    response = client.get("/api/vault/bede-sessions", params={"date": "2026-04-29"})
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["sessions"]) == 1
+    assert data["sessions"][0]["task_name"] == "Morning Briefing"

--- a/bede-data/tests/test_api_vault_data.py
+++ b/bede-data/tests/test_api_vault_data.py
@@ -17,15 +17,34 @@ def _seed_vault_data(db):
     )
     db.execute(
         "INSERT INTO safari_history (date, device, domain, title, url, visited_at) VALUES (?, ?, ?, ?, ?, ?)",
-        ("2026-04-29", "mac", "github.com", "GitHub", "https://github.com", "2026-04-29T10:00:00Z"),
+        (
+            "2026-04-29",
+            "mac",
+            "github.com",
+            "GitHub",
+            "https://github.com",
+            "2026-04-29T10:00:00Z",
+        ),
     )
     db.execute(
         "INSERT INTO safari_history (date, device, domain, title, url, visited_at) VALUES (?, ?, ?, ?, ?, ?)",
-        ("2026-04-29", "mac", "docs.python.org", "Python Docs", "https://docs.python.org/3/", "2026-04-29T11:00:00Z"),
+        (
+            "2026-04-29",
+            "mac",
+            "docs.python.org",
+            "Python Docs",
+            "https://docs.python.org/3/",
+            "2026-04-29T11:00:00Z",
+        ),
     )
     db.execute(
         "INSERT INTO youtube_history (date, title, url, visited_at) VALUES (?, ?, ?, ?)",
-        ("2026-04-29", "Cool Video", "https://youtube.com/watch?v=abc", "2026-04-29T14:00:00Z"),
+        (
+            "2026-04-29",
+            "Cool Video",
+            "https://youtube.com/watch?v=abc",
+            "2026-04-29T14:00:00Z",
+        ),
     )
     db.execute(
         "INSERT INTO podcasts (date, podcast, episode, duration_seconds, played_at) VALUES (?, ?, ?, ?, ?)",
@@ -33,11 +52,27 @@ def _seed_vault_data(db):
     )
     db.execute(
         "INSERT INTO claude_sessions (date, project, start_time, end_time, duration_min, turns, summary) VALUES (?, ?, ?, ?, ?, ?, ?)",
-        ("2026-04-29", "home-server-stack", "2026-04-29 09:00", "2026-04-29 10:30", 90, 25, "Worked on Bede plan"),
+        (
+            "2026-04-29",
+            "home-server-stack",
+            "2026-04-29 09:00",
+            "2026-04-29 10:30",
+            90,
+            25,
+            "Worked on Bede plan",
+        ),
     )
     db.execute(
         "INSERT INTO bede_sessions (date, task_name, start_time, end_time, duration_min, turns, summary) VALUES (?, ?, ?, ?, ?, ?, ?)",
-        ("2026-04-29", "Morning Briefing", "2026-04-29 08:00", "2026-04-29 08:05", 5, 3, "Delivered briefing"),
+        (
+            "2026-04-29",
+            "Morning Briefing",
+            "2026-04-29 08:00",
+            "2026-04-29 08:05",
+            5,
+            3,
+            "Delivered briefing",
+        ),
     )
     db.commit()
 
@@ -52,7 +87,9 @@ def test_get_screen_time(client, db):
 
 def test_get_screen_time_filter_device(client, db):
     _seed_vault_data(db)
-    response = client.get("/api/vault/screen-time", params={"date": "2026-04-29", "device": "mac"})
+    response = client.get(
+        "/api/vault/screen-time", params={"date": "2026-04-29", "device": "mac"}
+    )
     assert response.status_code == 200
     data = response.json()
     assert len(data["entries"]) == 3
@@ -61,7 +98,10 @@ def test_get_screen_time_filter_device(client, db):
 
 def test_get_screen_time_top_n(client, db):
     _seed_vault_data(db)
-    response = client.get("/api/vault/screen-time", params={"date": "2026-04-29", "device": "mac", "top_n": 2})
+    response = client.get(
+        "/api/vault/screen-time",
+        params={"date": "2026-04-29", "device": "mac", "top_n": 2},
+    )
     assert response.status_code == 200
     data = response.json()
     assert len(data["entries"]) == 2
@@ -78,7 +118,9 @@ def test_get_safari(client, db):
 
 def test_get_safari_filter_domain(client, db):
     _seed_vault_data(db)
-    response = client.get("/api/vault/safari", params={"date": "2026-04-29", "domain": "github.com"})
+    response = client.get(
+        "/api/vault/safari", params={"date": "2026-04-29", "domain": "github.com"}
+    )
     assert response.status_code == 200
     data = response.json()
     assert len(data["entries"]) == 1

--- a/bede-data/tests/test_api_vault_queue.py
+++ b/bede-data/tests/test_api_vault_queue.py
@@ -14,20 +14,32 @@ def test_enqueue_journal(client):
 
 
 def test_list_queue(client):
-    client.post("/api/vault-queue", json={"content_type": "journal", "content": "Entry 1", "vault_path": "a.md"})
-    client.post("/api/vault-queue", json={"content_type": "capture", "content": "Idea", "vault_path": "b.md"})
+    client.post(
+        "/api/vault-queue",
+        json={"content_type": "journal", "content": "Entry 1", "vault_path": "a.md"},
+    )
+    client.post(
+        "/api/vault-queue",
+        json={"content_type": "capture", "content": "Idea", "vault_path": "b.md"},
+    )
     response = client.get("/api/vault-queue")
     assert len(response.json()["items"]) == 2
 
 
 def test_list_queue_filter_status(client):
-    client.post("/api/vault-queue", json={"content_type": "journal", "content": "Entry", "vault_path": "a.md"})
+    client.post(
+        "/api/vault-queue",
+        json={"content_type": "journal", "content": "Entry", "vault_path": "a.md"},
+    )
     response = client.get("/api/vault-queue", params={"status": "pending"})
     assert len(response.json()["items"]) == 1
 
 
 def test_update_queue_item_published(client):
-    resp = client.post("/api/vault-queue", json={"content_type": "journal", "content": "Entry", "vault_path": "a.md"})
+    resp = client.post(
+        "/api/vault-queue",
+        json={"content_type": "journal", "content": "Entry", "vault_path": "a.md"},
+    )
     item_id = resp.json()["id"]
     response = client.put(
         f"/api/vault-queue/{item_id}",
@@ -39,7 +51,10 @@ def test_update_queue_item_published(client):
 
 
 def test_update_queue_item_failed(client):
-    resp = client.post("/api/vault-queue", json={"content_type": "journal", "content": "Entry", "vault_path": "a.md"})
+    resp = client.post(
+        "/api/vault-queue",
+        json={"content_type": "journal", "content": "Entry", "vault_path": "a.md"},
+    )
     item_id = resp.json()["id"]
     response = client.put(
         f"/api/vault-queue/{item_id}",

--- a/bede-data/tests/test_api_vault_queue.py
+++ b/bede-data/tests/test_api_vault_queue.py
@@ -1,0 +1,50 @@
+def test_enqueue_journal(client):
+    response = client.post(
+        "/api/vault-queue",
+        json={
+            "content_type": "journal",
+            "content": "# 2026-04-29\n\nA productive day.",
+            "vault_path": "Journal/2026-04-29.md",
+        },
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["status"] == "pending"
+    assert data["content_type"] == "journal"
+
+
+def test_list_queue(client):
+    client.post("/api/vault-queue", json={"content_type": "journal", "content": "Entry 1", "vault_path": "a.md"})
+    client.post("/api/vault-queue", json={"content_type": "capture", "content": "Idea", "vault_path": "b.md"})
+    response = client.get("/api/vault-queue")
+    assert len(response.json()["items"]) == 2
+
+
+def test_list_queue_filter_status(client):
+    client.post("/api/vault-queue", json={"content_type": "journal", "content": "Entry", "vault_path": "a.md"})
+    response = client.get("/api/vault-queue", params={"status": "pending"})
+    assert len(response.json()["items"]) == 1
+
+
+def test_update_queue_item_published(client):
+    resp = client.post("/api/vault-queue", json={"content_type": "journal", "content": "Entry", "vault_path": "a.md"})
+    item_id = resp.json()["id"]
+    response = client.put(
+        f"/api/vault-queue/{item_id}",
+        json={"status": "published"},
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "published"
+    assert response.json()["published_at"] is not None
+
+
+def test_update_queue_item_failed(client):
+    resp = client.post("/api/vault-queue", json={"content_type": "journal", "content": "Entry", "vault_path": "a.md"})
+    item_id = resp.json()["id"]
+    response = client.put(
+        f"/api/vault-queue/{item_id}",
+        json={"status": "failed", "error_detail": "git push failed"},
+    )
+    assert response.status_code == 200
+    assert response.json()["status"] == "failed"
+    assert response.json()["error_detail"] == "git push failed"

--- a/bede-data/tests/test_app.py
+++ b/bede-data/tests/test_app.py
@@ -1,0 +1,4 @@
+def test_health_check(client):
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/bede-data/tests/test_app.py
+++ b/bede-data/tests/test_app.py
@@ -3,4 +3,4 @@ def test_health_check(client):
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "ok"
-    assert data["schema_version"] == 2
+    assert data["schema_version"] == 3

--- a/bede-data/tests/test_app.py
+++ b/bede-data/tests/test_app.py
@@ -1,4 +1,6 @@
 def test_health_check(client):
     response = client.get("/health")
     assert response.status_code == 200
-    assert response.json() == {"status": "ok"}
+    data = response.json()
+    assert data["status"] == "ok"
+    assert data["schema_version"] == 1

--- a/bede-data/tests/test_app.py
+++ b/bede-data/tests/test_app.py
@@ -3,4 +3,4 @@ def test_health_check(client):
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "ok"
-    assert data["schema_version"] == 1
+    assert data["schema_version"] == 2

--- a/bede-data/tests/test_db.py
+++ b/bede-data/tests/test_db.py
@@ -48,7 +48,7 @@ def test_wal_mode_enabled(db):
 def test_schema_version_is_set(db):
     cursor = db.execute("SELECT MAX(version) FROM schema_version")
     version = cursor.fetchone()[0]
-    assert version == 1
+    assert version == 2
 
 
 def test_health_metrics_upsert_by_natural_key(db):
@@ -84,3 +84,32 @@ def test_goals_status_check_constraint(db):
             "INSERT INTO goals (name, status) VALUES (?, ?)",
             ("test goal", "invalid_status"),
         )
+
+
+def test_prototype_schema_detection(tmp_path):
+    from bede_data.db.schema import tables_needing_reset
+
+    db_path = str(tmp_path / "prototype.db")
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        "CREATE TABLE sleep_phases (id INTEGER PRIMARY KEY, date TEXT, stage TEXT, hours REAL, sleep_start TEXT, sleep_end TEXT, source TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE workouts (id INTEGER PRIMARY KEY, date TEXT, workout_name TEXT, start_time TEXT, end_time TEXT, duration_min REAL, active_energy_kj REAL, avg_heart_rate_bpm REAL, max_heart_rate_bpm REAL)"
+    )
+    conn.execute(
+        "CREATE TABLE screen_time (id INTEGER PRIMARY KEY, date TEXT, device TEXT, entry_type TEXT, identifier TEXT, seconds INTEGER)"
+    )
+    conn.commit()
+
+    reset = tables_needing_reset(conn)
+    assert "sleep_phases" in reset
+    assert "workouts" in reset
+    assert "screen_time" in reset
+    conn.close()
+
+
+def test_prototype_schema_not_detected_for_new_tables(db):
+    from bede_data.db.schema import tables_needing_reset
+
+    assert tables_needing_reset(db) == []

--- a/bede-data/tests/test_db.py
+++ b/bede-data/tests/test_db.py
@@ -1,0 +1,86 @@
+import sqlite3
+
+import pytest
+
+
+def test_schema_creates_all_tables(db):
+    cursor = db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+    )
+    tables = {row["name"] for row in cursor.fetchall()}
+    expected = {
+        "schema_version",
+        "health_metrics",
+        "sleep_phases",
+        "workouts",
+        "state_of_mind",
+        "medications",
+        "screen_time",
+        "safari_history",
+        "youtube_history",
+        "podcasts",
+        "claude_sessions",
+        "bede_sessions",
+        "music_listens",
+        "memories",
+        "goals",
+        "task_executions",
+        "analytics_flags",
+        "analytics_thresholds",
+        "schedules",
+        "monitored_items",
+        "settings",
+        "daily_scratchpads",
+        "daily_sessions",
+        "vault_publish_queue",
+        "message_queue",
+        "data_freshness",
+        "retention_policies",
+    }
+    assert expected.issubset(tables), f"Missing tables: {expected - tables}"
+
+
+def test_wal_mode_enabled(db):
+    cursor = db.execute("PRAGMA journal_mode")
+    assert cursor.fetchone()[0] == "wal"
+
+
+def test_schema_version_is_set(db):
+    cursor = db.execute("SELECT MAX(version) FROM schema_version")
+    version = cursor.fetchone()[0]
+    assert version == 1
+
+
+def test_health_metrics_upsert_by_natural_key(db):
+    db.execute(
+        "INSERT INTO health_metrics (date, metric, value, source) VALUES (?, ?, ?, ?)",
+        ("2026-04-29", "steps", 8000, "apple_health"),
+    )
+    db.execute(
+        "INSERT OR REPLACE INTO health_metrics (date, metric, value, source) VALUES (?, ?, ?, ?)",
+        ("2026-04-29", "steps", 9000, "apple_health"),
+    )
+    db.commit()
+    cursor = db.execute(
+        "SELECT value FROM health_metrics WHERE date = ? AND metric = ? AND source = ?",
+        ("2026-04-29", "steps", "apple_health"),
+    )
+    rows = cursor.fetchall()
+    assert len(rows) == 1
+    assert rows[0]["value"] == 9000
+
+
+def test_memories_check_constraint(db):
+    with pytest.raises(sqlite3.IntegrityError):
+        db.execute(
+            "INSERT INTO memories (content, type) VALUES (?, ?)",
+            ("test", "invalid_type"),
+        )
+
+
+def test_goals_status_check_constraint(db):
+    with pytest.raises(sqlite3.IntegrityError):
+        db.execute(
+            "INSERT INTO goals (name, status) VALUES (?, ?)",
+            ("test goal", "invalid_status"),
+        )

--- a/bede-data/tests/test_db.py
+++ b/bede-data/tests/test_db.py
@@ -48,17 +48,17 @@ def test_wal_mode_enabled(db):
 def test_schema_version_is_set(db):
     cursor = db.execute("SELECT MAX(version) FROM schema_version")
     version = cursor.fetchone()[0]
-    assert version == 2
+    assert version == 3
 
 
 def test_health_metrics_upsert_by_natural_key(db):
     db.execute(
-        "INSERT INTO health_metrics (date, metric, value, source) VALUES (?, ?, ?, ?)",
-        ("2026-04-29", "steps", 8000, "apple_health"),
+        "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
+        ("2026-04-29", "steps", 8000, "apple_health", "2026-04-29T00:00:00Z"),
     )
     db.execute(
-        "INSERT OR REPLACE INTO health_metrics (date, metric, value, source) VALUES (?, ?, ?, ?)",
-        ("2026-04-29", "steps", 9000, "apple_health"),
+        "INSERT OR REPLACE INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
+        ("2026-04-29", "steps", 9000, "apple_health", "2026-04-29T00:00:00Z"),
     )
     db.commit()
     cursor = db.execute(

--- a/bede-data/tests/test_ingest_health.py
+++ b/bede-data/tests/test_ingest_health.py
@@ -378,6 +378,33 @@ def test_parse_metric_avg_fallback():
     assert result["health_metrics"][0]["source"] == "Apple Watch"
 
 
+def test_parse_metric_avg_preferred_over_qty():
+    """When both Avg and qty are present, Avg should win (qty may be 0 in summarised mode)."""
+    payload = {
+        "data": {
+            "metrics": [
+                {
+                    "name": "heart_rate",
+                    "units": "bpm",
+                    "data": [
+                        {
+                            "date": "2026-04-29 08:30:00 +1000",
+                            "qty": 0,
+                            "Avg": 72,
+                            "Min": 60,
+                            "Max": 85,
+                            "source": "Apple Watch",
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+    result = parse_health_payload(payload)
+    assert len(result["health_metrics"]) == 1
+    assert result["health_metrics"][0]["value"] == 72
+
+
 def test_parse_sleep_unsummarised_phase_records():
     """Unsummarised sleep: data[] entries that ARE phase records with value/qty."""
     payload = {

--- a/bede-data/tests/test_ingest_health.py
+++ b/bede-data/tests/test_ingest_health.py
@@ -62,7 +62,7 @@ def test_parse_basic_metrics():
     assert result["health_metrics"][0]["source"] == "iPhone"
 
 
-def test_parse_sleep_analysis():
+def test_parse_sleep_inline_phases():
     payload = {
         "data": {
             "metrics": [
@@ -98,7 +98,37 @@ def test_parse_sleep_analysis():
     assert result["sleep_phases"][1]["hours"] == 1.5
 
 
-def test_parse_workouts():
+def test_parse_sleep_aggregated():
+    payload = {
+        "data": {
+            "metrics": [
+                {
+                    "name": "sleep_analysis",
+                    "aggregatedSleepAnalyses": [
+                        {
+                            "sleepStart": "2026-04-28 23:00:00 +1000",
+                            "sleepEnd": "2026-04-29 07:00:00 +1000",
+                            "source": "Apple Watch",
+                            "core": 3.5,
+                            "deep": 1.2,
+                            "rem": 1.8,
+                            "awake": 0.5,
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+    result = parse_health_payload(payload)
+    phases = {p["phase"]: p["hours"] for p in result["sleep_phases"]}
+    assert phases["core"] == 3.5
+    assert phases["deep"] == 1.2
+    assert phases["rem"] == 1.8
+    assert phases["awake"] == 0.5
+    assert result["sleep_phases"][0]["date"] == "2026-04-29"
+
+
+def test_parse_workouts_dict_fields():
     payload = {
         "data": {
             "workouts": [
@@ -120,18 +150,56 @@ def test_parse_workouts():
     assert result["workouts"][0]["active_energy_kj"] == 1800
 
 
-def test_parse_medications():
+def test_parse_workouts_list_fields():
+    payload = {
+        "data": {
+            "workouts": [
+                {
+                    "name": "Walking",
+                    "start": "2026-04-29 08:00:00 +1000",
+                    "end": "2026-04-29 08:30:00 +1000",
+                    "activeEnergy": [{"qty": 500, "units": "kJ"}],
+                    "avgHeartRate": [{"qty": 110, "units": "bpm"}],
+                    "maxHeartRate": [{"qty": 130, "units": "bpm"}],
+                }
+            ]
+        }
+    }
+    result = parse_health_payload(payload)
+    assert result["workouts"][0]["active_energy_kj"] == 500
+    assert result["workouts"][0]["avg_heart_rate"] == 110
+
+
+def test_parse_workouts_scalar_fields():
+    payload = {
+        "data": {
+            "workouts": [
+                {
+                    "name": "Yoga",
+                    "start": "2026-04-29 09:00:00 +1000",
+                    "end": "2026-04-29 10:00:00 +1000",
+                    "activeEnergy": 400.0,
+                    "avgHeartRate": 90,
+                }
+            ]
+        }
+    }
+    result = parse_health_payload(payload)
+    assert result["workouts"][0]["active_energy_kj"] == 400.0
+    assert result["workouts"][0]["avg_heart_rate"] == 90
+
+
+def test_parse_medications_regex():
     payload = {
         "data": {
             "metrics": [
                 {
-                    "name": "medication_record",
+                    "name": "Medication_Lexapro",
+                    "units": "tablet",
                     "data": [
                         {
                             "date": "2026-04-29 08:00:00 +1000",
-                            "medication": "Lexapro",
                             "qty": 1,
-                            "unit": "tablet",
                             "source": "Health",
                         }
                     ],
@@ -141,26 +209,23 @@ def test_parse_medications():
     }
     result = parse_health_payload(payload)
     assert len(result["medications"]) == 1
-    assert result["medications"][0]["medication"] == "Lexapro"
+    assert result["medications"][0]["medication"] == "Medication_Lexapro"
     assert result["medications"][0]["quantity"] == 1
+    assert result["medications"][0]["unit"] == "tablet"
 
 
-def test_parse_state_of_mind():
+def test_parse_state_of_mind_top_level():
+    """stateOfMind is a top-level array in data, not inside metrics."""
     payload = {
         "data": {
-            "metrics": [
+            "stateOfMind": [
                 {
-                    "name": "state_of_mind",
-                    "data": [
-                        {
-                            "date": "2026-04-29 14:00:00 +1000",
-                            "valence": 0.7,
-                            "labels": "Happy,Calm",
-                            "context": "Work",
-                            "associations": "Productivity",
-                            "source": "Health",
-                        }
-                    ],
+                    "start": "2026-04-29 14:00:00 +1000",
+                    "end": "2026-04-29 14:00:00 +1000",
+                    "kind": "mood",
+                    "valence": 0.7,
+                    "labels": ["Happy", "Calm"],
+                    "associations": ["Work"],
                 }
             ]
         }
@@ -168,7 +233,26 @@ def test_parse_state_of_mind():
     result = parse_health_payload(payload)
     assert len(result["state_of_mind"]) == 1
     assert result["state_of_mind"][0]["valence"] == 0.7
-    assert result["state_of_mind"][0]["labels"] == "Happy,Calm"
+    assert result["state_of_mind"][0]["date"] == "2026-04-29"
+    import json
+
+    assert json.loads(result["state_of_mind"][0]["labels"]) == ["Happy", "Calm"]
+    assert json.loads(result["state_of_mind"][0]["associations"]) == ["Work"]
+
+
+def test_parse_skips_metrics_with_no_qty():
+    payload = {
+        "data": {
+            "metrics": [
+                {
+                    "name": "step_count",
+                    "data": [{"date": "2026-04-29 00:00:00 +1000", "source": "iPhone"}],
+                }
+            ]
+        }
+    }
+    result = parse_health_payload(payload)
+    assert result["health_metrics"] == []
 
 
 def test_ingest_health_stores_metrics(client, db):

--- a/bede-data/tests/test_ingest_health.py
+++ b/bede-data/tests/test_ingest_health.py
@@ -1,4 +1,5 @@
 from bede_data.config import settings
+from bede_data.ingest.health_parser import parse_health_payload
 
 
 def test_ingest_health_rejects_missing_token(client):
@@ -24,9 +25,6 @@ def test_ingest_health_accepts_valid_token(client):
         headers={"Authorization": "Bearer correct-token"},
     )
     assert response.status_code == 200
-
-
-from bede_data.ingest.health_parser import parse_health_payload
 
 
 def test_parse_basic_metrics():

--- a/bede-data/tests/test_ingest_health.py
+++ b/bede-data/tests/test_ingest_health.py
@@ -128,6 +128,36 @@ def test_parse_sleep_aggregated():
     assert result["sleep_phases"][0]["date"] == "2026-04-29"
 
 
+def test_parse_sleep_data_entries_as_analyses():
+    """When no aggregatedSleepAnalyses or sleepAnalyses exist, data[] entries
+    themselves may contain named stage fields."""
+    payload = {
+        "data": {
+            "metrics": [
+                {
+                    "name": "sleep_analysis",
+                    "data": [
+                        {
+                            "date": "2026-04-29 07:00:00 +1000",
+                            "source": "Apple Watch",
+                            "sleepStart": "2026-04-28 23:00:00 +1000",
+                            "sleepEnd": "2026-04-29 07:00:00 +1000",
+                            "core": 3.0,
+                            "deep": 1.5,
+                            "rem": 2.0,
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+    result = parse_health_payload(payload)
+    phases = {p["phase"]: p["hours"] for p in result["sleep_phases"]}
+    assert phases["core"] == 3.0
+    assert phases["deep"] == 1.5
+    assert phases["rem"] == 2.0
+
+
 def test_parse_workouts_dict_fields():
     payload = {
         "data": {

--- a/bede-data/tests/test_ingest_health.py
+++ b/bede-data/tests/test_ingest_health.py
@@ -1,0 +1,238 @@
+from bede_data.config import settings
+
+
+def test_ingest_health_rejects_missing_token(client):
+    response = client.post("/ingest/health", json={})
+    assert response.status_code == 401
+
+
+def test_ingest_health_rejects_bad_token(client):
+    settings.ingest_write_token = "correct-token"
+    response = client.post(
+        "/ingest/health",
+        json={},
+        headers={"Authorization": "Bearer wrong-token"},
+    )
+    assert response.status_code == 401
+
+
+def test_ingest_health_accepts_valid_token(client):
+    settings.ingest_write_token = "correct-token"
+    response = client.post(
+        "/ingest/health",
+        json={"data": {"metrics": []}},
+        headers={"Authorization": "Bearer correct-token"},
+    )
+    assert response.status_code == 200
+
+
+from bede_data.ingest.health_parser import parse_health_payload
+
+
+def test_parse_basic_metrics():
+    payload = {
+        "data": {
+            "metrics": [
+                {
+                    "name": "step_count",
+                    "data": [
+                        {
+                            "date": "2026-04-29 00:00:00 +1000",
+                            "qty": 8500,
+                            "source": "iPhone",
+                        }
+                    ],
+                },
+                {
+                    "name": "active_energy",
+                    "data": [
+                        {
+                            "date": "2026-04-29 00:00:00 +1000",
+                            "qty": 2100.5,
+                            "source": "Apple Watch",
+                        }
+                    ],
+                },
+            ]
+        }
+    }
+    result = parse_health_payload(payload)
+    assert len(result["health_metrics"]) == 2
+    assert result["health_metrics"][0]["metric"] == "step_count"
+    assert result["health_metrics"][0]["value"] == 8500
+    assert result["health_metrics"][0]["date"] == "2026-04-29"
+    assert result["health_metrics"][0]["source"] == "iPhone"
+
+
+def test_parse_sleep_analysis():
+    payload = {
+        "data": {
+            "metrics": [
+                {
+                    "name": "sleep_analysis",
+                    "data": [
+                        {
+                            "date": "2026-04-29 00:00:00 +1000",
+                            "source": "Apple Watch",
+                            "sleepAnalysis": [
+                                {
+                                    "value": "HKCategoryValueSleepAnalysis.asleepCore",
+                                    "startDate": "2026-04-28 23:00:00 +1000",
+                                    "endDate": "2026-04-29 01:30:00 +1000",
+                                },
+                                {
+                                    "value": "HKCategoryValueSleepAnalysis.asleepDeep",
+                                    "startDate": "2026-04-29 01:30:00 +1000",
+                                    "endDate": "2026-04-29 03:00:00 +1000",
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+    result = parse_health_payload(payload)
+    assert len(result["sleep_phases"]) == 2
+    assert result["sleep_phases"][0]["phase"] == "asleepCore"
+    assert result["sleep_phases"][0]["hours"] == 2.5
+    assert result["sleep_phases"][1]["phase"] == "asleepDeep"
+    assert result["sleep_phases"][1]["hours"] == 1.5
+
+
+def test_parse_workouts():
+    payload = {
+        "data": {
+            "workouts": [
+                {
+                    "name": "Running",
+                    "start": "2026-04-29 07:00:00 +1000",
+                    "end": "2026-04-29 07:45:00 +1000",
+                    "activeEnergy": {"qty": 1800, "units": "kJ"},
+                    "avgHeartRate": {"qty": 155, "units": "bpm"},
+                    "maxHeartRate": {"qty": 178, "units": "bpm"},
+                }
+            ]
+        }
+    }
+    result = parse_health_payload(payload)
+    assert len(result["workouts"]) == 1
+    assert result["workouts"][0]["workout_type"] == "Running"
+    assert result["workouts"][0]["duration_minutes"] == 45.0
+    assert result["workouts"][0]["active_energy_kj"] == 1800
+
+
+def test_parse_medications():
+    payload = {
+        "data": {
+            "metrics": [
+                {
+                    "name": "medication_record",
+                    "data": [
+                        {
+                            "date": "2026-04-29 08:00:00 +1000",
+                            "medication": "Lexapro",
+                            "qty": 1,
+                            "unit": "tablet",
+                            "source": "Health",
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+    result = parse_health_payload(payload)
+    assert len(result["medications"]) == 1
+    assert result["medications"][0]["medication"] == "Lexapro"
+    assert result["medications"][0]["quantity"] == 1
+
+
+def test_parse_state_of_mind():
+    payload = {
+        "data": {
+            "metrics": [
+                {
+                    "name": "state_of_mind",
+                    "data": [
+                        {
+                            "date": "2026-04-29 14:00:00 +1000",
+                            "valence": 0.7,
+                            "labels": "Happy,Calm",
+                            "context": "Work",
+                            "associations": "Productivity",
+                            "source": "Health",
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+    result = parse_health_payload(payload)
+    assert len(result["state_of_mind"]) == 1
+    assert result["state_of_mind"][0]["valence"] == 0.7
+    assert result["state_of_mind"][0]["labels"] == "Happy,Calm"
+
+
+def test_ingest_health_stores_metrics(client, db):
+    settings.ingest_write_token = "test-token"
+    payload = {
+        "data": {
+            "metrics": [
+                {
+                    "name": "step_count",
+                    "data": [
+                        {
+                            "date": "2026-04-29 00:00:00 +1000",
+                            "qty": 8500,
+                            "source": "iPhone",
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+    response = client.post(
+        "/ingest/health",
+        json=payload,
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["records"] > 0
+
+    cursor = db.execute("SELECT * FROM health_metrics WHERE date = '2026-04-29'")
+    rows = cursor.fetchall()
+    assert len(rows) == 1
+    assert rows[0]["metric"] == "step_count"
+    assert rows[0]["value"] == 8500
+
+
+def test_ingest_health_upserts_on_duplicate(client, db):
+    settings.ingest_write_token = "test-token"
+    headers = {"Authorization": "Bearer test-token"}
+    payload = {
+        "data": {
+            "metrics": [
+                {
+                    "name": "step_count",
+                    "data": [
+                        {
+                            "date": "2026-04-29 00:00:00 +1000",
+                            "qty": 8500,
+                            "source": "iPhone",
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+    client.post("/ingest/health", json=payload, headers=headers)
+
+    payload["data"]["metrics"][0]["data"][0]["qty"] = 9500
+    response = client.post("/ingest/health", json=payload, headers=headers)
+    assert response.status_code == 200
+
+    cursor = db.execute("SELECT * FROM health_metrics WHERE date = '2026-04-29'")
+    rows = cursor.fetchall()
+    assert len(rows) == 1
+    assert rows[0]["value"] == 9500

--- a/bede-data/tests/test_ingest_health.py
+++ b/bede-data/tests/test_ingest_health.py
@@ -348,3 +348,94 @@ def test_ingest_health_upserts_on_duplicate(client, db):
     rows = cursor.fetchall()
     assert len(rows) == 1
     assert rows[0]["value"] == 9500
+
+
+def test_parse_metric_avg_fallback():
+    """Unsummarised metrics (e.g. heart_rate) use Avg/Min/Max instead of qty."""
+    payload = {
+        "data": {
+            "metrics": [
+                {
+                    "name": "heart_rate",
+                    "units": "bpm",
+                    "data": [
+                        {
+                            "date": "2026-04-29 08:30:00 +1000",
+                            "Avg": 72,
+                            "Min": 60,
+                            "Max": 85,
+                            "source": "Apple Watch",
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+    result = parse_health_payload(payload)
+    assert len(result["health_metrics"]) == 1
+    assert result["health_metrics"][0]["metric"] == "heart_rate"
+    assert result["health_metrics"][0]["value"] == 72
+    assert result["health_metrics"][0]["source"] == "Apple Watch"
+
+
+def test_parse_sleep_unsummarised_phase_records():
+    """Unsummarised sleep: data[] entries that ARE phase records with value/qty."""
+    payload = {
+        "data": {
+            "metrics": [
+                {
+                    "name": "sleep_analysis",
+                    "data": [
+                        {
+                            "date": "2026-04-29 07:00:00 +1000",
+                            "value": "HKCategoryValueSleepAnalysis.asleepCore",
+                            "qty": 3.2,
+                            "startDate": "2026-04-28 23:00:00 +1000",
+                            "endDate": "2026-04-29 02:12:00 +1000",
+                            "source": "Apple Watch",
+                        },
+                        {
+                            "date": "2026-04-29 07:00:00 +1000",
+                            "value": "HKCategoryValueSleepAnalysis.asleepDeep",
+                            "qty": 1.5,
+                            "startDate": "2026-04-29 02:12:00 +1000",
+                            "endDate": "2026-04-29 03:42:00 +1000",
+                            "source": "Apple Watch",
+                        },
+                    ],
+                }
+            ]
+        }
+    }
+    result = parse_health_payload(payload)
+    phases = {p["phase"]: p for p in result["sleep_phases"]}
+    assert "asleepCore" in phases
+    assert phases["asleepCore"]["hours"] == 3.2
+    assert "asleepDeep" in phases
+    assert phases["asleepDeep"]["hours"] == 1.5
+
+
+def test_parse_sleep_unsummarised_no_qty_uses_duration():
+    """Unsummarised sleep without qty falls back to calculating hours from start/end."""
+    payload = {
+        "data": {
+            "metrics": [
+                {
+                    "name": "sleep_analysis",
+                    "data": [
+                        {
+                            "date": "2026-04-29 07:00:00 +1000",
+                            "value": "HKCategoryValueSleepAnalysis.asleepREM",
+                            "startDate": "2026-04-29 03:00:00 +1000",
+                            "endDate": "2026-04-29 05:00:00 +1000",
+                            "source": "Apple Watch",
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+    result = parse_health_payload(payload)
+    assert len(result["sleep_phases"]) == 1
+    assert result["sleep_phases"][0]["phase"] == "asleepREM"
+    assert result["sleep_phases"][0]["hours"] == 2.0

--- a/bede-data/tests/test_ingest_vault.py
+++ b/bede-data/tests/test_ingest_vault.py
@@ -1,0 +1,171 @@
+from bede_data.config import settings
+from bede_data.ingest.vault_parser import parse_vault_payload
+
+
+def test_parse_screen_time_csv():
+    payload = {
+        "date": "2026-04-29",
+        "files": {
+            "screentime.csv": (
+                "device,entry_type,name,seconds\n"
+                "mac,app,Safari,3600\n"
+                "mac,app,Terminal,1800\n"
+                "mac,web,github.com,900\n"
+            ),
+        },
+    }
+    result = parse_vault_payload(payload)
+    assert len(result["screen_time"]) == 3
+    assert result["screen_time"][0]["device"] == "mac"
+    assert result["screen_time"][0]["name"] == "Safari"
+    assert result["screen_time"][0]["seconds"] == 3600
+
+
+def test_parse_iphone_screen_time_csv():
+    payload = {
+        "date": "2026-04-29",
+        "files": {
+            "iphone-screentime.csv": (
+                "device,entry_type,name,seconds\n"
+                "iphone,app,Instagram,2400\n"
+            ),
+        },
+    }
+    result = parse_vault_payload(payload)
+    assert len(result["screen_time"]) == 1
+    assert result["screen_time"][0]["device"] == "iphone"
+
+
+def test_parse_safari_csv():
+    payload = {
+        "date": "2026-04-29",
+        "files": {
+            "safari.csv": (
+                "device,domain,title,url,visited_at\n"
+                'mac,github.com,GitHub,https://github.com,2026-04-29T10:00:00Z\n'
+            ),
+        },
+    }
+    result = parse_vault_payload(payload)
+    assert len(result["safari_history"]) == 1
+    assert result["safari_history"][0]["domain"] == "github.com"
+    assert result["safari_history"][0]["url"] == "https://github.com"
+
+
+def test_parse_youtube_csv():
+    payload = {
+        "date": "2026-04-29",
+        "files": {
+            "youtube.csv": (
+                "title,url,visited_at\n"
+                "Cool Video,https://youtube.com/watch?v=abc,2026-04-29T14:00:00Z\n"
+            ),
+        },
+    }
+    result = parse_vault_payload(payload)
+    assert len(result["youtube_history"]) == 1
+    assert result["youtube_history"][0]["title"] == "Cool Video"
+
+
+def test_parse_podcasts_csv():
+    payload = {
+        "date": "2026-04-29",
+        "files": {
+            "podcasts.csv": (
+                "podcast,episode,duration_seconds,played_at\n"
+                "The Daily,Episode 123,1800,2026-04-29T08:00:00Z\n"
+            ),
+        },
+    }
+    result = parse_vault_payload(payload)
+    assert len(result["podcasts"]) == 1
+    assert result["podcasts"][0]["podcast"] == "The Daily"
+    assert result["podcasts"][0]["duration_seconds"] == 1800
+
+
+def test_parse_claude_sessions_markdown():
+    payload = {
+        "date": "2026-04-29",
+        "files": {
+            "claude-sessions.md": (
+                "## home-server-stack\n"
+                "- Start: 2026-04-29 09:00\n"
+                "- End: 2026-04-29 10:30\n"
+                "- Duration: 90 min\n"
+                "- Turns: 25\n"
+                "\n"
+                "Worked on Bede implementation plan.\n"
+            ),
+        },
+    }
+    result = parse_vault_payload(payload)
+    assert len(result["claude_sessions"]) == 1
+    assert result["claude_sessions"][0]["project"] == "home-server-stack"
+    assert result["claude_sessions"][0]["duration_min"] == 90
+
+
+def test_parse_empty_files():
+    payload = {"date": "2026-04-29", "files": {}}
+    result = parse_vault_payload(payload)
+    assert result["screen_time"] == []
+    assert result["safari_history"] == []
+
+
+def test_ingest_vault_stores_data(client, db):
+    settings.ingest_write_token = "test-token"
+    payload = {
+        "date": "2026-04-29",
+        "files": {
+            "screentime.csv": (
+                "device,entry_type,name,seconds\n" "mac,app,Safari,3600\n"
+            ),
+        },
+    }
+    response = client.post(
+        "/ingest/vault",
+        json=payload,
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert response.status_code == 200
+    assert response.json()["records"] > 0
+
+    cursor = db.execute("SELECT * FROM screen_time WHERE date = '2026-04-29'")
+    rows = cursor.fetchall()
+    assert len(rows) == 1
+    assert rows[0]["name"] == "Safari"
+
+
+def test_ingest_vault_replaces_daily_data(client, db):
+    settings.ingest_write_token = "test-token"
+    headers = {"Authorization": "Bearer test-token"}
+
+    payload1 = {
+        "date": "2026-04-29",
+        "files": {
+            "screentime.csv": (
+                "device,entry_type,name,seconds\n"
+                "mac,app,Safari,3600\n"
+                "mac,app,Terminal,1200\n"
+            ),
+        },
+    }
+    client.post("/ingest/vault", json=payload1, headers=headers)
+
+    payload2 = {
+        "date": "2026-04-29",
+        "files": {
+            "screentime.csv": (
+                "device,entry_type,name,seconds\n" "mac,app,Safari,5400\n"
+            ),
+        },
+    }
+    response = client.post("/ingest/vault", json=payload2, headers=headers)
+    assert response.status_code == 200
+
+    cursor = db.execute(
+        "SELECT * FROM screen_time WHERE date = '2026-04-29' AND device = 'mac'"
+    )
+    rows = cursor.fetchall()
+    assert len(rows) == 1
+    assert rows[0]["name"] == "Safari"
+    assert rows[0]["seconds"] == 5400

--- a/bede-data/tests/test_ingest_vault.py
+++ b/bede-data/tests/test_ingest_vault.py
@@ -26,8 +26,7 @@ def test_parse_iphone_screen_time_csv():
         "date": "2026-04-29",
         "files": {
             "iphone-screentime.csv": (
-                "device,entry_type,name,seconds\n"
-                "iphone,app,Instagram,2400\n"
+                "device,entry_type,name,seconds\niphone,app,Instagram,2400\n"
             ),
         },
     }
@@ -42,7 +41,7 @@ def test_parse_safari_csv():
         "files": {
             "safari.csv": (
                 "device,domain,title,url,visited_at\n"
-                'mac,github.com,GitHub,https://github.com,2026-04-29T10:00:00Z\n'
+                "mac,github.com,GitHub,https://github.com,2026-04-29T10:00:00Z\n"
             ),
         },
     }
@@ -116,9 +115,7 @@ def test_ingest_vault_stores_data(client, db):
     payload = {
         "date": "2026-04-29",
         "files": {
-            "screentime.csv": (
-                "device,entry_type,name,seconds\n" "mac,app,Safari,3600\n"
-            ),
+            "screentime.csv": ("device,entry_type,name,seconds\nmac,app,Safari,3600\n"),
         },
     }
     response = client.post(
@@ -154,9 +151,7 @@ def test_ingest_vault_replaces_daily_data(client, db):
     payload2 = {
         "date": "2026-04-29",
         "files": {
-            "screentime.csv": (
-                "device,entry_type,name,seconds\n" "mac,app,Safari,5400\n"
-            ),
+            "screentime.csv": ("device,entry_type,name,seconds\nmac,app,Safari,5400\n"),
         },
     }
     response = client.post("/ingest/vault", json=payload2, headers=headers)

--- a/bede-data/tests/test_live_location.py
+++ b/bede-data/tests/test_live_location.py
@@ -1,0 +1,69 @@
+import math
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from bede_data.live.location import (
+    GeoCache,
+    cluster_points,
+    haversine_m,
+)
+
+
+def test_haversine_same_point():
+    assert haversine_m(-33.8688, 151.2093, -33.8688, 151.2093) == 0.0
+
+
+def test_haversine_known_distance():
+    d = haversine_m(-33.8688, 151.2093, -33.8704, 151.2069)
+    assert 200 < d < 400
+
+
+def test_cluster_points_single_cluster():
+    points = [
+        {"lat": -33.8688, "lon": 151.2093, "tst": 1000},
+        {"lat": -33.8689, "lon": 151.2094, "tst": 1060},
+        {"lat": -33.8687, "lon": 151.2092, "tst": 1120},
+    ]
+    clusters = cluster_points(points, radius_m=200, gap_seconds=300)
+    assert len(clusters) == 1
+    assert clusters[0]["point_count"] == 3
+    assert clusters[0]["arrived_tst"] == 1000
+    assert clusters[0]["departed_tst"] == 1120
+
+
+def test_cluster_points_multiple_clusters():
+    points = [
+        {"lat": -33.8688, "lon": 151.2093, "tst": 1000},
+        {"lat": -33.8689, "lon": 151.2094, "tst": 1060},
+        {"lat": -33.9000, "lon": 151.2500, "tst": 2000},
+        {"lat": -33.9001, "lon": 151.2501, "tst": 2060},
+    ]
+    clusters = cluster_points(points, radius_m=200, gap_seconds=300)
+    assert len(clusters) == 2
+
+
+def test_cluster_points_time_gap_splits():
+    points = [
+        {"lat": -33.8688, "lon": 151.2093, "tst": 1000},
+        {"lat": -33.8689, "lon": 151.2094, "tst": 2000},
+    ]
+    clusters = cluster_points(points, radius_m=200, gap_seconds=300)
+    assert len(clusters) == 2
+
+
+def test_geocache_stores_and_retrieves():
+    cache = GeoCache()
+    cache.put(-33.8688, 151.2093, "Sydney Opera House")
+    assert cache.get(-33.8688, 151.2093) == "Sydney Opera House"
+
+
+def test_geocache_rounds_coordinates():
+    cache = GeoCache()
+    cache.put(-33.86881234, 151.20931234, "Sydney Opera House")
+    assert cache.get(-33.86889999, 151.20939999) == "Sydney Opera House"
+
+
+def test_geocache_miss():
+    cache = GeoCache()
+    assert cache.get(-33.8688, 151.2093) is None

--- a/bede-data/tests/test_live_location.py
+++ b/bede-data/tests/test_live_location.py
@@ -1,8 +1,3 @@
-import math
-from unittest.mock import AsyncMock, patch
-
-import pytest
-
 from bede_data.live.location import (
     GeoCache,
     cluster_points,

--- a/bede-data/tests/test_live_weather.py
+++ b/bede-data/tests/test_live_weather.py
@@ -1,0 +1,50 @@
+from unittest.mock import AsyncMock, patch
+
+import httpx
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_fetch_weather():
+    from bede_data.live.weather import fetch_weather
+
+    mock_response = httpx.Response(
+        200,
+        json={
+            "current": {"temp_c": 22, "condition": "Sunny"},
+            "forecast": [{"date": "2026-04-29", "max": 25, "min": 15}],
+        },
+        request=httpx.Request("GET", "http://test"),
+    )
+    with patch("bede_data.live.weather.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client
+
+        result = await fetch_weather()
+        assert result["current"]["temp_c"] == 22
+
+
+@pytest.mark.asyncio
+async def test_fetch_air_quality():
+    from bede_data.live.air_quality import fetch_air_quality
+
+    mock_response = httpx.Response(
+        200,
+        json={
+            "aqi": 42,
+            "category": "Good",
+        },
+        request=httpx.Request("GET", "http://test"),
+    )
+    with patch("bede_data.live.air_quality.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+        mock_client_cls.return_value = mock_client
+
+        result = await fetch_air_quality()
+        assert result["aqi"] == 42

--- a/bede-data/tests/test_retention.py
+++ b/bede-data/tests/test_retention.py
@@ -5,9 +5,17 @@ def test_retention_cleanup(client, db):
     old_date = (datetime.now(timezone.utc) - timedelta(days=100)).strftime("%Y-%m-%d")
     recent_date = (datetime.now(timezone.utc) - timedelta(days=5)).strftime("%Y-%m-%d")
 
-    db.execute("INSERT INTO health_metrics (date, metric, value, source) VALUES (?, 'steps', 8000, 'test')", (old_date,))
-    db.execute("INSERT INTO health_metrics (date, metric, value, source) VALUES (?, 'steps', 9000, 'test')", (recent_date,))
-    db.execute("INSERT INTO retention_policies (data_type, retention_days) VALUES ('health_metrics', 90)")
+    db.execute(
+        "INSERT INTO health_metrics (date, metric, value, source) VALUES (?, 'steps', 8000, 'test')",
+        (old_date,),
+    )
+    db.execute(
+        "INSERT INTO health_metrics (date, metric, value, source) VALUES (?, 'steps', 9000, 'test')",
+        (recent_date,),
+    )
+    db.execute(
+        "INSERT INTO retention_policies (data_type, retention_days) VALUES ('health_metrics', 90)"
+    )
     db.commit()
 
     response = client.post("/api/retention/cleanup")

--- a/bede-data/tests/test_retention.py
+++ b/bede-data/tests/test_retention.py
@@ -1,0 +1,35 @@
+from datetime import datetime, timedelta, timezone
+
+
+def test_retention_cleanup(client, db):
+    old_date = (datetime.now(timezone.utc) - timedelta(days=100)).strftime("%Y-%m-%d")
+    recent_date = (datetime.now(timezone.utc) - timedelta(days=5)).strftime("%Y-%m-%d")
+
+    db.execute("INSERT INTO health_metrics (date, metric, value, source) VALUES (?, 'steps', 8000, 'test')", (old_date,))
+    db.execute("INSERT INTO health_metrics (date, metric, value, source) VALUES (?, 'steps', 9000, 'test')", (recent_date,))
+    db.execute("INSERT INTO retention_policies (data_type, retention_days) VALUES ('health_metrics', 90)")
+    db.commit()
+
+    response = client.post("/api/retention/cleanup")
+    assert response.status_code == 200
+    assert response.json()["rows_deleted"] > 0
+
+    cursor = db.execute("SELECT COUNT(*) as cnt FROM health_metrics")
+    assert cursor.fetchone()["cnt"] == 1
+
+
+def test_set_retention_policy(client):
+    response = client.put(
+        "/api/retention/policies/health_metrics",
+        json={"retention_days": 90},
+    )
+    assert response.status_code == 200
+    assert response.json()["data_type"] == "health_metrics"
+    assert response.json()["retention_days"] == 90
+
+
+def test_list_retention_policies(client):
+    client.put("/api/retention/policies/health_metrics", json={"retention_days": 90})
+    client.put("/api/retention/policies/task_executions", json={"retention_days": 30})
+    response = client.get("/api/retention/policies")
+    assert len(response.json()["policies"]) == 2

--- a/bede-data/uv.lock
+++ b/bede-data/uv.lock
@@ -1,0 +1,614 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "bede-data"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "fastapi" },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "httpx", specifier = ">=0.28.0" },
+    { name = "pydantic", specifier = ">=2.10.0" },
+    { name = "pydantic-settings", specifier = ">=2.7.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.25.0" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
+]
+provides-extras = ["dev"]
+
+[[package]]
+name = "certifi"
+version = "2026.4.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/ee/6caf7a40c36a1220410afe15a1cc64993a1f864871f698c0f93acb72842a/certifi-2026.4.22.tar.gz", hash = "sha256:8d455352a37b71bf76a79caa83a3d6c25afee4a385d632127b6afb3963f1c580", size = 137077, upload-time = "2026-04-22T11:26:11.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl", hash = "sha256:3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a", size = 135707, upload-time = "2026-04-22T11:26:09.372Z" },
+]
+
+[[package]]
+name = "click"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "fastapi"
+version = "0.136.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/45/c130091c2dfa061bbfe3150f2a5091ef1adf149f2a8d2ae769ecaf6e99a2/fastapi-0.136.1.tar.gz", hash = "sha256:7af665ad7acfa0a3baf8983d393b6b471b9da10ede59c60045f49fbc89a0fa7f", size = 397448, upload-time = "2026-04-23T16:49:44.046Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl", hash = "sha256:a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f", size = 117683, upload-time = "2026-04-23T16:49:42.437Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httptools"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/46/120a669232c7bdedb9d52d4aeae7e6c7dfe151e99dc70802e2fc7a5e1993/httptools-0.7.1.tar.gz", hash = "sha256:abd72556974f8e7c74a259655924a717a2365b236c882c3f6f8a45fe94703ac9", size = 258961, upload-time = "2025-10-10T03:55:08.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/7f/403e5d787dc4942316e515e949b0c8a013d84078a915910e9f391ba9b3ed/httptools-0.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:38e0c83a2ea9746ebbd643bdfb521b9aa4a91703e2cd705c20443405d2fd16a5", size = 206280, upload-time = "2025-10-10T03:54:39.274Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0d/7f3fd28e2ce311ccc998c388dd1c53b18120fda3b70ebb022b135dc9839b/httptools-0.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f25bbaf1235e27704f1a7b86cd3304eabc04f569c828101d94a0e605ef7205a5", size = 110004, upload-time = "2025-10-10T03:54:40.403Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a6/b3965e1e146ef5762870bbe76117876ceba51a201e18cc31f5703e454596/httptools-0.7.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2c15f37ef679ab9ecc06bfc4e6e8628c32a8e4b305459de7cf6785acd57e4d03", size = 517655, upload-time = "2025-10-10T03:54:41.347Z" },
+    { url = "https://files.pythonhosted.org/packages/11/7d/71fee6f1844e6fa378f2eddde6c3e41ce3a1fb4b2d81118dd544e3441ec0/httptools-0.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fe6e96090df46b36ccfaf746f03034e5ab723162bc51b0a4cf58305324036f2", size = 511440, upload-time = "2025-10-10T03:54:42.452Z" },
+    { url = "https://files.pythonhosted.org/packages/22/a5/079d216712a4f3ffa24af4a0381b108aa9c45b7a5cc6eb141f81726b1823/httptools-0.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f72fdbae2dbc6e68b8239defb48e6a5937b12218e6ffc2c7846cc37befa84362", size = 495186, upload-time = "2025-10-10T03:54:43.937Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/025ad7b65278745dee3bd0ebf9314934c4592560878308a6121f7f812084/httptools-0.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e99c7b90a29fd82fea9ef57943d501a16f3404d7b9ee81799d41639bdaae412c", size = 499192, upload-time = "2025-10-10T03:54:45.003Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/de/40a8f202b987d43afc4d54689600ff03ce65680ede2f31df348d7f368b8f/httptools-0.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:3e14f530fefa7499334a79b0cf7e7cd2992870eb893526fb097d51b4f2d0f321", size = 86694, upload-time = "2025-10-10T03:54:45.923Z" },
+    { url = "https://files.pythonhosted.org/packages/09/8f/c77b1fcbfd262d422f12da02feb0d218fa228d52485b77b953832105bb90/httptools-0.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:6babce6cfa2a99545c60bfef8bee0cc0545413cb0018f617c8059a30ad985de3", size = 202889, upload-time = "2025-10-10T03:54:47.089Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1a/22887f53602feaa066354867bc49a68fc295c2293433177ee90870a7d517/httptools-0.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:601b7628de7504077dd3dcb3791c6b8694bbd967148a6d1f01806509254fb1ca", size = 108180, upload-time = "2025-10-10T03:54:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/32/6a/6aaa91937f0010d288d3d124ca2946d48d60c3a5ee7ca62afe870e3ea011/httptools-0.7.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:04c6c0e6c5fb0739c5b8a9eb046d298650a0ff38cf42537fc372b28dc7e4472c", size = 478596, upload-time = "2025-10-10T03:54:48.919Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/70/023d7ce117993107be88d2cbca566a7c1323ccbaf0af7eabf2064fe356f6/httptools-0.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:69d4f9705c405ae3ee83d6a12283dc9feba8cc6aaec671b412917e644ab4fa66", size = 473268, upload-time = "2025-10-10T03:54:49.993Z" },
+    { url = "https://files.pythonhosted.org/packages/32/4d/9dd616c38da088e3f436e9a616e1d0cc66544b8cdac405cc4e81c8679fc7/httptools-0.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:44c8f4347d4b31269c8a9205d8a5ee2df5322b09bbbd30f8f862185bb6b05346", size = 455517, upload-time = "2025-10-10T03:54:51.066Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/3a/a6c595c310b7df958e739aae88724e24f9246a514d909547778d776799be/httptools-0.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:465275d76db4d554918aba40bf1cbebe324670f3dfc979eaffaa5d108e2ed650", size = 458337, upload-time = "2025-10-10T03:54:52.196Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/82/88e8d6d2c51edc1cc391b6e044c6c435b6aebe97b1abc33db1b0b24cd582/httptools-0.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:322d00c2068d125bd570f7bf78b2d367dad02b919d8581d7476d8b75b294e3e6", size = 85743, upload-time = "2025-10-10T03:54:53.448Z" },
+    { url = "https://files.pythonhosted.org/packages/34/50/9d095fcbb6de2d523e027a2f304d4551855c2f46e0b82befd718b8b20056/httptools-0.7.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:c08fe65728b8d70b6923ce31e3956f859d5e1e8548e6f22ec520a962c6757270", size = 203619, upload-time = "2025-10-10T03:54:54.321Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f0/89720dc5139ae54b03f861b5e2c55a37dba9a5da7d51e1e824a1f343627f/httptools-0.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7aea2e3c3953521c3c51106ee11487a910d45586e351202474d45472db7d72d3", size = 108714, upload-time = "2025-10-10T03:54:55.163Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/cb/eea88506f191fb552c11787c23f9a405f4c7b0c5799bf73f2249cd4f5228/httptools-0.7.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0e68b8582f4ea9166be62926077a3334064d422cf08ab87d8b74664f8e9058e1", size = 472909, upload-time = "2025-10-10T03:54:56.056Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/4a/a548bdfae6369c0d078bab5769f7b66f17f1bfaa6fa28f81d6be6959066b/httptools-0.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:df091cf961a3be783d6aebae963cc9b71e00d57fa6f149025075217bc6a55a7b", size = 470831, upload-time = "2025-10-10T03:54:57.219Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/31/14df99e1c43bd132eec921c2e7e11cda7852f65619bc0fc5bdc2d0cb126c/httptools-0.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f084813239e1eb403ddacd06a30de3d3e09a9b76e7894dcda2b22f8a726e9c60", size = 452631, upload-time = "2025-10-10T03:54:58.219Z" },
+    { url = "https://files.pythonhosted.org/packages/22/d2/b7e131f7be8d854d48cb6d048113c30f9a46dca0c9a8b08fcb3fcd588cdc/httptools-0.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7347714368fb2b335e9063bc2b96f2f87a9ceffcd9758ac295f8bbcd3ffbc0ca", size = 452910, upload-time = "2025-10-10T03:54:59.366Z" },
+    { url = "https://files.pythonhosted.org/packages/53/cf/878f3b91e4e6e011eff6d1fa9ca39f7eb17d19c9d7971b04873734112f30/httptools-0.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:cfabda2a5bb85aa2a904ce06d974a3f30fb36cc63d7feaddec05d2050acede96", size = 88205, upload-time = "2025-10-10T03:55:00.389Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/e4/40d09941a2cebcb20609b86a559817d5b9291c49dd6f8c87e5feffbe703a/pydantic-2.13.3.tar.gz", hash = "sha256:af09e9d1d09f4e7fe37145c1f577e1d61ceb9a41924bf0094a36506285d0a84d", size = 844068, upload-time = "2026-04-20T14:46:43.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/0a/fd7d723f8f8153418fb40cf9c940e82004fce7e987026b08a68a36dd3fe7/pydantic-2.13.3-py3-none-any.whl", hash = "sha256:6db14ac8dfc9a1e57f87ea2c0de670c251240f43cb0c30a5130e9720dc612927", size = 471981, upload-time = "2026-04-20T14:46:41.402Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2a/ef/f7abb56c49382a246fd2ce9c799691e3c3e7175ec74b14d99e798bcddb1a/pydantic_core-2.46.3.tar.gz", hash = "sha256:41c178f65b8c29807239d47e6050262eb6bf84eb695e41101e62e38df4a5bc2c", size = 471412, upload-time = "2026-04-20T14:40:56.672Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/cb/5b47425556ecc1f3fe18ed2a0083188aa46e1dd812b06e406475b3a5d536/pydantic_core-2.46.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b11b59b3eee90a80a36701ddb4576d9ae31f93f05cb9e277ceaa09e6bf074a67", size = 2101946, upload-time = "2026-04-20T14:40:52.581Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/4f/2fb62c2267cae99b815bbf4a7b9283812c88ca3153ef29f7707200f1d4e5/pydantic_core-2.46.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:af8653713055ea18a3abc1537fe2ebc42f5b0bbb768d1eb79fd74eb47c0ac089", size = 1951612, upload-time = "2026-04-20T14:42:42.996Z" },
+    { url = "https://files.pythonhosted.org/packages/50/6e/b7348fd30d6556d132cddd5bd79f37f96f2601fe0608afac4f5fb01ec0b3/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:75a519dab6d63c514f3a81053e5266c549679e4aa88f6ec57f2b7b854aceb1b0", size = 1977027, upload-time = "2026-04-20T14:42:02.001Z" },
+    { url = "https://files.pythonhosted.org/packages/82/11/31d60ee2b45540d3fb0b29302a393dbc01cd771c473f5b5147bcd353e593/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6cd87cb1575b1ad05ba98894c5b5c96411ef678fa2f6ed2576607095b8d9789", size = 2063008, upload-time = "2026-04-20T14:44:17.952Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/db/3a9d1957181b59258f44a2300ab0f0be9d1e12d662a4f57bb31250455c52/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f80a55484b8d843c8ada81ebf70a682f3f00a3d40e378c06cf17ecb44d280d7d", size = 2233082, upload-time = "2026-04-20T14:40:57.934Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/e1/3277c38792aeb5cfb18c2f0c5785a221d9ff4e149abbe1184d53d5f72273/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3861f1731b90c50a3266316b9044f5c9b405eecb8e299b0a7120596334e4fe9c", size = 2304615, upload-time = "2026-04-20T14:42:12.584Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/d5/e3d9717c9eba10855325650afd2a9cba8e607321697f18953af9d562da2f/pydantic_core-2.46.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb528e295ed31570ac3dcc9bfdd6e0150bc11ce6168ac87a8082055cf1a67395", size = 2094380, upload-time = "2026-04-20T14:43:05.522Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/20/abac35dedcbfd66c6f0b03e4e3564511771d6c9b7ede10a362d03e110d9b/pydantic_core-2.46.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:367508faa4973b992b271ba1494acaab36eb7e8739d1e47be5035fb1ea225396", size = 2135429, upload-time = "2026-04-20T14:41:55.549Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a5/41bfd1df69afad71b5cf0535055bccc73022715ad362edbc124bc1e021d7/pydantic_core-2.46.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5ad3c826fe523e4becf4fe39baa44286cff85ef137c729a2c5e269afbfd0905d", size = 2174582, upload-time = "2026-04-20T14:41:45.96Z" },
+    { url = "https://files.pythonhosted.org/packages/79/65/38d86ea056b29b2b10734eb23329b7a7672ca604df4f2b6e9c02d4ee22fe/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:ec638c5d194ef8af27db69f16c954a09797c0dc25015ad6123eb2c73a4d271ca", size = 2187533, upload-time = "2026-04-20T14:40:55.367Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/55/a1129141678a2026badc539ad1dee0a71d06f54c2f06a4bd68c030ac781b/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:28ed528c45446062ee66edb1d33df5d88828ae167de76e773a3c7f64bd14e976", size = 2332985, upload-time = "2026-04-20T14:44:13.05Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/60/cb26f4077719f709e54819f4e8e1d43f4091f94e285eb6bd21e1190a7b7c/pydantic_core-2.46.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aed19d0c783886d5bd86d80ae5030006b45e28464218747dcf83dabfdd092c7b", size = 2373670, upload-time = "2026-04-20T14:41:53.421Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/7e/c3f21882bdf1d8d086876f81b5e296206c69c6082551d776895de7801fa0/pydantic_core-2.46.3-cp312-cp312-win32.whl", hash = "sha256:06d5d8820cbbdb4147578c1fe7ffcd5b83f34508cb9f9ab76e807be7db6ff0a4", size = 1966722, upload-time = "2026-04-20T14:44:30.588Z" },
+    { url = "https://files.pythonhosted.org/packages/57/be/6b5e757b859013ebfbd7adba02f23b428f37c86dcbf78b5bb0b4ffd36e99/pydantic_core-2.46.3-cp312-cp312-win_amd64.whl", hash = "sha256:c3212fda0ee959c1dd04c60b601ec31097aaa893573a3a1abd0a47bcac2968c1", size = 2072970, upload-time = "2026-04-20T14:42:54.248Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f8/a989b21cc75e9a32d24192ef700eea606521221a89faa40c919ce884f2b1/pydantic_core-2.46.3-cp312-cp312-win_arm64.whl", hash = "sha256:f1f8338dd7a7f31761f1f1a3c47503a9a3b34eea3c8b01fa6ee96408affb5e72", size = 2035963, upload-time = "2026-04-20T14:44:20.4Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/3c/9b5e8eb9821936d065439c3b0fb1490ffa64163bfe7e1595985a47896073/pydantic_core-2.46.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:12bc98de041458b80c86c56b24df1d23832f3e166cbaff011f25d187f5c62c37", size = 2102109, upload-time = "2026-04-20T14:41:24.219Z" },
+    { url = "https://files.pythonhosted.org/packages/91/97/1c41d1f5a19f241d8069f1e249853bcce378cdb76eec8ab636d7bc426280/pydantic_core-2.46.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:85348b8f89d2c3508b65b16c3c33a4da22b8215138d8b996912bb1532868885f", size = 1951820, upload-time = "2026-04-20T14:42:14.236Z" },
+    { url = "https://files.pythonhosted.org/packages/30/b4/d03a7ae14571bc2b6b3c7b122441154720619afe9a336fa3a95434df5e2f/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1105677a6df914b1fb71a81b96c8cce7726857e1717d86001f29be06a25ee6f8", size = 1977785, upload-time = "2026-04-20T14:42:31.648Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/0c/4086f808834b59e3c8f1aa26df8f4b6d998cdcf354a143d18ef41529d1fe/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:87082cd65669a33adeba5470769e9704c7cf026cc30afb9cc77fd865578ebaad", size = 2062761, upload-time = "2026-04-20T14:40:37.093Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/71/a649be5a5064c2df0db06e0a512c2281134ed2fcc981f52a657936a7527c/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:60e5f66e12c4f5212d08522963380eaaeac5ebd795826cfd19b2dfb0c7a52b9c", size = 2232989, upload-time = "2026-04-20T14:42:59.254Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/84/7756e75763e810b3a710f4724441d1ecc5883b94aacb07ca71c5fb5cfb69/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b6cdf19bf84128d5e7c37e8a73a0c5c10d51103a650ac585d42dd6ae233f2b7f", size = 2303975, upload-time = "2026-04-20T14:41:32.287Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/35/68a762e0c1e31f35fa0dac733cbd9f5b118042853698de9509c8e5bf128b/pydantic_core-2.46.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:031bb17f4885a43773c8c763089499f242aee2ea85cf17154168775dccdecf35", size = 2095325, upload-time = "2026-04-20T14:42:47.685Z" },
+    { url = "https://files.pythonhosted.org/packages/77/bf/1bf8c9a8e91836c926eae5e3e51dce009bf495a60ca56060689d3df3f340/pydantic_core-2.46.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:bcf2a8b2982a6673693eae7348ef3d8cf3979c1d63b54fca7c397a635cc68687", size = 2133368, upload-time = "2026-04-20T14:41:22.766Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/50/87d818d6bab915984995157ceb2380f5aac4e563dddbed6b56f0ed057aba/pydantic_core-2.46.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28e8cf2f52d72ced402a137145923a762cbb5081e48b34312f7a0c8f55928ec3", size = 2173908, upload-time = "2026-04-20T14:42:52.044Z" },
+    { url = "https://files.pythonhosted.org/packages/91/88/a311fb306d0bd6185db41fa14ae888fb81d0baf648a761ae760d30819d33/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:17eaface65d9fc5abb940003020309c1bf7a211f5f608d7870297c367e6f9022", size = 2186422, upload-time = "2026-04-20T14:43:29.55Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/79/28fd0d81508525ab2054fef7c77a638c8b5b0afcbbaeee493cf7c3fef7e1/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:93fd339f23408a07e98950a89644f92c54d8729719a40b30c0a30bb9ebc55d23", size = 2332709, upload-time = "2026-04-20T14:42:16.134Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/21/795bf5fe5c0f379308b8ef19c50dedab2e7711dbc8d0c2acf08f1c7daa05/pydantic_core-2.46.3-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:23cbdb3aaa74dfe0837975dbf69b469753bbde8eacace524519ffdb6b6e89eb7", size = 2372428, upload-time = "2026-04-20T14:41:10.974Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b3/ed14c659cbe7605e3ef063077680a64680aec81eb1a04763a05190d49b7f/pydantic_core-2.46.3-cp313-cp313-win32.whl", hash = "sha256:610eda2e3838f401105e6326ca304f5da1e15393ae25dacae5c5c63f2c275b13", size = 1965601, upload-time = "2026-04-20T14:41:42.128Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/bb/adb70d9a762ddd002d723fbf1bd492244d37da41e3af7b74ad212609027e/pydantic_core-2.46.3-cp313-cp313-win_amd64.whl", hash = "sha256:68cc7866ed863db34351294187f9b729964c371ba33e31c26f478471c52e1ed0", size = 2071517, upload-time = "2026-04-20T14:43:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/52/eb/66faefabebfe68bd7788339c9c9127231e680b11906368c67ce112fdb47f/pydantic_core-2.46.3-cp313-cp313-win_arm64.whl", hash = "sha256:f64b5537ac62b231572879cd08ec05600308636a5d63bcbdb15063a466977bec", size = 2035802, upload-time = "2026-04-20T14:43:38.507Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/db/a7bcb4940183fda36022cd18ba8dd12f2dff40740ec7b58ce7457befa416/pydantic_core-2.46.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:afa3aa644f74e290cdede48a7b0bee37d1c35e71b05105f6b340d484af536d9b", size = 2097614, upload-time = "2026-04-20T14:44:38.374Z" },
+    { url = "https://files.pythonhosted.org/packages/24/35/e4066358a22e3e99519db370494c7528f5a2aa1367370e80e27e20283543/pydantic_core-2.46.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ced3310e51aa425f7f77da8bbbb5212616655bedbe82c70944320bc1dbe5e018", size = 1951896, upload-time = "2026-04-20T14:40:53.996Z" },
+    { url = "https://files.pythonhosted.org/packages/87/92/37cf4049d1636996e4b888c05a501f40a43ff218983a551d57f9d5e14f0d/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e29908922ce9da1a30b4da490bd1d3d82c01dcfdf864d2a74aacee674d0bfa34", size = 1979314, upload-time = "2026-04-20T14:41:49.446Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/36/9ff4d676dfbdfb2d591cf43f3d90ded01e15b1404fd101180ed2d62a2fd3/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0c9ff69140423eea8ed2d5477df3ba037f671f5e897d206d921bc9fdc39613e7", size = 2056133, upload-time = "2026-04-20T14:42:23.574Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/f0/405b442a4d7ba855b06eec8b2bf9c617d43b8432d099dfdc7bf999293495/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b675ab0a0d5b1c8fdb81195dc5bcefea3f3c240871cdd7ff9a2de8aa50772eb2", size = 2228726, upload-time = "2026-04-20T14:44:22.816Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f8/65cd92dd5a0bd89ba277a98ecbfaf6fc36bbd3300973c7a4b826d6ab1391/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0087084960f209a9a4af50ecd1fb063d9ad3658c07bb81a7a53f452dacbfb2ba", size = 2301214, upload-time = "2026-04-20T14:44:48.792Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/86/ef96a4c6e79e7a2d0410826a68fbc0eccc0fd44aa733be199d5fcac3bb87/pydantic_core-2.46.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed42e6cc8e1b0e2b9b96e2276bad70ae625d10d6d524aed0c93de974ae029f9f", size = 2099927, upload-time = "2026-04-20T14:41:40.196Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/53/269caf30e0096e0a8a8f929d1982a27b3879872cca2d917d17c2f9fdf4fe/pydantic_core-2.46.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:f1771ce258afb3e4201e67d154edbbae712a76a6081079fe247c2f53c6322c22", size = 2128789, upload-time = "2026-04-20T14:41:15.868Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b0/1a6d9b6a587e118482910c244a1c5acf4d192604174132efd12bf0ac486f/pydantic_core-2.46.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a7610b6a5242a6c736d8ad47fd5fff87fcfe8f833b281b1c409c3d6835d9227f", size = 2173815, upload-time = "2026-04-20T14:44:25.152Z" },
+    { url = "https://files.pythonhosted.org/packages/87/56/e7e00d4041a7e62b5a40815590114db3b535bf3ca0bf4dca9f16cef25246/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:ff5e7783bcc5476e1db448bf268f11cb257b1c276d3e89f00b5727be86dd0127", size = 2181608, upload-time = "2026-04-20T14:41:28.933Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/22/4bd23c3d41f7c185d60808a1de83c76cf5aeabf792f6c636a55c3b1ec7f9/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:9d2e32edcc143bc01e95300671915d9ca052d4f745aa0a49c48d4803f8a85f2c", size = 2326968, upload-time = "2026-04-20T14:42:03.962Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ac/66cd45129e3915e5ade3b292cb3bc7fd537f58f8f8dbdaba6170f7cabb74/pydantic_core-2.46.3-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:6e42d83d1c6b87fa56b521479cff237e626a292f3b31b6345c15a99121b454c1", size = 2369842, upload-time = "2026-04-20T14:41:35.52Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/51/dd4248abb84113615473aa20d5545b7c4cd73c8644003b5259686f93996c/pydantic_core-2.46.3-cp314-cp314-win32.whl", hash = "sha256:07bc6d2a28c3adb4f7c6ae46aa4f2d2929af127f587ed44057af50bf1ce0f505", size = 1959661, upload-time = "2026-04-20T14:41:00.042Z" },
+    { url = "https://files.pythonhosted.org/packages/20/eb/59980e5f1ae54a3b86372bd9f0fa373ea2d402e8cdcd3459334430f91e91/pydantic_core-2.46.3-cp314-cp314-win_amd64.whl", hash = "sha256:8940562319bc621da30714617e6a7eaa6b98c84e8c685bcdc02d7ed5e7c7c44e", size = 2071686, upload-time = "2026-04-20T14:43:16.471Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/db/1cf77e5247047dfee34bc01fa9bca134854f528c8eb053e144298893d370/pydantic_core-2.46.3-cp314-cp314-win_arm64.whl", hash = "sha256:5dcbbcf4d22210ced8f837c96db941bdb078f419543472aca5d9a0bb7cddc7df", size = 2026907, upload-time = "2026-04-20T14:43:31.732Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c0/b3df9f6a543276eadba0a48487b082ca1f201745329d97dbfa287034a230/pydantic_core-2.46.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d0fe3dce1e836e418f912c1ad91c73357d03e556a4d286f441bf34fed2dbeecf", size = 2095047, upload-time = "2026-04-20T14:42:37.982Z" },
+    { url = "https://files.pythonhosted.org/packages/66/57/886a938073b97556c168fd99e1a7305bb363cd30a6d2c76086bf0587b32a/pydantic_core-2.46.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9ce92e58abc722dac1bf835a6798a60b294e48eb0e625ec9fd994b932ac5feee", size = 1934329, upload-time = "2026-04-20T14:43:49.655Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/7c/b42eaa5c34b13b07ecb51da21761297a9b8eb43044c864a035999998f328/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a03e6467f0f5ab796a486146d1b887b2dc5e5f9b3288898c1b1c3ad974e53e4a", size = 1974847, upload-time = "2026-04-20T14:42:10.737Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9b/92b42db6543e7de4f99ae977101a2967b63122d4b6cf7773812da2d7d5b5/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2798b6ba041b9d70acfb9071a2ea13c8456dd1e6a5555798e41ba7b0790e329c", size = 2041742, upload-time = "2026-04-20T14:40:44.262Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/19/46fbe1efabb5aa2834b43b9454e70f9a83ad9c338c1291e48bdc4fecf167/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9be3e221bdc6d69abf294dcf7aff6af19c31a5cdcc8f0aa3b14be29df4bd03b1", size = 2236235, upload-time = "2026-04-20T14:41:27.307Z" },
+    { url = "https://files.pythonhosted.org/packages/77/da/b3f95bc009ad60ec53120f5d16c6faa8cabdbe8a20d83849a1f2b8728148/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f13936129ce841f2a5ddf6f126fea3c43cd128807b5a59588c37cf10178c2e64", size = 2282633, upload-time = "2026-04-20T14:44:33.271Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/401336117722e28f32fb8220df676769d28ebdf08f2f4469646d404c43a3/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28b5f2ef03416facccb1c6ef744c69793175fd27e44ef15669201601cf423acb", size = 2109679, upload-time = "2026-04-20T14:44:41.065Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/53/b289f9bc8756a32fe718c46f55afaeaf8d489ee18d1a1e7be1db73f42cc4/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:830d1247d77ad23852314f069e9d7ddafeec5f684baf9d7e7065ed46a049c4e6", size = 2108342, upload-time = "2026-04-20T14:42:50.144Z" },
+    { url = "https://files.pythonhosted.org/packages/10/5b/8292fc7c1f9111f1b2b7c1b0dcf1179edcd014fc3ea4517499f50b829d71/pydantic_core-2.46.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0793c90c1a3c74966e7975eaef3ed30ebdff3260a0f815a62a22adc17e4c01c", size = 2157208, upload-time = "2026-04-20T14:42:08.133Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9e/f80044e9ec07580f057a89fc131f78dda7a58751ddf52bbe05eaf31db50f/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:d2d0aead851b66f5245ec0c4fb2612ef457f8bbafefdf65a2bf9d6bac6140f47", size = 2167237, upload-time = "2026-04-20T14:42:25.412Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/84/6781a1b037f3b96be9227edbd1101f6d3946746056231bf4ac48cdff1a8d/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:2f40e4246676beb31c5ce77c38a55ca4e465c6b38d11ea1bd935420568e0b1ab", size = 2312540, upload-time = "2026-04-20T14:40:40.313Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/db/19c0839feeb728e7df03255581f198dfdf1c2aeb1e174a8420b63c5252e5/pydantic_core-2.46.3-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:cf489cf8986c543939aeee17a09c04d6ffb43bfef8ca16fcbcc5cfdcbed24dba", size = 2369556, upload-time = "2026-04-20T14:41:09.427Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/15/3228774cb7cd45f5f721ddf1b2242747f4eb834d0c491f0c02d606f09fed/pydantic_core-2.46.3-cp314-cp314t-win32.whl", hash = "sha256:ffe0883b56cfc05798bf994164d2b2ff03efe2d22022a2bb080f3b626176dd56", size = 1949756, upload-time = "2026-04-20T14:41:25.717Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/2a/c79cf53fd91e5a87e30d481809f52f9a60dd221e39de66455cf04deaad37/pydantic_core-2.46.3-cp314-cp314t-win_amd64.whl", hash = "sha256:706d9d0ce9cf4593d07270d8e9f53b161f90c57d315aeec4fb4fd7a8b10240d8", size = 2051305, upload-time = "2026-04-20T14:43:18.627Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/db/d8182a7f1d9343a032265aae186eb063fe26ca4c40f256b21e8da4498e89/pydantic_core-2.46.3-cp314-cp314t-win_arm64.whl", hash = "sha256:77706aeb41df6a76568434701e0917da10692da28cb69d5fb6919ce5fdb07374", size = 2026310, upload-time = "2026-04-20T14:41:01.778Z" },
+    { url = "https://files.pythonhosted.org/packages/34/42/f426db557e8ab2791bc7562052299944a118655496fbff99914e564c0a94/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:b12dd51f1187c2eb489af8e20f880362db98e954b54ab792fa5d92e8bcc6b803", size = 2091877, upload-time = "2026-04-20T14:43:27.091Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/4f/86a832a9d14df58e663bfdf4627dc00d3317c2bd583c4fb23390b0f04b8e/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:f00a0961b125f1a47af7bcc17f00782e12f4cd056f83416006b30111d941dfa3", size = 1932428, upload-time = "2026-04-20T14:40:45.781Z" },
+    { url = "https://files.pythonhosted.org/packages/11/1a/fe857968954d93fb78e0d4b6df5c988c74c4aaa67181c60be7cfe327c0ca/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:57697d7c056aca4bbb680200f96563e841a6386ac1129370a0102592f4dddff5", size = 1997550, upload-time = "2026-04-20T14:44:02.425Z" },
+    { url = "https://files.pythonhosted.org/packages/17/eb/9d89ad2d9b0ba8cd65393d434471621b98912abb10fbe1df08e480ba57b5/pydantic_core-2.46.3-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd35aa21299def8db7ef4fe5c4ff862941a9a158ca7b63d61e66fe67d30416b4", size = 2137657, upload-time = "2026-04-20T14:42:45.149Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.46.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42", size = 1359936, upload-time = "2025-10-16T22:16:29.436Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c6/e5d433f88fd54d81ef4be58b2b7b0cea13c442454a1db703a1eea0db1a59/uvloop-0.22.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:51eb9bd88391483410daad430813d982010f9c9c89512321f5b60e2cddbdddd6", size = 752769, upload-time = "2025-10-16T22:16:30.493Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370", size = 4317413, upload-time = "2025-10-16T22:16:31.644Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4", size = 4426307, upload-time = "2025-10-16T22:16:32.917Z" },
+    { url = "https://files.pythonhosted.org/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2", size = 4131970, upload-time = "2025-10-16T22:16:34.015Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/6b3f7d234ba3964c428a6e40006340f53ba37993f46ed6e111c6e9141d18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:512fec6815e2dd45161054592441ef76c830eddaad55c8aa30952e6fe1ed07c0", size = 4296343, upload-time = "2025-10-16T22:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611, upload-time = "2025-10-16T22:16:36.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811, upload-time = "2025-10-16T22:16:38.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562, upload-time = "2025-10-16T22:16:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890, upload-time = "2025-10-16T22:16:40.547Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472, upload-time = "2025-10-16T22:16:41.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051, upload-time = "2025-10-16T22:16:43.224Z" },
+    { url = "https://files.pythonhosted.org/packages/90/cd/b62bdeaa429758aee8de8b00ac0dd26593a9de93d302bff3d21439e9791d/uvloop-0.22.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3879b88423ec7e97cd4eba2a443aa26ed4e59b45e6b76aabf13fe2f27023a142", size = 1362067, upload-time = "2025-10-16T22:16:44.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f8/a132124dfda0777e489ca86732e85e69afcd1ff7686647000050ba670689/uvloop-0.22.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4baa86acedf1d62115c1dc6ad1e17134476688f08c6efd8a2ab076e815665c74", size = 752423, upload-time = "2025-10-16T22:16:45.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/94/94af78c156f88da4b3a733773ad5ba0b164393e357cc4bd0ab2e2677a7d6/uvloop-0.22.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:297c27d8003520596236bdb2335e6b3f649480bd09e00d1e3a99144b691d2a35", size = 4272437, upload-time = "2025-10-16T22:16:47.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/35/60249e9fd07b32c665192cec7af29e06c7cd96fa1d08b84f012a56a0b38e/uvloop-0.22.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1955d5a1dd43198244d47664a5858082a3239766a839b2102a269aaff7a4e25", size = 4292101, upload-time = "2025-10-16T22:16:49.318Z" },
+    { url = "https://files.pythonhosted.org/packages/02/62/67d382dfcb25d0a98ce73c11ed1a6fba5037a1a1d533dcbb7cab033a2636/uvloop-0.22.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31dc2fccbd42adc73bc4e7cdbae4fc5086cf378979e53ca5d0301838c5682c6", size = 4114158, upload-time = "2025-10-16T22:16:50.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/f1171b4a882a5d13c8b7576f348acfe6074d72eaf52cccef752f748d4a9f/uvloop-0.22.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:93f617675b2d03af4e72a5333ef89450dfaa5321303ede6e67ba9c9d26878079", size = 4177360, upload-time = "2025-10-16T22:16:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/b01414f31546caf0919da80ad57cbfe24c56b151d12af68cee1b04922ca8/uvloop-0.22.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:37554f70528f60cad66945b885eb01f1bb514f132d92b6eeed1c90fd54ed6289", size = 1454790, upload-time = "2025-10-16T22:16:54.355Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/31/0bb232318dd838cad3fa8fb0c68c8b40e1145b32025581975e18b11fab40/uvloop-0.22.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b76324e2dc033a0b2f435f33eb88ff9913c156ef78e153fb210e03c13da746b3", size = 796783, upload-time = "2025-10-16T22:16:55.906Z" },
+    { url = "https://files.pythonhosted.org/packages/42/38/c9b09f3271a7a723a5de69f8e237ab8e7803183131bc57c890db0b6bb872/uvloop-0.22.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:badb4d8e58ee08dad957002027830d5c3b06aea446a6a3744483c2b3b745345c", size = 4647548, upload-time = "2025-10-16T22:16:57.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/d5/f039e7e3c639d9b1d09b07ea412a6806d38123f0508e5f9b48a87b0a76cc/watchfiles-1.1.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8c89f9f2f740a6b7dcc753140dd5e1ab9215966f7a3530d0c0705c83b401bd7d", size = 404745, upload-time = "2025-10-14T15:04:46.731Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd404be08018c37350f0d6e34676bd1e2889990117a2b90070b3007f172d0610", size = 391769, upload-time = "2025-10-14T15:04:48.003Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/5b/d3b460364aeb8da471c1989238ea0e56bec24b6042a68046adf3d9ddb01c/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8526e8f916bb5b9a0a777c8317c23ce65de259422bba5b31325a6fa6029d33af", size = 449374, upload-time = "2025-10-14T15:04:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/44/5769cb62d4ed055cb17417c0a109a92f007114a4e07f30812a73a4efdb11/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2edc3553362b1c38d9f06242416a5d8e9fe235c204a4072e988ce2e5bb1f69f6", size = 459485, upload-time = "2025-10-14T15:04:50.155Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0c/286b6301ded2eccd4ffd0041a1b726afda999926cf720aab63adb68a1e36/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30f7da3fb3f2844259cba4720c3fc7138eb0f7b659c38f3bfa65084c7fc7abce", size = 488813, upload-time = "2025-10-14T15:04:51.059Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2b/8530ed41112dd4a22f4dcfdb5ccf6a1baad1ff6eed8dc5a5f09e7e8c41c7/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8979280bdafff686ba5e4d8f97840f929a87ed9cdf133cbbd42f7766774d2aa", size = 594816, upload-time = "2025-10-14T15:04:52.031Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d2/f5f9fb49489f184f18470d4f99f4e862a4b3e9ac2865688eb2099e3d837a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dcc5c24523771db3a294c77d94771abcfcb82a0e0ee8efd910c37c59ec1b31bb", size = 475186, upload-time = "2025-10-14T15:04:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/68/5707da262a119fb06fbe214d82dd1fe4a6f4af32d2d14de368d0349eb52a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db5d7ae38ff20153d542460752ff397fcf5c96090c1230803713cf3147a6803", size = 456812, upload-time = "2025-10-14T15:04:55.174Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ab/3cbb8756323e8f9b6f9acb9ef4ec26d42b2109bce830cc1f3468df20511d/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:28475ddbde92df1874b6c5c8aaeb24ad5be47a11f87cde5a28ef3835932e3e94", size = 630196, upload-time = "2025-10-14T15:04:56.22Z" },
+    { url = "https://files.pythonhosted.org/packages/78/46/7152ec29b8335f80167928944a94955015a345440f524d2dfe63fc2f437b/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:36193ed342f5b9842edd3532729a2ad55c4160ffcfa3700e0d54be496b70dd43", size = 622657, upload-time = "2025-10-14T15:04:57.521Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/bf/95895e78dd75efe9a7f31733607f384b42eb5feb54bd2eb6ed57cc2e94f4/watchfiles-1.1.1-cp312-cp312-win32.whl", hash = "sha256:859e43a1951717cc8de7f4c77674a6d389b106361585951d9e69572823f311d9", size = 272042, upload-time = "2025-10-14T15:04:59.046Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0a/90eb755f568de2688cb220171c4191df932232c20946966c27a59c400850/watchfiles-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:91d4c9a823a8c987cce8fa2690923b069966dabb196dd8d137ea2cede885fde9", size = 288410, upload-time = "2025-10-14T15:05:00.081Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/f322701530586922fbd6723c4f91ace21364924822a8772c549483abed13/watchfiles-1.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:a625815d4a2bdca61953dbba5a39d60164451ef34c88d751f6c368c3ea73d404", size = 278209, upload-time = "2025-10-14T15:05:01.168Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/f750b29225fe77139f7ae5de89d4949f5a99f934c65a1f1c0b248f26f747/watchfiles-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:130e4876309e8686a5e37dba7d5e9bc77e6ed908266996ca26572437a5271e18", size = 404321, upload-time = "2025-10-14T15:05:02.063Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/f07a295cde762644aa4c4bb0f88921d2d141af45e735b965fb2e87858328/watchfiles-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f3bde70f157f84ece3765b42b4a52c6ac1a50334903c6eaf765362f6ccca88a", size = 391783, upload-time = "2025-10-14T15:05:03.052Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/11/fc2502457e0bea39a5c958d86d2cb69e407a4d00b85735ca724bfa6e0d1a/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e0b1fe858430fc0251737ef3824c54027bedb8c37c38114488b8e131cf8219", size = 449279, upload-time = "2025-10-14T15:05:04.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1f/d66bc15ea0b728df3ed96a539c777acfcad0eb78555ad9efcaa1274688f0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f27db948078f3823a6bb3b465180db8ebecf26dd5dae6f6180bd87383b6b4428", size = 459405, upload-time = "2025-10-14T15:05:04.942Z" },
+    { url = "https://files.pythonhosted.org/packages/be/90/9f4a65c0aec3ccf032703e6db02d89a157462fbb2cf20dd415128251cac0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059098c3a429f62fc98e8ec62b982230ef2c8df68c79e826e37b895bc359a9c0", size = 488976, upload-time = "2025-10-14T15:05:05.905Z" },
+    { url = "https://files.pythonhosted.org/packages/37/57/ee347af605d867f712be7029bb94c8c071732a4b44792e3176fa3c612d39/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfb5862016acc9b869bb57284e6cb35fdf8e22fe59f7548858e2f971d045f150", size = 595506, upload-time = "2025-10-14T15:05:06.906Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/78/cc5ab0b86c122047f75e8fc471c67a04dee395daf847d3e59381996c8707/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:319b27255aacd9923b8a276bb14d21a5f7ff82564c744235fc5eae58d95422ae", size = 474936, upload-time = "2025-10-14T15:05:07.906Z" },
+    { url = "https://files.pythonhosted.org/packages/62/da/def65b170a3815af7bd40a3e7010bf6ab53089ef1b75d05dd5385b87cf08/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c755367e51db90e75b19454b680903631d41f9e3607fbd941d296a020c2d752d", size = 456147, upload-time = "2025-10-14T15:05:09.138Z" },
+    { url = "https://files.pythonhosted.org/packages/57/99/da6573ba71166e82d288d4df0839128004c67d2778d3b566c138695f5c0b/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c22c776292a23bfc7237a98f791b9ad3144b02116ff10d820829ce62dff46d0b", size = 630007, upload-time = "2025-10-14T15:05:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/51/7439c4dd39511368849eb1e53279cd3454b4a4dbace80bab88feeb83c6b5/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3a476189be23c3686bc2f4321dd501cb329c0a0469e77b7b534ee10129ae6374", size = 622280, upload-time = "2025-10-14T15:05:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/8ed97d4bba5db6fdcdb2b298d3898f2dd5c20f6b73aee04eabe56c59677e/watchfiles-1.1.1-cp313-cp313-win32.whl", hash = "sha256:bf0a91bfb5574a2f7fc223cf95eeea79abfefa404bf1ea5e339c0c1560ae99a0", size = 272056, upload-time = "2025-10-14T15:05:12.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/c14e28429f744a260d8ceae18bf58c1d5fa56b50d006a7a9f80e1882cb0d/watchfiles-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:52e06553899e11e8074503c8e716d574adeeb7e68913115c4b3653c53f9bae42", size = 288162, upload-time = "2025-10-14T15:05:13.208Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/fe0e56c40d5cd29523e398d31153218718c5786b5e636d9ae8ae79453d27/watchfiles-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac3cc5759570cd02662b15fbcd9d917f7ecd47efe0d6b40474eafd246f91ea18", size = 277909, upload-time = "2025-10-14T15:05:14.49Z" },
+    { url = "https://files.pythonhosted.org/packages/79/42/e0a7d749626f1e28c7108a99fb9bf524b501bbbeb9b261ceecde644d5a07/watchfiles-1.1.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:563b116874a9a7ce6f96f87cd0b94f7faf92d08d0021e837796f0a14318ef8da", size = 403389, upload-time = "2025-10-14T15:05:15.777Z" },
+    { url = "https://files.pythonhosted.org/packages/15/49/08732f90ce0fbbc13913f9f215c689cfc9ced345fb1bcd8829a50007cc8d/watchfiles-1.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ad9fe1dae4ab4212d8c91e80b832425e24f421703b5a42ef2e4a1e215aff051", size = 389964, upload-time = "2025-10-14T15:05:16.85Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/7c315d4bd5f2538910491a0393c56bf70d333d51bc5b34bee8e68e8cea19/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce70f96a46b894b36eba678f153f052967a0d06d5b5a19b336ab0dbbd029f73e", size = 448114, upload-time = "2025-10-14T15:05:17.876Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/24/9e096de47a4d11bc4df41e9d1e61776393eac4cb6eb11b3e23315b78b2cc/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cb467c999c2eff23a6417e58d75e5828716f42ed8289fe6b77a7e5a91036ca70", size = 460264, upload-time = "2025-10-14T15:05:18.962Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0f/e8dea6375f1d3ba5fcb0b3583e2b493e77379834c74fd5a22d66d85d6540/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:836398932192dae4146c8f6f737d74baeac8b70ce14831a239bdb1ca882fc261", size = 487877, upload-time = "2025-10-14T15:05:20.094Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/df24cfc6424a12deb41503b64d42fbea6b8cb357ec62ca84a5a3476f654a/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:743185e7372b7bc7c389e1badcc606931a827112fbbd37f14c537320fca08620", size = 595176, upload-time = "2025-10-14T15:05:21.134Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/853b6757f7347de4e9b37e8cc3289283fb983cba1ab4d2d7144694871d9c/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afaeff7696e0ad9f02cbb8f56365ff4686ab205fcf9c4c5b6fdfaaa16549dd04", size = 473577, upload-time = "2025-10-14T15:05:22.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425, upload-time = "2025-10-14T15:05:23.348Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826, upload-time = "2025-10-14T15:05:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208, upload-time = "2025-10-14T15:05:25.45Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f4/0872229324ef69b2c3edec35e84bd57a1289e7d3fe74588048ed8947a323/watchfiles-1.1.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d1715143123baeeaeadec0528bb7441103979a1d5f6fd0e1f915383fea7ea6d5", size = 404315, upload-time = "2025-10-14T15:05:26.501Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/22/16d5331eaed1cb107b873f6ae1b69e9ced582fcf0c59a50cd84f403b1c32/watchfiles-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:39574d6370c4579d7f5d0ad940ce5b20db0e4117444e39b6d8f99db5676c52fd", size = 390869, upload-time = "2025-10-14T15:05:27.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7e/5643bfff5acb6539b18483128fdc0ef2cccc94a5b8fbda130c823e8ed636/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7365b92c2e69ee952902e8f70f3ba6360d0d596d9299d55d7d386df84b6941fb", size = 449919, upload-time = "2025-10-14T15:05:28.701Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2e/c410993ba5025a9f9357c376f48976ef0e1b1aefb73b97a5ae01a5972755/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bfff9740c69c0e4ed32416f013f3c45e2ae42ccedd1167ef2d805c000b6c71a5", size = 460845, upload-time = "2025-10-14T15:05:30.064Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a4/2df3b404469122e8680f0fcd06079317e48db58a2da2950fb45020947734/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27cf2eb1dda37b2089e3907d8ea92922b673c0c427886d4edc6b94d8dfe5db3", size = 489027, upload-time = "2025-10-14T15:05:31.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/84/4587ba5b1f267167ee715b7f66e6382cca6938e0a4b870adad93e44747e6/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:526e86aced14a65a5b0ec50827c745597c782ff46b571dbfe46192ab9e0b3c33", size = 595615, upload-time = "2025-10-14T15:05:32.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/0f/c6988c91d06e93cd0bb3d4a808bcf32375ca1904609835c3031799e3ecae/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04e78dd0b6352db95507fd8cb46f39d185cf8c74e4cf1e4fbad1d3df96faf510", size = 474836, upload-time = "2025-10-14T15:05:33.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/36/ded8aebea91919485b7bbabbd14f5f359326cb5ec218cd67074d1e426d74/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c85794a4cfa094714fb9c08d4a218375b2b95b8ed1666e8677c349906246c05", size = 455099, upload-time = "2025-10-14T15:05:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e0/8c9bdba88af756a2fce230dd365fab2baf927ba42cd47521ee7498fd5211/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:74d5012b7630714b66be7b7b7a78855ef7ad58e8650c73afc4c076a1f480a8d6", size = 630626, upload-time = "2025-10-14T15:05:35.216Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/84/a95db05354bf2d19e438520d92a8ca475e578c647f78f53197f5a2f17aaf/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:8fbe85cb3201c7d380d3d0b90e63d520f15d6afe217165d7f98c9c649654db81", size = 622519, upload-time = "2025-10-14T15:05:36.259Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ce/d8acdc8de545de995c339be67711e474c77d643555a9bb74a9334252bd55/watchfiles-1.1.1-cp314-cp314-win32.whl", hash = "sha256:3fa0b59c92278b5a7800d3ee7733da9d096d4aabcfabb9a928918bd276ef9b9b", size = 272078, upload-time = "2025-10-14T15:05:37.63Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c9/a74487f72d0451524be827e8edec251da0cc1fcf111646a511ae752e1a3d/watchfiles-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:c2047d0b6cea13b3316bdbafbfa0c4228ae593d995030fda39089d36e64fc03a", size = 287664, upload-time = "2025-10-14T15:05:38.95Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b8/8ac000702cdd496cdce998c6f4ee0ca1f15977bba51bdf07d872ebdfc34c/watchfiles-1.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:842178b126593addc05acf6fce960d28bc5fae7afbaa2c6c1b3a7b9460e5be02", size = 277154, upload-time = "2025-10-14T15:05:39.954Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a8/e3af2184707c29f0f14b1963c0aace6529f9d1b8582d5b99f31bbf42f59e/watchfiles-1.1.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:88863fbbc1a7312972f1c511f202eb30866370ebb8493aef2812b9ff28156a21", size = 403820, upload-time = "2025-10-14T15:05:40.932Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/e47e307c2f4bd75f9f9e8afbe3876679b18e1bcec449beca132a1c5ffb2d/watchfiles-1.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55c7475190662e202c08c6c0f4d9e345a29367438cf8e8037f3155e10a88d5a5", size = 390510, upload-time = "2025-10-14T15:05:41.945Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a0/ad235642118090f66e7b2f18fd5c42082418404a79205cdfca50b6309c13/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f53fa183d53a1d7a8852277c92b967ae99c2d4dcee2bfacff8868e6e30b15f7", size = 448408, upload-time = "2025-10-14T15:05:43.385Z" },
+    { url = "https://files.pythonhosted.org/packages/df/85/97fa10fd5ff3332ae17e7e40e20784e419e28521549780869f1413742e9d/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6aae418a8b323732fa89721d86f39ec8f092fc2af67f4217a2b07fd3e93c6101", size = 458968, upload-time = "2025-10-14T15:05:44.404Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c2/9059c2e8966ea5ce678166617a7f75ecba6164375f3b288e50a40dc6d489/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f096076119da54a6080e8920cbdaac3dbee667eb91dcc5e5b78840b87415bd44", size = 488096, upload-time = "2025-10-14T15:05:45.398Z" },
+    { url = "https://files.pythonhosted.org/packages/94/44/d90a9ec8ac309bc26db808a13e7bfc0e4e78b6fc051078a554e132e80160/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00485f441d183717038ed2e887a7c868154f216877653121068107b227a2f64c", size = 596040, upload-time = "2025-10-14T15:05:46.502Z" },
+    { url = "https://files.pythonhosted.org/packages/95/68/4e3479b20ca305cfc561db3ed207a8a1c745ee32bf24f2026a129d0ddb6e/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a55f3e9e493158d7bfdb60a1165035f1cf7d320914e7b7ea83fe22c6023b58fc", size = 473847, upload-time = "2025-10-14T15:05:47.484Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]

--- a/bede-data/uv.lock
+++ b/bede-data/uv.lock
@@ -49,6 +49,7 @@ dependencies = [
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -59,6 +60,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.7.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.25.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.11.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
 ]
 provides-extras = ["dev"]
@@ -406,6 +408,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

New `bede-data` FastAPI service — the data foundation layer for the Bede personal AI assistant rebuild.

- **Ingest API**: Authenticated POST endpoints for Apple Health data and Mac vault data (screen time, safari, youtube, podcasts, sessions, music) with upsert-by-natural-key and daily replacement strategies
- **SQLite database**: 27 tables, WAL mode, schema versioning, retention policies — single source of truth for all personal data
- **Read API**: 16 routers serving health metrics, sleep, activity, workouts, wellbeing, medications, screen time, safari, youtube, podcasts, sessions, location, weather, air quality, conversations, and storage stats
- **Analytics engine**: 7 deterministic signal types (sleep_declining, exercise_gap, goal_stale, goal_drifting, passive_screen_up, medication_missed, bedtime_drifting) with DB-driven thresholds
- **CRUD systems**: Memories (with correction supersession), goals (with status tracking), task execution logs, configuration management (schedules, settings, monitored items)
- **Operational**: Daily sessions, scratchpads, vault publish queue, message queue, data freshness tracking, retention cleanup
- **Dockerfile**: Production-ready with non-root user, health check, uv layer caching

18 commits, 120 tests, 17 source modules + test files.

## Test Plan

- [x] 120 pytest tests pass (`uv run pytest tests/ -v`)
- [x] All 27 tables created with correct constraints
- [x] Ingest endpoints require bearer auth, reject empty tokens
- [x] Path traversal protection on conversation history endpoint
- [x] Atomic ingest transactions (single commit per request)
- [x] Analytics signals compute correctly from seeded test data
- [x] Retention cleanup deletes old data, preserves recent
- [ ] Docker build succeeds (`docker build -t bede-data bede-data/`)
- [ ] Integration test on server with real data sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)