### PR TITLE
fix: include workflow_dispatch in build-push condition

### DIFF
--- a/.github/workflows/bede-data-ci.yml
+++ b/.github/workflows/bede-data-ci.yml
@@ -33,7 +33,7 @@ jobs:
       - run: uv run pytest tests/ -v --tb=short
 
   build-push:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
     needs: [lint, test]
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary
- The `build-push` job's `if` condition only matched `push` events, so `workflow_dispatch` triggers skipped the Docker build
- Adds `workflow_dispatch` to the condition so manual triggers also build and push the image

## Test plan
- [ ] Merge, then `gh workflow run "bede-data CI" --ref main`
- [ ] Verify `build-push` job runs (not skipped)
- [ ] Verify `ghcr.io/josephradford/bede-data:latest` is pullable

🤖 Generated with [Claude Code](https://claude.com/claude-code)