### PR TITLE
ci: add workflow_dispatch to both workflows

### DIFF
--- a/.github/workflows/bede-data-ci.yml
+++ b/.github/workflows/bede-data-ci.yml
@@ -1,6 +1,7 @@
 name: bede-data CI
 
 on:
+  workflow_dispatch:
   pull_request:
     paths:
       - "bede-data/**"

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -1,6 +1,7 @@
 name: Build and push Docker image
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
 


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to both `bede-data-ci.yml` and `build-push.yml`
- Needed because the bede-data GHCR image was never pushed — the build-push job was added (PR #29) after the data code landed (PR #28), and the path filter never re-triggered
- Once merged, we can manually trigger bede-data CI via `gh workflow run` to push the initial image

## Test plan
- [ ] Merge this PR
- [ ] Manually trigger bede-data CI via `gh workflow run`
- [ ] Verify `ghcr.io/josephradford/bede-data:latest` is accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)