### PR TITLE
feat: bede-core implementation

### DIFF
--- a/.github/workflows/bede-core-ci.yml
+++ b/.github/workflows/bede-core-ci.yml
@@ -1,0 +1,62 @@
+name: bede-core CI
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "bede-core/**"
+  push:
+    branches: [main]
+    paths:
+      - "bede-core/**"
+
+defaults:
+  run:
+    working-directory: bede-core
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - run: uv sync --extra dev
+      - run: uv run ruff check src/ tests/
+      - run: uv run ruff format --check src/ tests/
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - run: uv sync --extra dev
+      - run: uv run pytest tests/ -v --tb=short
+
+  build-push:
+    if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: ./bede-core
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ghcr.io/josephradford/bede-core:latest
+            ghcr.io/josephradford/bede-core:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/bede-core/Dockerfile
+++ b/bede-core/Dockerfile
@@ -1,0 +1,33 @@
+FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git curl ca-certificates openssh-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Claude CLI
+RUN curl -fsSL https://claude.ai/install.sh | bash && \
+    cp /root/.local/bin/claude /usr/local/bin/claude
+
+# Create non-root user
+RUN useradd --create-home --uid 1000 --shell /bin/bash bede && \
+    mkdir -p /home/bede/.ssh /home/bede/.claude && \
+    chmod 700 /home/bede/.ssh && \
+    chown -R bede:bede /home/bede/.ssh /home/bede/.claude
+
+WORKDIR /app
+
+COPY pyproject.toml .
+RUN uv sync --no-dev --no-install-project
+
+COPY src/ src/
+COPY scripts/ scripts/
+
+RUN uv sync --no-dev && \
+    chmod +x scripts/entrypoint.sh && \
+    chown -R bede:bede /app
+
+USER bede
+
+EXPOSE 8080
+
+ENTRYPOINT ["scripts/entrypoint.sh"]

--- a/bede-core/Dockerfile
+++ b/bede-core/Dockerfile
@@ -21,6 +21,7 @@ RUN uv sync --no-dev --no-install-project
 
 COPY src/ src/
 COPY scripts/ scripts/
+COPY mcp.json .
 
 RUN uv sync --no-dev && \
     chmod +x scripts/entrypoint.sh && \

--- a/bede-core/mcp.json
+++ b/bede-core/mcp.json
@@ -1,0 +1,16 @@
+{
+  "mcpServers": {
+    "personal-data": {
+      "type": "url",
+      "url": "http://bede-data-mcp:8002/mcp"
+    },
+    "workspace": {
+      "type": "url",
+      "url": "http://bede-workspace-mcp:8003/mcp"
+    },
+    "browser": {
+      "type": "url",
+      "url": "http://bede-browser-mcp:8004/mcp"
+    }
+  }
+}

--- a/bede-core/pyproject.toml
+++ b/bede-core/pyproject.toml
@@ -1,0 +1,33 @@
+[project]
+name = "bede-core"
+version = "0.1.0"
+description = "Bede brain: Telegram bot, scheduler, session manager, memory manager"
+requires-python = ">=3.12"
+dependencies = [
+    "python-telegram-bot==21.10",
+    "APScheduler==3.10.4",
+    "httpx>=0.28.0",
+    "pydantic-settings>=2.7.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.25.0",
+    "ruff>=0.11.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/bede_core"]
+
+[tool.ruff]
+line-length = 88
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+asyncio_mode = "auto"

--- a/bede-core/pyproject.toml
+++ b/bede-core/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.25.0",
+    "pytest-httpx>=0.35.0",
     "ruff>=0.11.0",
 ]
 

--- a/bede-core/scripts/entrypoint.sh
+++ b/bede-core/scripts/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -e
+
+# Ensure persona file exists
+if [ ! -f /app/CLAUDE.md ]; then
+    echo "ERROR: CLAUDE.md not found. Bind-mount it to /app/CLAUDE.md"
+    exit 1
+fi
+
+# Configure SSH key for private vault repos
+if [ -f "/home/bede/.ssh/vault_key" ] && [ -s "/home/bede/.ssh/vault_key" ]; then
+    chmod 600 /home/bede/.ssh/vault_key
+    ssh-keyscan github.com gitlab.com bitbucket.org >> /home/bede/.ssh/known_hosts 2>/dev/null || true
+    export GIT_SSH_COMMAND="ssh -i /home/bede/.ssh/vault_key -o StrictHostKeyChecking=no"
+fi
+
+# Pull Obsidian vault if VAULT_REPO is configured
+if [ -n "${VAULT_REPO}" ]; then
+    if [ -d "/vault/.git" ]; then
+        echo "[entrypoint] Pulling vault..."
+        git -C /vault pull --ff-only || echo "[entrypoint] Vault pull failed — continuing with existing state"
+    else
+        echo "[entrypoint] Cloning vault..."
+        git clone "${VAULT_REPO}" /vault
+    fi
+fi
+
+echo "[entrypoint] Starting bede-core..."
+exec uv run python -m bede_core.main

--- a/bede-core/src/bede_core/__main__.py
+++ b/bede-core/src/bede_core/__main__.py
@@ -1,0 +1,3 @@
+from bede_core.main import main
+
+main()

--- a/bede-core/src/bede_core/bot.py
+++ b/bede-core/src/bede_core/bot.py
@@ -5,7 +5,6 @@ import time
 from telegram import Update
 from telegram.ext import ContextTypes
 
-from bede_core.claude_cli import ClaudeResult
 from bede_core.session_manager import SessionManager
 from bede_core.telegram_format import md_to_html, chunk_text
 
@@ -63,22 +62,30 @@ def create_message_handler(
 
         if result.timed_out:
             if data_client:
-                await data_client.post("/api/message-queue", body={"message": text, "source": "telegram"})
-                await update.message.reply_text("Request timed out. I've queued your message and will process it when I'm available.")
+                await data_client.post(
+                    "/api/message-queue", body={"message": text, "source": "telegram"}
+                )
+                await update.message.reply_text(
+                    "Request timed out. I've queued your message and will process it when I'm available."
+                )
             else:
                 await update.message.reply_text("Request timed out.")
             return
 
         if result.auth_failure:
             if data_client:
-                await data_client.post("/api/message-queue", body={"message": text, "source": "telegram"})
+                await data_client.post(
+                    "/api/message-queue", body={"message": text, "source": "telegram"}
+                )
             await update.message.reply_text(REAUTH_NOTICE, parse_mode="Markdown")
             return
 
         response_text = result.text or "No response."
 
         if result.stop_reason == "max_tokens":
-            response_text += "\n\n⚠️ _Response was truncated (output token limit reached)._"
+            response_text += (
+                "\n\n⚠️ _Response was truncated (output token limit reached)._"
+            )
 
         await _send_response(update.message, response_text)
 

--- a/bede-core/src/bede_core/bot.py
+++ b/bede-core/src/bede_core/bot.py
@@ -1,0 +1,135 @@
+import asyncio
+import logging
+import time
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from bede_core.claude_cli import ClaudeResult
+from bede_core.session_manager import SessionManager
+from bede_core.telegram_format import md_to_html, chunk_text
+
+log = logging.getLogger(__name__)
+
+REAUTH_NOTICE = (
+    "⚠️ Claude auth has expired.\n\n"
+    "Run this from your Mac to re-authenticate:\n"
+    "```\n"
+    'security find-generic-password -s "Claude Code-credentials" -w | \\\n'
+    '  ssh user@SERVER_IP "cat > ~/.claude/.credentials.json"\n'
+    "```"
+)
+
+TYPING_MAX_DURATION = 600
+
+
+async def _keep_typing(bot, chat_id: int, max_duration: float = TYPING_MAX_DURATION):
+    deadline = time.monotonic() + max_duration
+    while time.monotonic() < deadline:
+        try:
+            await bot.send_chat_action(chat_id=chat_id, action="typing")
+        except Exception:
+            pass
+        await asyncio.sleep(4)
+
+
+async def _send_response(message, text: str):
+    for c in chunk_text(text):
+        try:
+            await message.reply_text(md_to_html(c), parse_mode="HTML")
+        except Exception:
+            await message.reply_text(c)
+
+
+def create_message_handler(
+    session_manager: SessionManager,
+    allowed_user_id: int,
+    timezone: str,
+    data_client=None,
+):
+    async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
+        if update.effective_user.id != allowed_user_id:
+            log.warning("Rejected message from user %s", update.effective_user.id)
+            return
+
+        chat_id = update.effective_chat.id
+        text = update.message.text
+
+        typing_task = asyncio.create_task(_keep_typing(context.bot, chat_id))
+        try:
+            result = await session_manager.send(text)
+        finally:
+            typing_task.cancel()
+
+        if result.timed_out:
+            if data_client:
+                await data_client.post("/api/message-queue", body={"message": text, "source": "telegram"})
+                await update.message.reply_text("Request timed out. I've queued your message and will process it when I'm available.")
+            else:
+                await update.message.reply_text("Request timed out.")
+            return
+
+        if result.auth_failure:
+            if data_client:
+                await data_client.post("/api/message-queue", body={"message": text, "source": "telegram"})
+            await update.message.reply_text(REAUTH_NOTICE, parse_mode="Markdown")
+            return
+
+        response_text = result.text or "No response."
+
+        if result.stop_reason == "max_tokens":
+            response_text += "\n\n⚠️ _Response was truncated (output token limit reached)._"
+
+        await _send_response(update.message, response_text)
+
+    return handle_message
+
+
+def create_reset_handler(session_manager: SessionManager, allowed_user_id: int):
+    async def handle_reset(update: Update, context: ContextTypes.DEFAULT_TYPE):
+        if update.effective_user.id != allowed_user_id:
+            return
+        await session_manager.clear_daily_session()
+        await update.message.reply_text("Session cleared. Next message starts fresh.")
+
+    return handle_reset
+
+
+def create_start_handler(allowed_user_id: int):
+    async def handle_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
+        if update.effective_user.id != allowed_user_id:
+            return
+        await update.message.reply_text(
+            "Hi, I'm Bede. Send me a message to get started.\n"
+            "/reset — start a new conversation session"
+        )
+
+    return handle_start
+
+
+def create_task_trigger_handler(
+    task_name: str,
+    runner,
+    data_client,
+    allowed_user_id: int,
+):
+    async def handle_trigger(update: Update, context: ContextTypes.DEFAULT_TYPE):
+        if update.effective_user.id != allowed_user_id:
+            return
+
+        if task_name in runner._running:
+            await update.message.reply_text(f"⚠️ {task_name} is already running.")
+            return
+
+        schedules = await data_client.get("/api/config/schedules")
+        all_schedules = schedules.get("schedules", [])
+        task = next((s for s in all_schedules if s.get("task_name") == task_name), None)
+
+        if not task:
+            await update.message.reply_text(f"{task_name} not found in schedules.")
+            return
+
+        await update.message.reply_text(f"Running {task_name}...")
+        asyncio.create_task(runner.run_task(task))
+
+    return handle_trigger

--- a/bede-core/src/bede_core/bot.py
+++ b/bede-core/src/bede_core/bot.py
@@ -57,6 +57,10 @@ def create_message_handler(
         typing_task = asyncio.create_task(_keep_typing(context.bot, chat_id))
         try:
             result = await session_manager.send(text)
+        except Exception as e:
+            log.error("Unexpected error handling message: %s", e)
+            await update.message.reply_text("Something went wrong. Please try again.")
+            return
         finally:
             typing_task.cancel()
 
@@ -124,7 +128,7 @@ def create_task_trigger_handler(
         if update.effective_user.id != allowed_user_id:
             return
 
-        if task_name in runner._running:
+        if runner.is_running(task_name):
             await update.message.reply_text(f"⚠️ {task_name} is already running.")
             return
 

--- a/bede-core/src/bede_core/claude_cli.py
+++ b/bede-core/src/bede_core/claude_cli.py
@@ -1,0 +1,147 @@
+import asyncio
+import json
+import logging
+import os
+import signal
+import subprocess
+from dataclasses import dataclass, field
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class ClaudeResult:
+    text: str = ""
+    session_id: str | None = None
+    stop_reason: str = "end_turn"
+    returncode: int = 0
+    stderr: str = ""
+    timed_out: bool = False
+    stale_session: bool = False
+    auth_failure: bool = False
+
+
+def build_command(
+    prompt: str,
+    model: str,
+    session_id: str | None = None,
+    mcp_config: str | None = None,
+) -> list[str]:
+    cmd = [
+        "claude", "-p", prompt,
+        "--model", model,
+        "--dangerously-skip-permissions",
+        "--output-format", "json",
+    ]
+    if session_id:
+        cmd += ["--resume", session_id]
+    if mcp_config:
+        cmd += ["--mcp-config", mcp_config]
+    return cmd
+
+
+def parse_output(stdout: str) -> ClaudeResult:
+    result = ClaudeResult()
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if obj.get("type") == "result":
+            result.text = obj.get("result", "").strip()
+            result.session_id = obj.get("session_id")
+            result.stop_reason = obj.get("stop_reason", "end_turn")
+    return result
+
+
+def _run_subprocess(
+    cmd: list[str], workdir: str, timeout: int, env: dict | None = None
+) -> subprocess.CompletedProcess:
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        stdin=subprocess.DEVNULL,
+        cwd=workdir,
+        text=True,
+        env=env,
+        start_new_session=True,
+    )
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+        return subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        except (ProcessLookupError, OSError):
+            pass
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            try:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            except (ProcessLookupError, OSError):
+                proc.kill()
+            try:
+                proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                pass
+        raise
+
+
+_AUTH_KEYWORDS = ("unauthorized", "authentication", "auth", "login")
+
+
+class ClaudeCli:
+    def __init__(
+        self,
+        workdir: str,
+        timeout: int,
+        filter_env_keys: list[str] | None = None,
+        mcp_config: str | None = None,
+    ):
+        self._workdir = workdir
+        self._timeout = timeout
+        self._filter_env_keys = set(filter_env_keys or [])
+        self._mcp_config = mcp_config
+
+    def _build_env(self) -> dict:
+        env = {k: v for k, v in os.environ.items() if k not in self._filter_env_keys}
+        return env
+
+    async def run(
+        self,
+        prompt: str,
+        model: str,
+        session_id: str | None = None,
+        timeout: int | None = None,
+    ) -> ClaudeResult:
+        cmd = build_command(prompt, model, session_id=session_id, mcp_config=self._mcp_config)
+        env = self._build_env()
+        effective_timeout = timeout or self._timeout
+
+        try:
+            proc = await asyncio.to_thread(
+                _run_subprocess, cmd, self._workdir, effective_timeout, env
+            )
+        except subprocess.TimeoutExpired:
+            log.warning("Claude CLI timed out after %ds", effective_timeout)
+            return ClaudeResult(timed_out=True)
+
+        result = parse_output(proc.stdout)
+        result.returncode = proc.returncode
+        result.stderr = proc.stderr
+
+        if session_id and "no conversation found" in proc.stderr.lower():
+            result.stale_session = True
+
+        if proc.returncode != 0 and any(kw in proc.stderr.lower() for kw in _AUTH_KEYWORDS):
+            result.auth_failure = True
+
+        if not result.text and proc.returncode != 0:
+            result.text = (proc.stderr or proc.stdout or "No response.").strip()[:4096]
+
+        return result

--- a/bede-core/src/bede_core/claude_cli.py
+++ b/bede-core/src/bede_core/claude_cli.py
@@ -4,7 +4,7 @@ import logging
 import os
 import signal
 import subprocess
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 log = logging.getLogger(__name__)
 
@@ -28,10 +28,14 @@ def build_command(
     mcp_config: str | None = None,
 ) -> list[str]:
     cmd = [
-        "claude", "-p", prompt,
-        "--model", model,
+        "claude",
+        "-p",
+        prompt,
+        "--model",
+        model,
         "--dangerously-skip-permissions",
-        "--output-format", "json",
+        "--output-format",
+        "json",
     ]
     if session_id:
         cmd += ["--resume", session_id]
@@ -119,7 +123,9 @@ class ClaudeCli:
         session_id: str | None = None,
         timeout: int | None = None,
     ) -> ClaudeResult:
-        cmd = build_command(prompt, model, session_id=session_id, mcp_config=self._mcp_config)
+        cmd = build_command(
+            prompt, model, session_id=session_id, mcp_config=self._mcp_config
+        )
         env = self._build_env()
         effective_timeout = timeout or self._timeout
 
@@ -138,7 +144,9 @@ class ClaudeCli:
         if session_id and "no conversation found" in proc.stderr.lower():
             result.stale_session = True
 
-        if proc.returncode != 0 and any(kw in proc.stderr.lower() for kw in _AUTH_KEYWORDS):
+        if proc.returncode != 0 and any(
+            kw in proc.stderr.lower() for kw in _AUTH_KEYWORDS
+        ):
             result.auth_failure = True
 
         if not result.text and proc.returncode != 0:

--- a/bede-core/src/bede_core/config.py
+++ b/bede-core/src/bede_core/config.py
@@ -15,5 +15,6 @@ class Settings(BaseSettings):
     quiet_hours_start: int = 22
     quiet_hours_end: int = 7
     vault_path: str = "/vault"
+    mcp_config_path: str = "/app/mcp.json"
 
     model_config = {"env_prefix": "", "case_sensitive": False}

--- a/bede-core/src/bede_core/config.py
+++ b/bede-core/src/bede_core/config.py
@@ -1,0 +1,19 @@
+from pydantic_settings import BaseSettings
+
+
+class Settings(BaseSettings):
+    telegram_bot_token: str = ""
+    allowed_user_id: int = 0
+    claude_model: str = "claude-sonnet-4-5-20250514"
+    claude_workdir: str = "/app"
+    claude_timeout_seconds: int = 300
+    session_timeout_minutes: int = 120
+    interactive_idle_timeout_minutes: int = 30
+    interactive_max_age_hours: int = 2
+    timezone: str = "Australia/Sydney"
+    bede_data_url: str = "http://bede-data:8001"
+    quiet_hours_start: int = 22
+    quiet_hours_end: int = 7
+    vault_path: str = "/vault"
+
+    model_config = {"env_prefix": "", "case_sensitive": False}

--- a/bede-core/src/bede_core/data_client.py
+++ b/bede-core/src/bede_core/data_client.py
@@ -4,6 +4,16 @@ import httpx
 class DataClient:
     def __init__(self, base_url: str):
         self._base_url = base_url
+        self._client: httpx.AsyncClient | None = None
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(base_url=self._base_url, timeout=30.0)
+        return self._client
+
+    async def close(self):
+        if self._client and not self._client.is_closed:
+            await self._client.aclose()
 
     async def _request(
         self,
@@ -13,10 +23,10 @@ class DataClient:
         body: dict | None = None,
     ) -> dict:
         try:
-            async with httpx.AsyncClient(base_url=self._base_url, timeout=30.0) as c:
-                r = await c.request(method, path, params=params, json=body)
-                r.raise_for_status()
-                return r.json()
+            client = self._get_client()
+            r = await client.request(method, path, params=params, json=body)
+            r.raise_for_status()
+            return r.json()
         except httpx.HTTPStatusError as e:
             return {
                 "error": f"bede-data returned {e.response.status_code}",

--- a/bede-core/src/bede_core/data_client.py
+++ b/bede-core/src/bede_core/data_client.py
@@ -6,7 +6,11 @@ class DataClient:
         self._base_url = base_url
 
     async def _request(
-        self, method: str, path: str, params: dict | None = None, body: dict | None = None
+        self,
+        method: str,
+        path: str,
+        params: dict | None = None,
+        body: dict | None = None,
     ) -> dict:
         try:
             async with httpx.AsyncClient(base_url=self._base_url, timeout=30.0) as c:
@@ -14,7 +18,10 @@ class DataClient:
                 r.raise_for_status()
                 return r.json()
         except httpx.HTTPStatusError as e:
-            return {"error": f"bede-data returned {e.response.status_code}", "detail": e.response.text}
+            return {
+                "error": f"bede-data returned {e.response.status_code}",
+                "detail": e.response.text,
+            }
         except (httpx.ConnectError, httpx.TimeoutException):
             return {"error": "bede-data unavailable"}
 

--- a/bede-core/src/bede_core/data_client.py
+++ b/bede-core/src/bede_core/data_client.py
@@ -1,0 +1,32 @@
+import httpx
+
+
+class DataClient:
+    def __init__(self, base_url: str):
+        self._base_url = base_url
+
+    async def _request(
+        self, method: str, path: str, params: dict | None = None, body: dict | None = None
+    ) -> dict:
+        try:
+            async with httpx.AsyncClient(base_url=self._base_url, timeout=30.0) as c:
+                r = await c.request(method, path, params=params, json=body)
+                r.raise_for_status()
+                return r.json()
+        except httpx.HTTPStatusError as e:
+            return {"error": f"bede-data returned {e.response.status_code}", "detail": e.response.text}
+        except (httpx.ConnectError, httpx.TimeoutException):
+            return {"error": "bede-data unavailable"}
+
+    async def get(self, path: str, **params) -> dict:
+        p = {k: v for k, v in params.items() if v is not None}
+        return await self._request("GET", path, params=p)
+
+    async def post(self, path: str, body: dict | None = None) -> dict:
+        return await self._request("POST", path, body=body)
+
+    async def put(self, path: str, body: dict | None = None) -> dict:
+        return await self._request("PUT", path, body=body)
+
+    async def delete(self, path: str) -> dict:
+        return await self._request("DELETE", path)

--- a/bede-core/src/bede_core/main.py
+++ b/bede-core/src/bede_core/main.py
@@ -59,6 +59,7 @@ def main():
         workdir=settings.claude_workdir,
         timeout=settings.claude_timeout_seconds,
         filter_env_keys=["TELEGRAM_BOT_TOKEN", "ALLOWED_USER_ID", "INGEST_WRITE_TOKEN"],
+        mcp_config=settings.mcp_config_path,
     )
 
     memory_manager = MemoryManager(data_client)

--- a/bede-core/src/bede_core/main.py
+++ b/bede-core/src/bede_core/main.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 
 from telegram import BotCommand, BotCommandScopeAllPrivateChats
@@ -46,6 +45,8 @@ def _start_health_server(port: int = 8080):
     server = HTTPServer(("0.0.0.0", port), Handler)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
+
+
 log = logging.getLogger(__name__)
 
 
@@ -114,7 +115,9 @@ def main():
             BotCommand("triage", "Triage today's emails"),
         ]
         await application.bot.set_my_commands(commands)
-        await application.bot.set_my_commands(commands, scope=BotCommandScopeAllPrivateChats())
+        await application.bot.set_my_commands(
+            commands, scope=BotCommandScopeAllPrivateChats()
+        )
 
         scheduler.start()
         await reload_schedules(scheduler, data_client, runner, settings.timezone)
@@ -133,17 +136,65 @@ def main():
         .build()
     )
 
-    app.add_handler(CommandHandler("start", create_start_handler(settings.allowed_user_id)))
-    app.add_handler(CommandHandler("reset", create_reset_handler(session_manager, settings.allowed_user_id)))
-    app.add_handler(CommandHandler("morning", create_task_trigger_handler("Morning Briefing", runner, data_client, settings.allowed_user_id)))
-    app.add_handler(CommandHandler("evening", create_task_trigger_handler("Evening Reflection", runner, data_client, settings.allowed_user_id)))
-    app.add_handler(CommandHandler("scout", create_task_trigger_handler("Deal Scout", runner, data_client, settings.allowed_user_id)))
-    app.add_handler(CommandHandler("datacheck", create_task_trigger_handler("Evening Data Check", runner, data_client, settings.allowed_user_id)))
-    app.add_handler(CommandHandler("triage", create_task_trigger_handler("Email Triage", runner, data_client, settings.allowed_user_id)))
-    app.add_handler(MessageHandler(
-        filters.TEXT & ~filters.COMMAND,
-        create_message_handler(session_manager, settings.allowed_user_id, settings.timezone, data_client=data_client),
-    ))
+    app.add_handler(
+        CommandHandler("start", create_start_handler(settings.allowed_user_id))
+    )
+    app.add_handler(
+        CommandHandler(
+            "reset", create_reset_handler(session_manager, settings.allowed_user_id)
+        )
+    )
+    app.add_handler(
+        CommandHandler(
+            "morning",
+            create_task_trigger_handler(
+                "Morning Briefing", runner, data_client, settings.allowed_user_id
+            ),
+        )
+    )
+    app.add_handler(
+        CommandHandler(
+            "evening",
+            create_task_trigger_handler(
+                "Evening Reflection", runner, data_client, settings.allowed_user_id
+            ),
+        )
+    )
+    app.add_handler(
+        CommandHandler(
+            "scout",
+            create_task_trigger_handler(
+                "Deal Scout", runner, data_client, settings.allowed_user_id
+            ),
+        )
+    )
+    app.add_handler(
+        CommandHandler(
+            "datacheck",
+            create_task_trigger_handler(
+                "Evening Data Check", runner, data_client, settings.allowed_user_id
+            ),
+        )
+    )
+    app.add_handler(
+        CommandHandler(
+            "triage",
+            create_task_trigger_handler(
+                "Email Triage", runner, data_client, settings.allowed_user_id
+            ),
+        )
+    )
+    app.add_handler(
+        MessageHandler(
+            filters.TEXT & ~filters.COMMAND,
+            create_message_handler(
+                session_manager,
+                settings.allowed_user_id,
+                settings.timezone,
+                data_client=data_client,
+            ),
+        )
+    )
 
     log.info("Bede is running.")
     app.run_polling(drop_pending_updates=True)

--- a/bede-core/src/bede_core/main.py
+++ b/bede-core/src/bede_core/main.py
@@ -1,0 +1,152 @@
+import asyncio
+import logging
+
+from telegram import BotCommand, BotCommandScopeAllPrivateChats
+from telegram.ext import Application, CommandHandler, MessageHandler, filters
+
+from bede_core.bot import (
+    create_message_handler,
+    create_reset_handler,
+    create_start_handler,
+    create_task_trigger_handler,
+)
+from bede_core.claude_cli import ClaudeCli
+from bede_core.config import Settings
+from bede_core.data_client import DataClient
+from bede_core.memory_manager import MemoryManager
+from bede_core.scheduler import TaskRunner, reload_schedules, setup_scheduler
+from bede_core.session_manager import SessionManager
+from bede_core.telegram_format import md_to_html, chunk_text
+
+logging.basicConfig(
+    format="%(asctime)s %(levelname)s %(message)s",
+    level=logging.INFO,
+)
+
+
+def _start_health_server(port: int = 8080):
+    """Minimal HTTP health endpoint on a background thread."""
+    from http.server import HTTPServer, BaseHTTPRequestHandler
+    import threading
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path == "/health":
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain")
+                self.end_headers()
+                self.wfile.write(b"ok")
+            else:
+                self.send_response(404)
+                self.end_headers()
+
+        def log_message(self, *args):
+            pass
+
+    server = HTTPServer(("0.0.0.0", port), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+log = logging.getLogger(__name__)
+
+
+def main():
+    settings = Settings()
+    _start_health_server()
+
+    data_client = DataClient(base_url=settings.bede_data_url)
+
+    claude_cli = ClaudeCli(
+        workdir=settings.claude_workdir,
+        timeout=settings.claude_timeout_seconds,
+        filter_env_keys=["TELEGRAM_BOT_TOKEN", "ALLOWED_USER_ID", "INGEST_WRITE_TOKEN"],
+    )
+
+    memory_manager = MemoryManager(data_client)
+
+    session_manager = SessionManager(
+        data_client=data_client,
+        claude_cli=claude_cli,
+        memory_manager=memory_manager,
+        timezone=settings.timezone,
+        model=settings.claude_model,
+        vault_path=settings.vault_path,
+    )
+
+    async def send_telegram(text: str):
+        for c in chunk_text(text):
+            try:
+                await app.bot.send_message(
+                    chat_id=settings.allowed_user_id,
+                    text=md_to_html(c),
+                    parse_mode="HTML",
+                    disable_web_page_preview=True,
+                )
+            except Exception:
+                try:
+                    await app.bot.send_message(
+                        chat_id=settings.allowed_user_id,
+                        text=c,
+                        disable_web_page_preview=True,
+                    )
+                except Exception as e:
+                    log.error("Failed to send Telegram message: %s", e)
+
+    runner = TaskRunner(
+        data_client=data_client,
+        session_manager=session_manager,
+        send_fn=send_telegram,
+        timezone=settings.timezone,
+        quiet_hours_start=settings.quiet_hours_start,
+        quiet_hours_end=settings.quiet_hours_end,
+    )
+
+    scheduler = setup_scheduler(data_client, runner, settings.timezone)
+
+    async def post_init(application):
+        commands = [
+            BotCommand("start", "Start a conversation"),
+            BotCommand("reset", "Clear session and start fresh"),
+            BotCommand("morning", "Run the Morning Briefing"),
+            BotCommand("evening", "Run the Evening Reflection"),
+            BotCommand("scout", "Run the Deal Scout"),
+            BotCommand("datacheck", "Run the Evening Data Check"),
+            BotCommand("triage", "Triage today's emails"),
+        ]
+        await application.bot.set_my_commands(commands)
+        await application.bot.set_my_commands(commands, scope=BotCommandScopeAllPrivateChats())
+
+        scheduler.start()
+        await reload_schedules(scheduler, data_client, runner, settings.timezone)
+        log.info("Scheduler started.")
+
+    async def post_shutdown(application):
+        if scheduler.running:
+            scheduler.shutdown(wait=False)
+            log.info("Scheduler stopped.")
+
+    app = (
+        Application.builder()
+        .token(settings.telegram_bot_token)
+        .post_init(post_init)
+        .post_shutdown(post_shutdown)
+        .build()
+    )
+
+    app.add_handler(CommandHandler("start", create_start_handler(settings.allowed_user_id)))
+    app.add_handler(CommandHandler("reset", create_reset_handler(session_manager, settings.allowed_user_id)))
+    app.add_handler(CommandHandler("morning", create_task_trigger_handler("Morning Briefing", runner, data_client, settings.allowed_user_id)))
+    app.add_handler(CommandHandler("evening", create_task_trigger_handler("Evening Reflection", runner, data_client, settings.allowed_user_id)))
+    app.add_handler(CommandHandler("scout", create_task_trigger_handler("Deal Scout", runner, data_client, settings.allowed_user_id)))
+    app.add_handler(CommandHandler("datacheck", create_task_trigger_handler("Evening Data Check", runner, data_client, settings.allowed_user_id)))
+    app.add_handler(CommandHandler("triage", create_task_trigger_handler("Email Triage", runner, data_client, settings.allowed_user_id)))
+    app.add_handler(MessageHandler(
+        filters.TEXT & ~filters.COMMAND,
+        create_message_handler(session_manager, settings.allowed_user_id, settings.timezone, data_client=data_client),
+    ))
+
+    log.info("Bede is running.")
+    app.run_polling(drop_pending_updates=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/bede-core/src/bede_core/memory_manager.py
+++ b/bede-core/src/bede_core/memory_manager.py
@@ -1,0 +1,47 @@
+import logging
+
+from bede_core.data_client import DataClient
+
+log = logging.getLogger(__name__)
+
+
+class MemoryManager:
+    def __init__(self, data_client: DataClient, max_context_chars: int = 2000):
+        self._client = data_client
+        self._max_chars = max_context_chars
+
+    async def get_context(self) -> str:
+        result = await self._client.get("/api/memories", limit=50)
+        if "error" in result:
+            log.warning("Failed to fetch memories: %s", result["error"])
+            return ""
+        memories = result.get("memories", [])
+        if not memories:
+            return ""
+
+        lines: list[str] = []
+        total = 0
+        for m in memories:
+            line = f"- [{m['type']}] {m['content']}"
+            if total + len(line) > self._max_chars:
+                break
+            lines.append(line)
+            total += len(line)
+
+        if not lines:
+            return ""
+        return "## Your memories about the user\n\n" + "\n".join(lines)
+
+    async def store(
+        self,
+        content: str,
+        type: str,
+        source_conversation: str | None = None,
+        supersedes: int | None = None,
+    ) -> dict:
+        body: dict = {"content": content, "type": type}
+        if source_conversation:
+            body["source_conversation"] = source_conversation
+        if supersedes is not None:
+            body["supersedes"] = supersedes
+        return await self._client.post("/api/memories", body=body)

--- a/bede-core/src/bede_core/quiet_hours.py
+++ b/bede-core/src/bede_core/quiet_hours.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+
+
+def is_quiet_hours(now: datetime, start_hour: int, end_hour: int) -> bool:
+    """Check if the current time falls within quiet hours.
+
+    Quiet hours span midnight: e.g., start=22, end=7 means 22:00-06:59.
+    Returns False if start == end == 0 (disabled).
+    """
+    if start_hour == 0 and end_hour == 0:
+        return False
+    hour = now.hour
+    if start_hour > end_hour:
+        return hour >= start_hour or hour < end_hour
+    return start_hour <= hour < end_hour

--- a/bede-core/src/bede_core/scheduler.py
+++ b/bede-core/src/bede_core/scheduler.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import time
 from datetime import datetime, timezone
@@ -7,7 +6,6 @@ from zoneinfo import ZoneInfo
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 
-from bede_core.claude_cli import ClaudeResult
 from bede_core.data_client import DataClient
 from bede_core.quiet_hours import is_quiet_hours
 from bede_core.session_manager import SessionManager
@@ -46,14 +44,23 @@ class TaskRunner:
 
     async def _log_start(self, task_name: str) -> int | None:
         now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-        result = await self._data.post("/api/tasks/log", body={
-            "task_name": task_name,
-            "start_time": now,
-            "status": "running",
-        })
+        result = await self._data.post(
+            "/api/tasks/log",
+            body={
+                "task_name": task_name,
+                "start_time": now,
+                "status": "running",
+            },
+        )
         return result.get("id")
 
-    async def _log_end(self, exec_id: int | None, status: str, duration: float, error: str | None = None):
+    async def _log_end(
+        self,
+        exec_id: int | None,
+        status: str,
+        duration: float,
+        error: str | None = None,
+    ):
         if exec_id is None:
             return
         now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -90,7 +97,6 @@ class TaskRunner:
         prompt = task["prompt"]
         model = task.get("model")
         timeout = task.get("timeout_seconds", 300)
-        interactive = task.get("interactive", False)
 
         now = datetime.now(self._tz)
         now_str = now.strftime("%H:%M")
@@ -122,9 +128,13 @@ class TaskRunner:
         output = header + text
         now_check = datetime.now(self._tz)
         if is_quiet_hours(now_check, self._quiet_start, self._quiet_end):
-            await self._data.post("/api/message-queue", body={
-                "message": output, "source": f"scheduler:{name}",
-            })
+            await self._data.post(
+                "/api/message-queue",
+                body={
+                    "message": output,
+                    "source": f"scheduler:{name}",
+                },
+            )
             log.info("Task '%s' output queued (quiet hours).", name)
         else:
             await self._send(output)
@@ -146,7 +156,12 @@ def _next_run_str(cron: str, tz: ZoneInfo, now: datetime) -> str:
     return ""
 
 
-async def reload_schedules(scheduler: AsyncIOScheduler, data_client: DataClient, runner: TaskRunner, timezone: str):
+async def reload_schedules(
+    scheduler: AsyncIOScheduler,
+    data_client: DataClient,
+    runner: TaskRunner,
+    timezone: str,
+):
     schedules = await load_schedules(data_client)
     tz = ZoneInfo(timezone)
 

--- a/bede-core/src/bede_core/scheduler.py
+++ b/bede-core/src/bede_core/scheduler.py
@@ -139,6 +139,9 @@ class TaskRunner:
         else:
             await self._send(output)
 
+    def is_running(self, name: str) -> bool:
+        return name in self._running
+
     def cancel_task(self, name: str):
         self._running.discard(name)
 

--- a/bede-core/src/bede_core/scheduler.py
+++ b/bede-core/src/bede_core/scheduler.py
@@ -1,0 +1,197 @@
+import asyncio
+import logging
+import time
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from bede_core.claude_cli import ClaudeResult
+from bede_core.data_client import DataClient
+from bede_core.quiet_hours import is_quiet_hours
+from bede_core.session_manager import SessionManager
+
+log = logging.getLogger(__name__)
+
+RELOAD_INTERVAL_MINUTES = 5
+
+
+async def load_schedules(data_client: DataClient) -> list[dict]:
+    result = await data_client.get("/api/config/schedules")
+    if "error" in result:
+        log.warning("Failed to load schedules: %s", result["error"])
+        return []
+    schedules = result.get("schedules", [])
+    return [s for s in schedules if s.get("enabled", True)]
+
+
+class TaskRunner:
+    def __init__(
+        self,
+        data_client: DataClient,
+        session_manager: SessionManager,
+        send_fn,
+        timezone: str,
+        quiet_hours_start: int = 22,
+        quiet_hours_end: int = 7,
+    ):
+        self._data = data_client
+        self._session = session_manager
+        self._send = send_fn
+        self._tz = ZoneInfo(timezone)
+        self._running: set[str] = set()
+        self._quiet_start = quiet_hours_start
+        self._quiet_end = quiet_hours_end
+
+    async def _log_start(self, task_name: str) -> int | None:
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        result = await self._data.post("/api/tasks/log", body={
+            "task_name": task_name,
+            "start_time": now,
+            "status": "running",
+        })
+        return result.get("id")
+
+    async def _log_end(self, exec_id: int | None, status: str, duration: float, error: str | None = None):
+        if exec_id is None:
+            return
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        body: dict = {"status": status, "end_time": now, "duration_seconds": duration}
+        if error:
+            body["error_detail"] = error[:1000]
+        await self._data.put(f"/api/tasks/log/{exec_id}", body=body)
+
+    async def run_task(self, task: dict):
+        name = task["task_name"]
+
+        if name in self._running:
+            log.warning("Task '%s' already running — skipping.", name)
+            return
+
+        self._running.add(name)
+        start = time.monotonic()
+        exec_id = await self._log_start(name)
+
+        try:
+            await self._run_task_inner(task)
+            duration = time.monotonic() - start
+            await self._log_end(exec_id, "success", duration)
+        except Exception as e:
+            duration = time.monotonic() - start
+            log.error("Task '%s' failed: %s", name, e)
+            await self._log_end(exec_id, "failure", duration, error=str(e))
+            await self._send(f"⚠️ *{name}* failed: {e}")
+        finally:
+            self._running.discard(name)
+
+    async def _run_task_inner(self, task: dict):
+        name = task["task_name"]
+        prompt = task["prompt"]
+        model = task.get("model")
+        timeout = task.get("timeout_seconds", 300)
+        interactive = task.get("interactive", False)
+
+        now = datetime.now(self._tz)
+        now_str = now.strftime("%H:%M")
+        now_date_str = now.strftime("%A, %d %B %Y")
+        prompt = f"Today is {now_date_str}.\n\n{prompt}"
+
+        cron = task.get("cron_expression", "")
+        next_str = _next_run_str(cron, self._tz, now)
+
+        log.info("Running task: %s (timeout: %ds)", name, timeout)
+
+        result = await self._session.send_task(prompt, model=model, timeout=timeout)
+
+        if result.timed_out:
+            mins = timeout // 60
+            await self._send(f"📅 *{name}*\n⚠️ Timed out after {mins} minutes.")
+            return
+
+        text = result.text or "No response."
+
+        if result.stop_reason == "max_tokens":
+            text += "\n\n⚠️ _Response was truncated (output token limit reached)._"
+
+        header = f"📅 *{name}* ({now_str})"
+        if next_str:
+            header += f"\n↻ Next: {next_str}"
+        header += "\n---\n"
+
+        output = header + text
+        now_check = datetime.now(self._tz)
+        if is_quiet_hours(now_check, self._quiet_start, self._quiet_end):
+            await self._data.post("/api/message-queue", body={
+                "message": output, "source": f"scheduler:{name}",
+            })
+            log.info("Task '%s' output queued (quiet hours).", name)
+        else:
+            await self._send(output)
+
+    def cancel_task(self, name: str):
+        self._running.discard(name)
+
+
+def _next_run_str(cron: str, tz: ZoneInfo, now: datetime) -> str:
+    if not cron:
+        return ""
+    try:
+        trigger = CronTrigger.from_crontab(cron, timezone=tz)
+        next_run = trigger.get_next_fire_time(None, now)
+        if next_run:
+            return next_run.strftime("%a %H:%M")
+    except Exception as e:
+        log.warning("Could not calculate next run time: %s", e)
+    return ""
+
+
+async def reload_schedules(scheduler: AsyncIOScheduler, data_client: DataClient, runner: TaskRunner, timezone: str):
+    schedules = await load_schedules(data_client)
+    tz = ZoneInfo(timezone)
+
+    builtin_jobs = {"reload_watcher"}
+    for job in scheduler.get_jobs():
+        if job.id not in builtin_jobs:
+            job.remove()
+
+    for task in schedules:
+        cron = task.get("cron_expression", "")
+        name = task.get("task_name", "task")
+        if not cron:
+            log.warning("Task '%s' has no schedule — skipping.", name)
+            continue
+        try:
+            scheduler.add_job(
+                runner.run_task,
+                CronTrigger.from_crontab(cron, timezone=tz),
+                args=[task],
+                id=f"task_{name}",
+                name=name,
+                replace_existing=True,
+            )
+            log.info("Scheduled '%s' with cron '%s' (%s)", name, cron, timezone)
+        except Exception as e:
+            log.error("Invalid schedule for '%s': %s", name, e)
+
+
+def setup_scheduler(
+    data_client: DataClient,
+    runner: TaskRunner,
+    timezone: str,
+) -> AsyncIOScheduler:
+    scheduler = AsyncIOScheduler(
+        job_defaults={"misfire_grace_time": 300, "coalesce": True}
+    )
+
+    async def _reload():
+        await reload_schedules(scheduler, data_client, runner, timezone)
+
+    scheduler.add_job(
+        _reload,
+        "interval",
+        minutes=RELOAD_INTERVAL_MINUTES,
+        id="reload_watcher",
+        name="Schedule reload watcher",
+    )
+    return scheduler

--- a/bede-core/src/bede_core/session_manager.py
+++ b/bede-core/src/bede_core/session_manager.py
@@ -1,0 +1,159 @@
+import logging
+import subprocess
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from bede_core.claude_cli import ClaudeCli, ClaudeResult
+from bede_core.data_client import DataClient
+from bede_core.memory_manager import MemoryManager
+
+log = logging.getLogger(__name__)
+
+
+class SessionManager:
+    def __init__(
+        self,
+        data_client: DataClient,
+        claude_cli: ClaudeCli,
+        memory_manager: MemoryManager,
+        timezone: str,
+        model: str,
+        vault_path: str,
+    ):
+        self._data = data_client
+        self._cli = claude_cli
+        self._memory = memory_manager
+        self._tz = ZoneInfo(timezone)
+        self._model = model
+        self._vault_path = vault_path
+        self._session_cleared = False
+
+    def _today(self) -> str:
+        return datetime.now(self._tz).strftime("%Y-%m-%d")
+
+    def _now_str(self) -> str:
+        return datetime.now(self._tz).strftime("%Y-%m-%d %H:%M")
+
+    async def _get_daily_session_id(self) -> str | None:
+        if self._session_cleared:
+            return None
+        date = self._today()
+        result = await self._data.get("/api/sessions/daily", date=date)
+        if "error" in result:
+            return None
+        return result.get("session_id")
+
+    async def _store_daily_session(self, session_id: str):
+        date = self._today()
+        await self._data.post("/api/sessions/daily", body={"date": date, "session_id": session_id})
+        self._session_cleared = False
+
+    async def _get_scratchpad(self) -> str:
+        date = self._today()
+        result = await self._data.get("/api/scratchpad", date=date)
+        entries = result.get("entries", [])
+        if not entries:
+            return ""
+        lines = [f"[{e['entry_time']}] {e['content']}" for e in entries]
+        return "## Earlier today\n\n" + "\n".join(lines)
+
+    async def _append_scratchpad(self, content: str):
+        date = self._today()
+        entry_time = datetime.now(self._tz).strftime("%H:%M")
+        await self._data.post("/api/scratchpad", body={
+            "date": date,
+            "entry_time": entry_time,
+            "content": content,
+        })
+
+    async def _build_context(self, message: str, is_new_session: bool) -> str:
+        parts: list[str] = []
+
+        now = datetime.now(self._tz)
+        parts.append(f"Current date and time: {now.strftime('%A, %d %B %Y %H:%M')} ({self._tz})")
+
+        memory_context = await self._memory.get_context()
+        if memory_context:
+            parts.append(memory_context)
+
+        if is_new_session:
+            scratchpad = await self._get_scratchpad()
+            if scratchpad:
+                parts.append(scratchpad)
+
+        parts.append(message)
+        return "\n\n".join(parts)
+
+    def _pull_vault(self):
+        import os
+        if not os.path.isdir(f"{self._vault_path}/.git"):
+            return
+        try:
+            subprocess.run(
+                ["git", "-C", self._vault_path, "pull", "--ff-only"],
+                capture_output=True, timeout=30,
+            )
+        except Exception as e:
+            log.warning("Vault pull failed: %s", e)
+
+    async def send(
+        self,
+        message: str,
+        model: str | None = None,
+        timeout: int | None = None,
+    ) -> ClaudeResult:
+        import asyncio
+        await asyncio.to_thread(self._pull_vault)
+
+        effective_model = model or self._model
+        session_id = await self._get_daily_session_id()
+        is_new_session = session_id is None
+
+        if is_new_session:
+            prompt = await self._build_context(message, is_new_session=True)
+        else:
+            prompt = await self._build_context(message, is_new_session=False)
+
+        result = await self._cli.run(
+            prompt=prompt,
+            model=effective_model,
+            session_id=session_id,
+            timeout=timeout,
+        )
+
+        if result.stale_session and session_id:
+            log.warning("Stale session %s, retrying fresh.", session_id)
+            prompt = await self._build_context(message, is_new_session=True)
+            result = await self._cli.run(
+                prompt=prompt,
+                model=effective_model,
+                session_id=None,
+                timeout=timeout,
+            )
+            result.stale_session = False
+
+        if result.session_id and result.session_id != session_id:
+            await self._store_daily_session(result.session_id)
+
+        if result.text and not result.timed_out and not result.auth_failure:
+            summary = f"User: {message[:100]}\nBede: {result.text[:200]}"
+            await self._append_scratchpad(summary)
+
+        return result
+
+    async def send_task(
+        self,
+        prompt: str,
+        model: str | None = None,
+        timeout: int | None = None,
+    ) -> ClaudeResult:
+        """Send a scheduled task prompt through the daily session."""
+        return await self.send(prompt, model=model, timeout=timeout)
+
+    async def clear_daily_session(self):
+        """Clear the daily session so the next message starts fresh."""
+        self._session_cleared = True
+
+    async def append_scratchpad_entry(self, content: str):
+        """Public method to add a scratchpad entry after a completed interaction."""
+        await self._append_scratchpad(content)

--- a/bede-core/src/bede_core/session_manager.py
+++ b/bede-core/src/bede_core/session_manager.py
@@ -45,7 +45,9 @@ class SessionManager:
 
     async def _store_daily_session(self, session_id: str):
         date = self._today()
-        await self._data.post("/api/sessions/daily", body={"date": date, "session_id": session_id})
+        await self._data.post(
+            "/api/sessions/daily", body={"date": date, "session_id": session_id}
+        )
         self._session_cleared = False
 
     async def _get_scratchpad(self) -> str:
@@ -60,17 +62,22 @@ class SessionManager:
     async def _append_scratchpad(self, content: str):
         date = self._today()
         entry_time = datetime.now(self._tz).strftime("%H:%M")
-        await self._data.post("/api/scratchpad", body={
-            "date": date,
-            "entry_time": entry_time,
-            "content": content,
-        })
+        await self._data.post(
+            "/api/scratchpad",
+            body={
+                "date": date,
+                "entry_time": entry_time,
+                "content": content,
+            },
+        )
 
     async def _build_context(self, message: str, is_new_session: bool) -> str:
         parts: list[str] = []
 
         now = datetime.now(self._tz)
-        parts.append(f"Current date and time: {now.strftime('%A, %d %B %Y %H:%M')} ({self._tz})")
+        parts.append(
+            f"Current date and time: {now.strftime('%A, %d %B %Y %H:%M')} ({self._tz})"
+        )
 
         memory_context = await self._memory.get_context()
         if memory_context:
@@ -86,12 +93,14 @@ class SessionManager:
 
     def _pull_vault(self):
         import os
+
         if not os.path.isdir(f"{self._vault_path}/.git"):
             return
         try:
             subprocess.run(
                 ["git", "-C", self._vault_path, "pull", "--ff-only"],
-                capture_output=True, timeout=30,
+                capture_output=True,
+                timeout=30,
             )
         except Exception as e:
             log.warning("Vault pull failed: %s", e)
@@ -103,6 +112,7 @@ class SessionManager:
         timeout: int | None = None,
     ) -> ClaudeResult:
         import asyncio
+
         await asyncio.to_thread(self._pull_vault)
 
         effective_model = model or self._model

--- a/bede-core/src/bede_core/telegram_format.py
+++ b/bede-core/src/bede_core/telegram_format.py
@@ -1,0 +1,37 @@
+import re
+
+
+def md_to_html(text: str) -> str:
+    """Convert CommonMark-style markdown to Telegram HTML."""
+    text = text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    text = re.sub(r"```(?:\w+\n)?(.*?)```", r"<pre>\1</pre>", text, flags=re.DOTALL)
+    text = re.sub(r"`([^`\n]+)`", r"<code>\1</code>", text)
+    text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r'<a href="\2">\1</a>', text)
+    text = re.sub(r"^#{1,3} (.+)$", r"<b>\1</b>", text, flags=re.MULTILINE)
+    text = re.sub(r"\*\*\*(.*?)\*\*\*", r"<b><i>\1</i></b>", text, flags=re.DOTALL)
+    text = re.sub(r"\*\*(.*?)\*\*", r"<b>\1</b>", text, flags=re.DOTALL)
+    text = re.sub(r"__(.*?)__", r"<b>\1</b>", text, flags=re.DOTALL)
+    text = re.sub(r"\*(.*?)\*", r"<i>\1</i>", text, flags=re.DOTALL)
+    text = re.sub(r"(?<!\w)_([^_\n]+)_(?!\w)", r"<i>\1</i>", text)
+    return text
+
+
+def chunk_text(text: str, max_len: int = 4096) -> list[str]:
+    """Split text into chunks at paragraph boundaries."""
+    if len(text) <= max_len:
+        return [text]
+    chunks: list[str] = []
+    while text:
+        if len(text) <= max_len:
+            chunks.append(text)
+            break
+        split_at = text.rfind("\n\n", 0, max_len)
+        if split_at == -1:
+            split_at = text.rfind("\n", 0, max_len)
+        if split_at == -1:
+            split_at = text.rfind(" ", 0, max_len)
+        if split_at == -1:
+            split_at = max_len
+        chunks.append(text[:split_at].rstrip())
+        text = text[split_at:].lstrip("\n")
+    return chunks

--- a/bede-core/tests/test_bot.py
+++ b/bede-core/tests/test_bot.py
@@ -1,0 +1,117 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bede_core.claude_cli import ClaudeResult
+
+
+class FakeUser:
+    def __init__(self, uid):
+        self.id = uid
+
+
+class FakeChat:
+    def __init__(self, cid):
+        self.id = cid
+
+
+class FakeMessage:
+    def __init__(self, text, user_id=12345, chat_id=12345):
+        self.text = text
+        self.reply_text = AsyncMock()
+        self.from_user = FakeUser(user_id)
+        self.chat = FakeChat(chat_id)
+
+
+class FakeUpdate:
+    def __init__(self, text, user_id=12345, chat_id=12345):
+        self.message = FakeMessage(text, user_id, chat_id)
+        self.effective_user = FakeUser(user_id)
+        self.effective_chat = FakeChat(chat_id)
+
+
+class FakeContext:
+    def __init__(self):
+        self.bot = AsyncMock()
+
+
+@pytest.fixture
+def session_manager():
+    return AsyncMock()
+
+
+@pytest.fixture
+def quiet_hours_check():
+    return MagicMock(return_value=False)
+
+
+class TestBotHandlers:
+    async def test_rejects_unauthorized_user(self, session_manager):
+        from bede_core.bot import create_message_handler
+        handler = create_message_handler(session_manager, allowed_user_id=12345, timezone="Australia/Sydney")
+
+        update = FakeUpdate("hello", user_id=99999)
+        context = FakeContext()
+        await handler(update, context)
+
+        session_manager.send.assert_not_called()
+        update.message.reply_text.assert_not_called()
+
+    async def test_handles_normal_message(self, session_manager):
+        from bede_core.bot import create_message_handler
+        handler = create_message_handler(session_manager, allowed_user_id=12345, timezone="Australia/Sydney")
+
+        session_manager.send.return_value = ClaudeResult(text="Hi there!", session_id="s1")
+        update = FakeUpdate("hello", user_id=12345)
+        context = FakeContext()
+        await handler(update, context)
+
+        session_manager.send.assert_called_once()
+        update.message.reply_text.assert_called()
+
+    async def test_handles_timeout(self, session_manager):
+        from bede_core.bot import create_message_handler
+        handler = create_message_handler(session_manager, allowed_user_id=12345, timezone="Australia/Sydney")
+
+        session_manager.send.return_value = ClaudeResult(timed_out=True)
+        update = FakeUpdate("hello", user_id=12345)
+        context = FakeContext()
+        await handler(update, context)
+
+        calls = [str(c) for c in update.message.reply_text.call_args_list]
+        assert any("timed out" in c.lower() for c in calls)
+
+    async def test_handles_auth_failure(self, session_manager):
+        from bede_core.bot import create_message_handler
+        handler = create_message_handler(session_manager, allowed_user_id=12345, timezone="Australia/Sydney")
+
+        session_manager.send.return_value = ClaudeResult(auth_failure=True)
+        update = FakeUpdate("hello", user_id=12345)
+        context = FakeContext()
+        await handler(update, context)
+
+        calls = [str(c) for c in update.message.reply_text.call_args_list]
+        assert any("auth" in c.lower() or "expired" in c.lower() for c in calls)
+
+
+class TestResetHandler:
+    async def test_reset_clears_session(self, session_manager):
+        from bede_core.bot import create_reset_handler
+        handler = create_reset_handler(session_manager, allowed_user_id=12345)
+
+        update = FakeUpdate("/reset", user_id=12345)
+        context = FakeContext()
+        await handler(update, context)
+
+        session_manager.clear_daily_session.assert_called_once()
+        update.message.reply_text.assert_called_once()
+        assert "cleared" in update.message.reply_text.call_args.args[0].lower()
+
+    async def test_reset_rejects_unauthorized(self, session_manager):
+        from bede_core.bot import create_reset_handler
+        handler = create_reset_handler(session_manager, allowed_user_id=12345)
+
+        update = FakeUpdate("/reset", user_id=99999)
+        context = FakeContext()
+        await handler(update, context)
+
+        session_manager.clear_daily_session.assert_not_called()

--- a/bede-core/tests/test_bot.py
+++ b/bede-core/tests/test_bot.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 from bede_core.claude_cli import ClaudeResult
 
@@ -47,7 +47,10 @@ def quiet_hours_check():
 class TestBotHandlers:
     async def test_rejects_unauthorized_user(self, session_manager):
         from bede_core.bot import create_message_handler
-        handler = create_message_handler(session_manager, allowed_user_id=12345, timezone="Australia/Sydney")
+
+        handler = create_message_handler(
+            session_manager, allowed_user_id=12345, timezone="Australia/Sydney"
+        )
 
         update = FakeUpdate("hello", user_id=99999)
         context = FakeContext()
@@ -58,9 +61,14 @@ class TestBotHandlers:
 
     async def test_handles_normal_message(self, session_manager):
         from bede_core.bot import create_message_handler
-        handler = create_message_handler(session_manager, allowed_user_id=12345, timezone="Australia/Sydney")
 
-        session_manager.send.return_value = ClaudeResult(text="Hi there!", session_id="s1")
+        handler = create_message_handler(
+            session_manager, allowed_user_id=12345, timezone="Australia/Sydney"
+        )
+
+        session_manager.send.return_value = ClaudeResult(
+            text="Hi there!", session_id="s1"
+        )
         update = FakeUpdate("hello", user_id=12345)
         context = FakeContext()
         await handler(update, context)
@@ -70,7 +78,10 @@ class TestBotHandlers:
 
     async def test_handles_timeout(self, session_manager):
         from bede_core.bot import create_message_handler
-        handler = create_message_handler(session_manager, allowed_user_id=12345, timezone="Australia/Sydney")
+
+        handler = create_message_handler(
+            session_manager, allowed_user_id=12345, timezone="Australia/Sydney"
+        )
 
         session_manager.send.return_value = ClaudeResult(timed_out=True)
         update = FakeUpdate("hello", user_id=12345)
@@ -82,7 +93,10 @@ class TestBotHandlers:
 
     async def test_handles_auth_failure(self, session_manager):
         from bede_core.bot import create_message_handler
-        handler = create_message_handler(session_manager, allowed_user_id=12345, timezone="Australia/Sydney")
+
+        handler = create_message_handler(
+            session_manager, allowed_user_id=12345, timezone="Australia/Sydney"
+        )
 
         session_manager.send.return_value = ClaudeResult(auth_failure=True)
         update = FakeUpdate("hello", user_id=12345)
@@ -96,6 +110,7 @@ class TestBotHandlers:
 class TestResetHandler:
     async def test_reset_clears_session(self, session_manager):
         from bede_core.bot import create_reset_handler
+
         handler = create_reset_handler(session_manager, allowed_user_id=12345)
 
         update = FakeUpdate("/reset", user_id=12345)
@@ -108,6 +123,7 @@ class TestResetHandler:
 
     async def test_reset_rejects_unauthorized(self, session_manager):
         from bede_core.bot import create_reset_handler
+
         handler = create_reset_handler(session_manager, allowed_user_id=12345)
 
         update = FakeUpdate("/reset", user_id=99999)

--- a/bede-core/tests/test_claude_cli.py
+++ b/bede-core/tests/test_claude_cli.py
@@ -1,0 +1,130 @@
+import json
+import subprocess
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from bede_core.claude_cli import ClaudeCli, ClaudeResult, build_command, parse_output
+
+
+class TestBuildCommand:
+    def test_basic_command(self):
+        cmd = build_command("hello", model="claude-sonnet-4-5-20250514")
+        assert cmd[:2] == ["claude", "-p"]
+        assert "hello" in cmd
+        assert "--model" in cmd
+        assert "--dangerously-skip-permissions" in cmd
+        assert "--output-format" in cmd
+        assert "json" in cmd
+
+    def test_with_session_resume(self):
+        cmd = build_command("hello", model="claude-sonnet-4-5-20250514", session_id="abc-123")
+        assert "--resume" in cmd
+        idx = cmd.index("--resume")
+        assert cmd[idx + 1] == "abc-123"
+
+    def test_without_session(self):
+        cmd = build_command("hello", model="claude-sonnet-4-5-20250514")
+        assert "--resume" not in cmd
+
+    def test_mcp_config(self):
+        cmd = build_command("hello", model="claude-sonnet-4-5-20250514", mcp_config="/path/mcp.json")
+        assert "--mcp-config" in cmd
+        idx = cmd.index("--mcp-config")
+        assert cmd[idx + 1] == "/path/mcp.json"
+
+
+class TestParseOutput:
+    def test_extracts_result(self):
+        stdout = json.dumps({"type": "result", "result": "hello world", "session_id": "sess-1", "stop_reason": "end_turn"})
+        r = parse_output(stdout)
+        assert r.text == "hello world"
+        assert r.session_id == "sess-1"
+        assert r.stop_reason == "end_turn"
+
+    def test_multiple_lines(self):
+        lines = [
+            json.dumps({"type": "assistant", "content": "thinking..."}),
+            json.dumps({"type": "result", "result": "final answer", "session_id": "s2", "stop_reason": "end_turn"}),
+        ]
+        r = parse_output("\n".join(lines))
+        assert r.text == "final answer"
+        assert r.session_id == "s2"
+
+    def test_empty_stdout(self):
+        r = parse_output("")
+        assert r.text == ""
+        assert r.session_id is None
+
+    def test_max_tokens(self):
+        stdout = json.dumps({"type": "result", "result": "truncated", "session_id": "s3", "stop_reason": "max_tokens"})
+        r = parse_output(stdout)
+        assert r.stop_reason == "max_tokens"
+
+    def test_invalid_json_lines_skipped(self):
+        lines = ["not json", json.dumps({"type": "result", "result": "ok", "session_id": "s4", "stop_reason": "end_turn"})]
+        r = parse_output("\n".join(lines))
+        assert r.text == "ok"
+
+
+class TestClaudeCli:
+    async def test_run_success(self):
+        mock_result = subprocess.CompletedProcess(
+            args=["claude"], returncode=0,
+            stdout=json.dumps({"type": "result", "result": "hi", "session_id": "s1", "stop_reason": "end_turn"}),
+            stderr="",
+        )
+        cli = ClaudeCli(workdir="/app", timeout=300)
+        with patch("bede_core.claude_cli._run_subprocess", return_value=mock_result):
+            r = await cli.run("hello", model="claude-sonnet-4-5-20250514")
+        assert r.text == "hi"
+        assert r.session_id == "s1"
+        assert r.returncode == 0
+
+    async def test_run_timeout(self):
+        cli = ClaudeCli(workdir="/app", timeout=1)
+        with patch("bede_core.claude_cli._run_subprocess", side_effect=subprocess.TimeoutExpired(cmd="claude", timeout=1)):
+            r = await cli.run("hello", model="claude-sonnet-4-5-20250514")
+        assert r.timed_out is True
+        assert r.text == ""
+
+    async def test_run_stale_session_detected(self):
+        mock_result = subprocess.CompletedProcess(
+            args=["claude"], returncode=1,
+            stdout="",
+            stderr="Error: no conversation found for session abc",
+        )
+        cli = ClaudeCli(workdir="/app", timeout=300)
+        with patch("bede_core.claude_cli._run_subprocess", return_value=mock_result):
+            r = await cli.run("hello", model="claude-sonnet-4-5-20250514", session_id="abc")
+        assert r.stale_session is True
+
+    async def test_run_auth_failure_detected(self):
+        mock_result = subprocess.CompletedProcess(
+            args=["claude"], returncode=1,
+            stdout="",
+            stderr="Authentication failed: unauthorized",
+        )
+        cli = ClaudeCli(workdir="/app", timeout=300)
+        with patch("bede_core.claude_cli._run_subprocess", return_value=mock_result):
+            r = await cli.run("hello", model="claude-sonnet-4-5-20250514")
+        assert r.auth_failure is True
+
+    async def test_env_filtering(self):
+        cli = ClaudeCli(workdir="/app", timeout=300, filter_env_keys=["SECRET_TOKEN"])
+        captured_env = {}
+
+        def fake_run(cmd, workdir, timeout, env=None):
+            if env:
+                captured_env.update(env)
+            return subprocess.CompletedProcess(
+                args=cmd, returncode=0,
+                stdout=json.dumps({"type": "result", "result": "ok", "session_id": "s1", "stop_reason": "end_turn"}),
+                stderr="",
+            )
+
+        with patch("bede_core.claude_cli._run_subprocess", side_effect=fake_run):
+            with patch.dict("os.environ", {"SECRET_TOKEN": "secret", "SAFE_VAR": "ok"}, clear=True):
+                await cli.run("hello", model="claude-sonnet-4-5-20250514")
+        assert "SECRET_TOKEN" not in captured_env
+        assert captured_env.get("SAFE_VAR") == "ok"

--- a/bede-core/tests/test_claude_cli.py
+++ b/bede-core/tests/test_claude_cli.py
@@ -1,10 +1,9 @@
 import json
 import subprocess
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 
-import pytest
 
-from bede_core.claude_cli import ClaudeCli, ClaudeResult, build_command, parse_output
+from bede_core.claude_cli import ClaudeCli, build_command, parse_output
 
 
 class TestBuildCommand:
@@ -18,7 +17,9 @@ class TestBuildCommand:
         assert "json" in cmd
 
     def test_with_session_resume(self):
-        cmd = build_command("hello", model="claude-sonnet-4-5-20250514", session_id="abc-123")
+        cmd = build_command(
+            "hello", model="claude-sonnet-4-5-20250514", session_id="abc-123"
+        )
         assert "--resume" in cmd
         idx = cmd.index("--resume")
         assert cmd[idx + 1] == "abc-123"
@@ -28,7 +29,9 @@ class TestBuildCommand:
         assert "--resume" not in cmd
 
     def test_mcp_config(self):
-        cmd = build_command("hello", model="claude-sonnet-4-5-20250514", mcp_config="/path/mcp.json")
+        cmd = build_command(
+            "hello", model="claude-sonnet-4-5-20250514", mcp_config="/path/mcp.json"
+        )
         assert "--mcp-config" in cmd
         idx = cmd.index("--mcp-config")
         assert cmd[idx + 1] == "/path/mcp.json"
@@ -36,7 +39,14 @@ class TestBuildCommand:
 
 class TestParseOutput:
     def test_extracts_result(self):
-        stdout = json.dumps({"type": "result", "result": "hello world", "session_id": "sess-1", "stop_reason": "end_turn"})
+        stdout = json.dumps(
+            {
+                "type": "result",
+                "result": "hello world",
+                "session_id": "sess-1",
+                "stop_reason": "end_turn",
+            }
+        )
         r = parse_output(stdout)
         assert r.text == "hello world"
         assert r.session_id == "sess-1"
@@ -45,7 +55,14 @@ class TestParseOutput:
     def test_multiple_lines(self):
         lines = [
             json.dumps({"type": "assistant", "content": "thinking..."}),
-            json.dumps({"type": "result", "result": "final answer", "session_id": "s2", "stop_reason": "end_turn"}),
+            json.dumps(
+                {
+                    "type": "result",
+                    "result": "final answer",
+                    "session_id": "s2",
+                    "stop_reason": "end_turn",
+                }
+            ),
         ]
         r = parse_output("\n".join(lines))
         assert r.text == "final answer"
@@ -57,12 +74,29 @@ class TestParseOutput:
         assert r.session_id is None
 
     def test_max_tokens(self):
-        stdout = json.dumps({"type": "result", "result": "truncated", "session_id": "s3", "stop_reason": "max_tokens"})
+        stdout = json.dumps(
+            {
+                "type": "result",
+                "result": "truncated",
+                "session_id": "s3",
+                "stop_reason": "max_tokens",
+            }
+        )
         r = parse_output(stdout)
         assert r.stop_reason == "max_tokens"
 
     def test_invalid_json_lines_skipped(self):
-        lines = ["not json", json.dumps({"type": "result", "result": "ok", "session_id": "s4", "stop_reason": "end_turn"})]
+        lines = [
+            "not json",
+            json.dumps(
+                {
+                    "type": "result",
+                    "result": "ok",
+                    "session_id": "s4",
+                    "stop_reason": "end_turn",
+                }
+            ),
+        ]
         r = parse_output("\n".join(lines))
         assert r.text == "ok"
 
@@ -70,8 +104,16 @@ class TestParseOutput:
 class TestClaudeCli:
     async def test_run_success(self):
         mock_result = subprocess.CompletedProcess(
-            args=["claude"], returncode=0,
-            stdout=json.dumps({"type": "result", "result": "hi", "session_id": "s1", "stop_reason": "end_turn"}),
+            args=["claude"],
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "type": "result",
+                    "result": "hi",
+                    "session_id": "s1",
+                    "stop_reason": "end_turn",
+                }
+            ),
             stderr="",
         )
         cli = ClaudeCli(workdir="/app", timeout=300)
@@ -83,25 +125,32 @@ class TestClaudeCli:
 
     async def test_run_timeout(self):
         cli = ClaudeCli(workdir="/app", timeout=1)
-        with patch("bede_core.claude_cli._run_subprocess", side_effect=subprocess.TimeoutExpired(cmd="claude", timeout=1)):
+        with patch(
+            "bede_core.claude_cli._run_subprocess",
+            side_effect=subprocess.TimeoutExpired(cmd="claude", timeout=1),
+        ):
             r = await cli.run("hello", model="claude-sonnet-4-5-20250514")
         assert r.timed_out is True
         assert r.text == ""
 
     async def test_run_stale_session_detected(self):
         mock_result = subprocess.CompletedProcess(
-            args=["claude"], returncode=1,
+            args=["claude"],
+            returncode=1,
             stdout="",
             stderr="Error: no conversation found for session abc",
         )
         cli = ClaudeCli(workdir="/app", timeout=300)
         with patch("bede_core.claude_cli._run_subprocess", return_value=mock_result):
-            r = await cli.run("hello", model="claude-sonnet-4-5-20250514", session_id="abc")
+            r = await cli.run(
+                "hello", model="claude-sonnet-4-5-20250514", session_id="abc"
+            )
         assert r.stale_session is True
 
     async def test_run_auth_failure_detected(self):
         mock_result = subprocess.CompletedProcess(
-            args=["claude"], returncode=1,
+            args=["claude"],
+            returncode=1,
             stdout="",
             stderr="Authentication failed: unauthorized",
         )
@@ -118,13 +167,23 @@ class TestClaudeCli:
             if env:
                 captured_env.update(env)
             return subprocess.CompletedProcess(
-                args=cmd, returncode=0,
-                stdout=json.dumps({"type": "result", "result": "ok", "session_id": "s1", "stop_reason": "end_turn"}),
+                args=cmd,
+                returncode=0,
+                stdout=json.dumps(
+                    {
+                        "type": "result",
+                        "result": "ok",
+                        "session_id": "s1",
+                        "stop_reason": "end_turn",
+                    }
+                ),
                 stderr="",
             )
 
         with patch("bede_core.claude_cli._run_subprocess", side_effect=fake_run):
-            with patch.dict("os.environ", {"SECRET_TOKEN": "secret", "SAFE_VAR": "ok"}, clear=True):
+            with patch.dict(
+                "os.environ", {"SECRET_TOKEN": "secret", "SAFE_VAR": "ok"}, clear=True
+            ):
                 await cli.run("hello", model="claude-sonnet-4-5-20250514")
         assert "SECRET_TOKEN" not in captured_env
         assert captured_env.get("SAFE_VAR") == "ok"

--- a/bede-core/tests/test_config.py
+++ b/bede-core/tests/test_config.py
@@ -1,0 +1,40 @@
+import os
+
+
+def test_settings_defaults():
+    """Settings load with sensible defaults when no env vars are set."""
+    os.environ.pop("TELEGRAM_BOT_TOKEN", None)
+    os.environ.pop("ALLOWED_USER_ID", None)
+    from bede_core.config import Settings
+    s = Settings(telegram_bot_token="test-token", allowed_user_id=12345)
+    assert s.telegram_bot_token == "test-token"
+    assert s.allowed_user_id == 12345
+    assert s.claude_model == "claude-sonnet-4-5-20250514"
+    assert s.claude_workdir == "/app"
+    assert s.session_timeout_minutes == 120
+    assert s.timezone == "Australia/Sydney"
+    assert s.bede_data_url == "http://bede-data:8001"
+    assert s.claude_timeout_seconds == 300
+    assert s.interactive_idle_timeout_minutes == 30
+    assert s.interactive_max_age_hours == 2
+    assert s.quiet_hours_start == 22
+    assert s.quiet_hours_end == 7
+    assert s.vault_path == "/vault"
+
+
+def test_settings_from_env(monkeypatch):
+    """Settings can be overridden via environment variables."""
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "my-token")
+    monkeypatch.setenv("ALLOWED_USER_ID", "99999")
+    monkeypatch.setenv("CLAUDE_MODEL", "claude-haiku-4-5-20251001")
+    monkeypatch.setenv("SESSION_TIMEOUT_MINUTES", "60")
+    monkeypatch.setenv("TIMEZONE", "US/Eastern")
+    monkeypatch.setenv("BEDE_DATA_URL", "http://localhost:8001")
+    from bede_core.config import Settings
+    s = Settings()
+    assert s.telegram_bot_token == "my-token"
+    assert s.allowed_user_id == 99999
+    assert s.claude_model == "claude-haiku-4-5-20251001"
+    assert s.session_timeout_minutes == 60
+    assert s.timezone == "US/Eastern"
+    assert s.bede_data_url == "http://localhost:8001"

--- a/bede-core/tests/test_config.py
+++ b/bede-core/tests/test_config.py
@@ -6,6 +6,7 @@ def test_settings_defaults():
     os.environ.pop("TELEGRAM_BOT_TOKEN", None)
     os.environ.pop("ALLOWED_USER_ID", None)
     from bede_core.config import Settings
+
     s = Settings(telegram_bot_token="test-token", allowed_user_id=12345)
     assert s.telegram_bot_token == "test-token"
     assert s.allowed_user_id == 12345
@@ -31,6 +32,7 @@ def test_settings_from_env(monkeypatch):
     monkeypatch.setenv("TIMEZONE", "US/Eastern")
     monkeypatch.setenv("BEDE_DATA_URL", "http://localhost:8001")
     from bede_core.config import Settings
+
     s = Settings()
     assert s.telegram_bot_token == "my-token"
     assert s.allowed_user_id == 99999

--- a/bede-core/tests/test_data_client.py
+++ b/bede-core/tests/test_data_client.py
@@ -37,7 +37,9 @@ async def test_post_success(client, httpx_mock):
         json={"id": 1, "content": "test"},
         status_code=201,
     )
-    result = await client.post("/api/memories", body={"content": "test", "type": "fact"})
+    result = await client.post(
+        "/api/memories", body={"content": "test", "type": "fact"}
+    )
     assert result == {"id": 1, "content": "test"}
 
 

--- a/bede-core/tests/test_data_client.py
+++ b/bede-core/tests/test_data_client.py
@@ -1,0 +1,59 @@
+import re
+
+import httpx
+import pytest
+
+from bede_core.data_client import DataClient
+
+
+@pytest.fixture
+def client():
+    return DataClient(base_url="http://test:8001")
+
+
+async def test_get_success(client, httpx_mock):
+    httpx_mock.add_response(
+        url="http://test:8001/api/health/sleep?date=today",
+        json={"sleep": {"duration": 7.5}},
+    )
+    result = await client.get("/api/health/sleep", date="today")
+    assert result == {"sleep": {"duration": 7.5}}
+
+
+async def test_get_filters_none_params(client, httpx_mock):
+    httpx_mock.add_response(
+        url=re.compile(r"http://test:8001/api/memories"),
+        json={"memories": []},
+    )
+    await client.get("/api/memories", type=None, search="test")
+    request = httpx_mock.get_request()
+    assert "type" not in str(request.url)
+    assert "search=test" in str(request.url)
+
+
+async def test_post_success(client, httpx_mock):
+    httpx_mock.add_response(
+        url="http://test:8001/api/memories",
+        json={"id": 1, "content": "test"},
+        status_code=201,
+    )
+    result = await client.post("/api/memories", body={"content": "test", "type": "fact"})
+    assert result == {"id": 1, "content": "test"}
+
+
+async def test_connection_error(client, httpx_mock):
+    httpx_mock.add_exception(httpx.ConnectError("refused"))
+    result = await client.get("/api/health/sleep", date="today")
+    assert "error" in result
+    assert "unavailable" in result["error"]
+
+
+async def test_http_error(client, httpx_mock):
+    httpx_mock.add_response(
+        url="http://test:8001/api/goals/999",
+        status_code=404,
+        text="Not found",
+    )
+    result = await client.get("/api/goals/999")
+    assert "error" in result
+    assert "404" in result["error"]

--- a/bede-core/tests/test_memory_manager.py
+++ b/bede-core/tests/test_memory_manager.py
@@ -1,0 +1,58 @@
+import pytest
+from unittest.mock import AsyncMock
+
+from bede_core.memory_manager import MemoryManager
+
+
+@pytest.fixture
+def data_client():
+    return AsyncMock()
+
+
+@pytest.fixture
+def mm(data_client):
+    return MemoryManager(data_client, max_context_chars=500)
+
+
+class TestMemoryManager:
+    async def test_get_context_returns_formatted_memories(self, mm, data_client):
+        data_client.get.return_value = {
+            "memories": [
+                {"id": 1, "content": "Training for a half marathon", "type": "fact"},
+                {"id": 2, "content": "Don't nag about meditation", "type": "preference"},
+            ]
+        }
+        context = await mm.get_context()
+        assert "half marathon" in context
+        assert "meditation" in context
+        assert "fact" in context.lower() or "preference" in context.lower()
+
+    async def test_get_context_respects_budget(self, data_client):
+        data_client.get.return_value = {
+            "memories": [
+                {"id": i, "content": f"Memory content number {i} " * 10, "type": "fact"}
+                for i in range(20)
+            ]
+        }
+        mm = MemoryManager(data_client, max_context_chars=200)
+        context = await mm.get_context()
+        assert len(context) <= 250  # some buffer for formatting
+
+    async def test_get_context_empty(self, mm, data_client):
+        data_client.get.return_value = {"memories": []}
+        context = await mm.get_context()
+        assert context == ""
+
+    async def test_get_context_handles_error(self, mm, data_client):
+        data_client.get.return_value = {"error": "bede-data unavailable"}
+        context = await mm.get_context()
+        assert context == ""
+
+    async def test_propose_memory(self, mm, data_client):
+        data_client.post.return_value = {"id": 5, "content": "Likes camping", "type": "fact"}
+        result = await mm.store("Likes camping", "fact", source_conversation="sess-1")
+        data_client.post.assert_called_once_with(
+            "/api/memories",
+            body={"content": "Likes camping", "type": "fact", "source_conversation": "sess-1"},
+        )
+        assert result["id"] == 5

--- a/bede-core/tests/test_memory_manager.py
+++ b/bede-core/tests/test_memory_manager.py
@@ -19,7 +19,11 @@ class TestMemoryManager:
         data_client.get.return_value = {
             "memories": [
                 {"id": 1, "content": "Training for a half marathon", "type": "fact"},
-                {"id": 2, "content": "Don't nag about meditation", "type": "preference"},
+                {
+                    "id": 2,
+                    "content": "Don't nag about meditation",
+                    "type": "preference",
+                },
             ]
         }
         context = await mm.get_context()
@@ -49,10 +53,18 @@ class TestMemoryManager:
         assert context == ""
 
     async def test_propose_memory(self, mm, data_client):
-        data_client.post.return_value = {"id": 5, "content": "Likes camping", "type": "fact"}
+        data_client.post.return_value = {
+            "id": 5,
+            "content": "Likes camping",
+            "type": "fact",
+        }
         result = await mm.store("Likes camping", "fact", source_conversation="sess-1")
         data_client.post.assert_called_once_with(
             "/api/memories",
-            body={"content": "Likes camping", "type": "fact", "source_conversation": "sess-1"},
+            body={
+                "content": "Likes camping",
+                "type": "fact",
+                "source_conversation": "sess-1",
+            },
         )
         assert result["id"] == 5

--- a/bede-core/tests/test_quiet_hours.py
+++ b/bede-core/tests/test_quiet_hours.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from bede_core.quiet_hours import is_quiet_hours
+
+
+TZ = ZoneInfo("Australia/Sydney")
+
+
+def test_quiet_hours_late_night():
+    dt = datetime(2026, 5, 1, 23, 30, tzinfo=TZ)
+    assert is_quiet_hours(dt, start_hour=22, end_hour=7) is True
+
+
+def test_quiet_hours_early_morning():
+    dt = datetime(2026, 5, 1, 5, 0, tzinfo=TZ)
+    assert is_quiet_hours(dt, start_hour=22, end_hour=7) is True
+
+
+def test_not_quiet_hours_afternoon():
+    dt = datetime(2026, 5, 1, 14, 0, tzinfo=TZ)
+    assert is_quiet_hours(dt, start_hour=22, end_hour=7) is False
+
+
+def test_quiet_hours_boundary_start():
+    dt = datetime(2026, 5, 1, 22, 0, tzinfo=TZ)
+    assert is_quiet_hours(dt, start_hour=22, end_hour=7) is True
+
+
+def test_quiet_hours_boundary_end():
+    dt = datetime(2026, 5, 1, 7, 0, tzinfo=TZ)
+    assert is_quiet_hours(dt, start_hour=22, end_hour=7) is False
+
+
+def test_quiet_hours_disabled():
+    dt = datetime(2026, 5, 1, 23, 30, tzinfo=TZ)
+    assert is_quiet_hours(dt, start_hour=0, end_hour=0) is False

--- a/bede-core/tests/test_scheduler.py
+++ b/bede-core/tests/test_scheduler.py
@@ -1,6 +1,5 @@
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
-from datetime import datetime
+from unittest.mock import AsyncMock
 from zoneinfo import ZoneInfo
 
 from bede_core.claude_cli import ClaudeResult
@@ -18,7 +17,9 @@ def data_client():
 @pytest.fixture
 def session_manager():
     sm = AsyncMock()
-    sm.send_task.return_value = ClaudeResult(text="Task done!", session_id="task-sess-1")
+    sm.send_task.return_value = ClaudeResult(
+        text="Task done!", session_id="task-sess-1"
+    )
     return sm
 
 
@@ -43,12 +44,26 @@ class TestLoadSchedules:
     async def test_loads_enabled_schedules(self, data_client):
         data_client.get.return_value = {
             "schedules": [
-                {"id": 1, "task_name": "Morning Briefing", "cron_expression": "0 8 * * 1-5",
-                 "prompt": "Give me a briefing", "model": None, "timeout_seconds": 300,
-                 "interactive": False, "enabled": True},
-                {"id": 2, "task_name": "Disabled Task", "cron_expression": "0 9 * * *",
-                 "prompt": "test", "model": None, "timeout_seconds": 300,
-                 "interactive": False, "enabled": False},
+                {
+                    "id": 1,
+                    "task_name": "Morning Briefing",
+                    "cron_expression": "0 8 * * 1-5",
+                    "prompt": "Give me a briefing",
+                    "model": None,
+                    "timeout_seconds": 300,
+                    "interactive": False,
+                    "enabled": True,
+                },
+                {
+                    "id": 2,
+                    "task_name": "Disabled Task",
+                    "cron_expression": "0 9 * * *",
+                    "prompt": "test",
+                    "model": None,
+                    "timeout_seconds": 300,
+                    "interactive": False,
+                    "enabled": False,
+                },
             ]
         }
         schedules = await load_schedules(data_client)
@@ -62,7 +77,9 @@ class TestLoadSchedules:
 
 
 class TestTaskRunner:
-    async def test_run_task_success(self, runner, data_client, session_manager, send_fn):
+    async def test_run_task_success(
+        self, runner, data_client, session_manager, send_fn
+    ):
         task = {
             "id": 1,
             "task_name": "Morning Briefing",
@@ -72,7 +89,11 @@ class TestTaskRunner:
             "timeout_seconds": 300,
             "interactive": False,
         }
-        data_client.post.return_value = {"id": 1, "task_name": "Morning Briefing", "status": "running"}
+        data_client.post.return_value = {
+            "id": 1,
+            "task_name": "Morning Briefing",
+            "status": "running",
+        }
         data_client.put.return_value = {"id": 1, "status": "success"}
 
         await runner.run_task(task)
@@ -83,7 +104,9 @@ class TestTaskRunner:
         assert data_client.post.call_count >= 1
         assert data_client.put.call_count >= 1
 
-    async def test_run_task_timeout(self, runner, data_client, session_manager, send_fn):
+    async def test_run_task_timeout(
+        self, runner, data_client, session_manager, send_fn
+    ):
         task = {
             "id": 1,
             "task_name": "Slow Task",
@@ -101,9 +124,13 @@ class TestTaskRunner:
 
         send_fn.assert_called()
         last_call_text = send_fn.call_args.args[0] if send_fn.call_args.args else ""
-        assert "timed out" in last_call_text.lower() or "timeout" in last_call_text.lower()
+        assert (
+            "timed out" in last_call_text.lower() or "timeout" in last_call_text.lower()
+        )
 
-    async def test_run_task_prevents_duplicate(self, runner, data_client, session_manager, send_fn):
+    async def test_run_task_prevents_duplicate(
+        self, runner, data_client, session_manager, send_fn
+    ):
         task = {
             "id": 1,
             "task_name": "Morning Briefing",

--- a/bede-core/tests/test_scheduler.py
+++ b/bede-core/tests/test_scheduler.py
@@ -1,0 +1,120 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from bede_core.claude_cli import ClaudeResult
+from bede_core.scheduler import TaskRunner, load_schedules
+
+
+TZ = ZoneInfo("Australia/Sydney")
+
+
+@pytest.fixture
+def data_client():
+    return AsyncMock()
+
+
+@pytest.fixture
+def session_manager():
+    sm = AsyncMock()
+    sm.send_task.return_value = ClaudeResult(text="Task done!", session_id="task-sess-1")
+    return sm
+
+
+@pytest.fixture
+def send_fn():
+    return AsyncMock()
+
+
+@pytest.fixture
+def runner(data_client, session_manager, send_fn):
+    return TaskRunner(
+        data_client=data_client,
+        session_manager=session_manager,
+        send_fn=send_fn,
+        timezone="Australia/Sydney",
+        quiet_hours_start=0,
+        quiet_hours_end=0,
+    )
+
+
+class TestLoadSchedules:
+    async def test_loads_enabled_schedules(self, data_client):
+        data_client.get.return_value = {
+            "schedules": [
+                {"id": 1, "task_name": "Morning Briefing", "cron_expression": "0 8 * * 1-5",
+                 "prompt": "Give me a briefing", "model": None, "timeout_seconds": 300,
+                 "interactive": False, "enabled": True},
+                {"id": 2, "task_name": "Disabled Task", "cron_expression": "0 9 * * *",
+                 "prompt": "test", "model": None, "timeout_seconds": 300,
+                 "interactive": False, "enabled": False},
+            ]
+        }
+        schedules = await load_schedules(data_client)
+        assert len(schedules) == 1
+        assert schedules[0]["task_name"] == "Morning Briefing"
+
+    async def test_handles_api_error(self, data_client):
+        data_client.get.return_value = {"error": "bede-data unavailable"}
+        schedules = await load_schedules(data_client)
+        assert schedules == []
+
+
+class TestTaskRunner:
+    async def test_run_task_success(self, runner, data_client, session_manager, send_fn):
+        task = {
+            "id": 1,
+            "task_name": "Morning Briefing",
+            "cron_expression": "0 8 * * 1-5",
+            "prompt": "Give me a morning briefing",
+            "model": None,
+            "timeout_seconds": 300,
+            "interactive": False,
+        }
+        data_client.post.return_value = {"id": 1, "task_name": "Morning Briefing", "status": "running"}
+        data_client.put.return_value = {"id": 1, "status": "success"}
+
+        await runner.run_task(task)
+
+        session_manager.send_task.assert_called_once()
+        assert send_fn.call_count >= 1
+        # Task log should be created and updated
+        assert data_client.post.call_count >= 1
+        assert data_client.put.call_count >= 1
+
+    async def test_run_task_timeout(self, runner, data_client, session_manager, send_fn):
+        task = {
+            "id": 1,
+            "task_name": "Slow Task",
+            "cron_expression": "0 8 * * *",
+            "prompt": "Do something slow",
+            "model": None,
+            "timeout_seconds": 60,
+            "interactive": False,
+        }
+        session_manager.send_task.return_value = ClaudeResult(timed_out=True)
+        data_client.post.return_value = {"id": 1, "status": "running"}
+        data_client.put.return_value = {"id": 1, "status": "timeout"}
+
+        await runner.run_task(task)
+
+        send_fn.assert_called()
+        last_call_text = send_fn.call_args.args[0] if send_fn.call_args.args else ""
+        assert "timed out" in last_call_text.lower() or "timeout" in last_call_text.lower()
+
+    async def test_run_task_prevents_duplicate(self, runner, data_client, session_manager, send_fn):
+        task = {
+            "id": 1,
+            "task_name": "Morning Briefing",
+            "cron_expression": "0 8 * * *",
+            "prompt": "test",
+            "model": None,
+            "timeout_seconds": 300,
+            "interactive": False,
+        }
+        runner._running.add("Morning Briefing")
+
+        await runner.run_task(task)
+
+        session_manager.send_task.assert_not_called()

--- a/bede-core/tests/test_session_manager.py
+++ b/bede-core/tests/test_session_manager.py
@@ -1,6 +1,5 @@
 import pytest
-from unittest.mock import AsyncMock, patch, MagicMock
-from datetime import datetime
+from unittest.mock import AsyncMock
 from zoneinfo import ZoneInfo
 
 from bede_core.claude_cli import ClaudeResult
@@ -41,52 +40,88 @@ def sm(data_client, claude_cli, memory_manager):
 
 class TestSessionManager:
     async def test_send_creates_new_daily_session(self, sm, data_client, claude_cli):
-        data_client.get.return_value = {"error": "bede-data returned 404", "detail": "No session for this date"}
-        claude_cli.run.return_value = ClaudeResult(text="Hello!", session_id="new-sess-1")
-        data_client.post.return_value = {"date": "2026-05-01", "session_id": "new-sess-1"}
+        data_client.get.return_value = {
+            "error": "bede-data returned 404",
+            "detail": "No session for this date",
+        }
+        claude_cli.run.return_value = ClaudeResult(
+            text="Hello!", session_id="new-sess-1"
+        )
+        data_client.post.return_value = {
+            "date": "2026-05-01",
+            "session_id": "new-sess-1",
+        }
 
         result = await sm.send("Hi there")
 
         assert result.text == "Hello!"
         assert claude_cli.run.call_count == 1
         call_kwargs = claude_cli.run.call_args
-        assert "--resume" not in str(call_kwargs) or call_kwargs.kwargs.get("session_id") is None
+        assert (
+            "--resume" not in str(call_kwargs)
+            or call_kwargs.kwargs.get("session_id") is None
+        )
 
     async def test_send_resumes_existing_session(self, sm, data_client, claude_cli):
-        data_client.get.return_value = {"date": "2026-05-01", "session_id": "existing-sess"}
-        claude_cli.run.return_value = ClaudeResult(text="Welcome back!", session_id="existing-sess")
+        data_client.get.return_value = {
+            "date": "2026-05-01",
+            "session_id": "existing-sess",
+        }
+        claude_cli.run.return_value = ClaudeResult(
+            text="Welcome back!", session_id="existing-sess"
+        )
 
         result = await sm.send("What's up?")
 
         assert result.text == "Welcome back!"
         call_kwargs = claude_cli.run.call_args
-        assert call_kwargs.kwargs.get("session_id") == "existing-sess" or "existing-sess" in str(call_kwargs)
+        assert call_kwargs.kwargs.get(
+            "session_id"
+        ) == "existing-sess" or "existing-sess" in str(call_kwargs)
 
     async def test_send_retries_on_stale_session(self, sm, data_client, claude_cli):
-        data_client.get.return_value = {"date": "2026-05-01", "session_id": "stale-sess"}
+        data_client.get.return_value = {
+            "date": "2026-05-01",
+            "session_id": "stale-sess",
+        }
         stale_result = ClaudeResult(stale_session=True, stderr="no conversation found")
         fresh_result = ClaudeResult(text="Fresh start!", session_id="new-sess-2")
         claude_cli.run.side_effect = [stale_result, fresh_result]
-        data_client.post.return_value = {"date": "2026-05-01", "session_id": "new-sess-2"}
+        data_client.post.return_value = {
+            "date": "2026-05-01",
+            "session_id": "new-sess-2",
+        }
 
         result = await sm.send("Hello again")
 
         assert result.text == "Fresh start!"
         assert claude_cli.run.call_count == 2
 
-    async def test_send_injects_memory_context(self, sm, data_client, claude_cli, memory_manager):
-        data_client.get.return_value = {"error": "bede-data returned 404", "detail": "No session"}
+    async def test_send_injects_memory_context(
+        self, sm, data_client, claude_cli, memory_manager
+    ):
+        data_client.get.return_value = {
+            "error": "bede-data returned 404",
+            "detail": "No session",
+        }
         memory_manager.get_context.return_value = "## Memories\n- Training for marathon"
         claude_cli.run.return_value = ClaudeResult(text="Got it!", session_id="s1")
         data_client.post.return_value = {"date": "2026-05-01", "session_id": "s1"}
 
         await sm.send("Hi")
 
-        prompt = claude_cli.run.call_args.args[0] if claude_cli.run.call_args.args else claude_cli.run.call_args.kwargs.get("prompt", "")
+        prompt = (
+            claude_cli.run.call_args.args[0]
+            if claude_cli.run.call_args.args
+            else claude_cli.run.call_args.kwargs.get("prompt", "")
+        )
         assert "marathon" in prompt or memory_manager.get_context.called
 
     async def test_send_handles_timeout(self, sm, data_client, claude_cli):
-        data_client.get.return_value = {"error": "bede-data returned 404", "detail": "No session"}
+        data_client.get.return_value = {
+            "error": "bede-data returned 404",
+            "detail": "No session",
+        }
         claude_cli.run.return_value = ClaudeResult(timed_out=True)
 
         result = await sm.send("Hello")
@@ -94,7 +129,10 @@ class TestSessionManager:
         assert result.timed_out is True
 
     async def test_send_detects_auth_failure(self, sm, data_client, claude_cli):
-        data_client.get.return_value = {"error": "bede-data returned 404", "detail": "No session"}
+        data_client.get.return_value = {
+            "error": "bede-data returned 404",
+            "detail": "No session",
+        }
         claude_cli.run.return_value = ClaudeResult(auth_failure=True)
 
         result = await sm.send("Hello")
@@ -102,14 +140,18 @@ class TestSessionManager:
         assert result.auth_failure is True
 
     async def test_send_populates_scratchpad(self, sm, data_client, claude_cli):
-        data_client.get.return_value = {"error": "bede-data returned 404", "detail": "No session"}
+        data_client.get.return_value = {
+            "error": "bede-data returned 404",
+            "detail": "No session",
+        }
         claude_cli.run.return_value = ClaudeResult(text="Got it!", session_id="s1")
         data_client.post.return_value = {"date": "2026-05-01", "session_id": "s1"}
 
         await sm.send("Remember this")
 
         scratchpad_calls = [
-            c for c in data_client.post.call_args_list
+            c
+            for c in data_client.post.call_args_list
             if c.args and c.args[0] == "/api/scratchpad"
         ]
         assert len(scratchpad_calls) == 1
@@ -117,13 +159,17 @@ class TestSessionManager:
         assert "Remember this" in body.get("content", "")
 
     async def test_send_skips_scratchpad_on_timeout(self, sm, data_client, claude_cli):
-        data_client.get.return_value = {"error": "bede-data returned 404", "detail": "No session"}
+        data_client.get.return_value = {
+            "error": "bede-data returned 404",
+            "detail": "No session",
+        }
         claude_cli.run.return_value = ClaudeResult(timed_out=True)
 
         await sm.send("Hello")
 
         scratchpad_calls = [
-            c for c in data_client.post.call_args_list
+            c
+            for c in data_client.post.call_args_list
             if c.args and c.args[0] == "/api/scratchpad"
         ]
         assert len(scratchpad_calls) == 0

--- a/bede-core/tests/test_session_manager.py
+++ b/bede-core/tests/test_session_manager.py
@@ -1,0 +1,129 @@
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+from bede_core.claude_cli import ClaudeResult
+from bede_core.session_manager import SessionManager
+
+
+TZ = ZoneInfo("Australia/Sydney")
+
+
+@pytest.fixture
+def data_client():
+    return AsyncMock()
+
+
+@pytest.fixture
+def claude_cli():
+    return AsyncMock()
+
+
+@pytest.fixture
+def memory_manager():
+    mm = AsyncMock()
+    mm.get_context.return_value = ""
+    return mm
+
+
+@pytest.fixture
+def sm(data_client, claude_cli, memory_manager):
+    return SessionManager(
+        data_client=data_client,
+        claude_cli=claude_cli,
+        memory_manager=memory_manager,
+        timezone="Australia/Sydney",
+        model="claude-sonnet-4-5-20250514",
+        vault_path="/vault",
+    )
+
+
+class TestSessionManager:
+    async def test_send_creates_new_daily_session(self, sm, data_client, claude_cli):
+        data_client.get.return_value = {"error": "bede-data returned 404", "detail": "No session for this date"}
+        claude_cli.run.return_value = ClaudeResult(text="Hello!", session_id="new-sess-1")
+        data_client.post.return_value = {"date": "2026-05-01", "session_id": "new-sess-1"}
+
+        result = await sm.send("Hi there")
+
+        assert result.text == "Hello!"
+        assert claude_cli.run.call_count == 1
+        call_kwargs = claude_cli.run.call_args
+        assert "--resume" not in str(call_kwargs) or call_kwargs.kwargs.get("session_id") is None
+
+    async def test_send_resumes_existing_session(self, sm, data_client, claude_cli):
+        data_client.get.return_value = {"date": "2026-05-01", "session_id": "existing-sess"}
+        claude_cli.run.return_value = ClaudeResult(text="Welcome back!", session_id="existing-sess")
+
+        result = await sm.send("What's up?")
+
+        assert result.text == "Welcome back!"
+        call_kwargs = claude_cli.run.call_args
+        assert call_kwargs.kwargs.get("session_id") == "existing-sess" or "existing-sess" in str(call_kwargs)
+
+    async def test_send_retries_on_stale_session(self, sm, data_client, claude_cli):
+        data_client.get.return_value = {"date": "2026-05-01", "session_id": "stale-sess"}
+        stale_result = ClaudeResult(stale_session=True, stderr="no conversation found")
+        fresh_result = ClaudeResult(text="Fresh start!", session_id="new-sess-2")
+        claude_cli.run.side_effect = [stale_result, fresh_result]
+        data_client.post.return_value = {"date": "2026-05-01", "session_id": "new-sess-2"}
+
+        result = await sm.send("Hello again")
+
+        assert result.text == "Fresh start!"
+        assert claude_cli.run.call_count == 2
+
+    async def test_send_injects_memory_context(self, sm, data_client, claude_cli, memory_manager):
+        data_client.get.return_value = {"error": "bede-data returned 404", "detail": "No session"}
+        memory_manager.get_context.return_value = "## Memories\n- Training for marathon"
+        claude_cli.run.return_value = ClaudeResult(text="Got it!", session_id="s1")
+        data_client.post.return_value = {"date": "2026-05-01", "session_id": "s1"}
+
+        await sm.send("Hi")
+
+        prompt = claude_cli.run.call_args.args[0] if claude_cli.run.call_args.args else claude_cli.run.call_args.kwargs.get("prompt", "")
+        assert "marathon" in prompt or memory_manager.get_context.called
+
+    async def test_send_handles_timeout(self, sm, data_client, claude_cli):
+        data_client.get.return_value = {"error": "bede-data returned 404", "detail": "No session"}
+        claude_cli.run.return_value = ClaudeResult(timed_out=True)
+
+        result = await sm.send("Hello")
+
+        assert result.timed_out is True
+
+    async def test_send_detects_auth_failure(self, sm, data_client, claude_cli):
+        data_client.get.return_value = {"error": "bede-data returned 404", "detail": "No session"}
+        claude_cli.run.return_value = ClaudeResult(auth_failure=True)
+
+        result = await sm.send("Hello")
+
+        assert result.auth_failure is True
+
+    async def test_send_populates_scratchpad(self, sm, data_client, claude_cli):
+        data_client.get.return_value = {"error": "bede-data returned 404", "detail": "No session"}
+        claude_cli.run.return_value = ClaudeResult(text="Got it!", session_id="s1")
+        data_client.post.return_value = {"date": "2026-05-01", "session_id": "s1"}
+
+        await sm.send("Remember this")
+
+        scratchpad_calls = [
+            c for c in data_client.post.call_args_list
+            if c.args and c.args[0] == "/api/scratchpad"
+        ]
+        assert len(scratchpad_calls) == 1
+        body = scratchpad_calls[0].kwargs.get("body", {})
+        assert "Remember this" in body.get("content", "")
+
+    async def test_send_skips_scratchpad_on_timeout(self, sm, data_client, claude_cli):
+        data_client.get.return_value = {"error": "bede-data returned 404", "detail": "No session"}
+        claude_cli.run.return_value = ClaudeResult(timed_out=True)
+
+        await sm.send("Hello")
+
+        scratchpad_calls = [
+            c for c in data_client.post.call_args_list
+            if c.args and c.args[0] == "/api/scratchpad"
+        ]
+        assert len(scratchpad_calls) == 0

--- a/bede-core/tests/test_telegram_format.py
+++ b/bede-core/tests/test_telegram_format.py
@@ -1,0 +1,63 @@
+from bede_core.telegram_format import md_to_html, chunk_text
+
+
+class TestMdToHtml:
+    def test_bold(self):
+        assert "<b>hello</b>" in md_to_html("**hello**")
+
+    def test_italic(self):
+        assert "<i>hello</i>" in md_to_html("*hello*")
+
+    def test_code_inline(self):
+        assert "<code>foo</code>" in md_to_html("`foo`")
+
+    def test_code_block(self):
+        result = md_to_html("```python\nprint(1)\n```")
+        assert "<pre>" in result
+        assert "print(1)" in result
+
+    def test_heading_becomes_bold(self):
+        assert "<b>Title</b>" in md_to_html("# Title")
+        assert "<b>Sub</b>" in md_to_html("## Sub")
+
+    def test_link(self):
+        result = md_to_html("[click](https://example.com)")
+        assert '<a href="https://example.com">click</a>' in result
+
+    def test_html_entities_escaped(self):
+        result = md_to_html("a < b & c > d")
+        assert "&lt;" in result
+        assert "&amp;" in result
+        assert "&gt;" in result
+
+    def test_bold_italic(self):
+        result = md_to_html("***both***")
+        assert "<b><i>both</i></b>" in result
+
+
+class TestChunkText:
+    def test_short_text_single_chunk(self):
+        assert chunk_text("hello", 100) == ["hello"]
+
+    def test_splits_at_paragraph(self):
+        text = "A" * 50 + "\n\n" + "B" * 50
+        chunks = chunk_text(text, 60)
+        assert len(chunks) == 2
+        assert chunks[0].strip() == "A" * 50
+        assert chunks[1].strip() == "B" * 50
+
+    def test_splits_at_newline_if_no_paragraph(self):
+        text = "A" * 50 + "\n" + "B" * 50
+        chunks = chunk_text(text, 60)
+        assert len(chunks) == 2
+
+    def test_splits_at_space_if_no_newline(self):
+        text = "word " * 20
+        chunks = chunk_text(text, 30)
+        assert all(len(c) <= 30 for c in chunks)
+
+    def test_hard_split_if_no_whitespace(self):
+        text = "A" * 100
+        chunks = chunk_text(text, 40)
+        assert len(chunks) == 3
+        assert "".join(chunks) == text


### PR DESCRIPTION
## Summary

- Complete implementation of bede-core — the brain of the Bede personal assistant
- Telegram bot with user auth, typing indicator, chunked replies, and error handling
- APScheduler task runner loading cron schedules from bede-data's config API
- Claude CLI session manager with daily session continuity via `--resume`
- Memory manager for context injection from bede-data memories
- Dockerfile with Claude CLI, git/SSH for vault access, health endpoint
- CI/CD workflow: ruff lint → pytest → Docker build-push to GHCR

## Architecture

```
main.py
├── bot.py (Telegram handlers)
│   ├── session_manager.py (send messages to Claude)
│   │   ├── claude_cli.py (subprocess execution)
│   │   ├── memory_manager.py (context injection)
│   │   │   └── data_client.py (HTTP to bede-data)
│   │   └── data_client.py (daily session, scratchpad)
│   ├── telegram_format.py (md → html)
│   └── quiet_hours.py
├── scheduler.py (APScheduler + task execution)
│   ├── session_manager.py
│   ├── data_client.py (task config, task logging)
│   └── quiet_hours.py
└── config.py (shared settings)
```

## Test plan

- [x] 64 unit tests passing across 10 test files
- [x] Ruff lint clean (check + format)
- [x] Import verification: `from bede_core.main import main` succeeds
- [ ] Docker build on CI
- [ ] Integration test on server after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)