### PR TITLE
ci: add GHCR build-push for bede-data

### DIFF
--- a/.github/workflows/bede-data-ci.yml
+++ b/.github/workflows/bede-data-ci.yml
@@ -30,3 +30,32 @@ jobs:
       - uses: astral-sh/setup-uv@v6
       - run: uv sync --extra dev
       - run: uv run pytest tests/ -v --tb=short
+
+  build-push:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ./bede-data
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ghcr.io/josephradford/bede-data:latest
+            ghcr.io/josephradford/bede-data:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary
- Extends `bede-data-ci.yml` with a `build-push` job that builds and pushes the bede-data Docker image to `ghcr.io/josephradford/bede-data` on merge to main
- Only runs after lint + test pass; tags with `:latest` and `:sha`
- Uses GHA build cache for fast rebuilds

## Test plan
- [ ] CI lint + test jobs still pass on the PR
- [ ] After merge, verify the `build-push` job runs and the image appears at `ghcr.io/josephradford/bede-data`

🤖 Generated with [Claude Code](https://claude.com/claude-code)