### PR TITLE
fix(bede-core): remove non-existent MCP servers from config

### DIFF
--- a/bede-core/mcp.json
+++ b/bede-core/mcp.json
@@ -3,14 +3,6 @@
     "personal-data": {
       "type": "url",
       "url": "http://bede-data-mcp:8002/mcp"
-    },
-    "workspace": {
-      "type": "url",
-      "url": "http://bede-workspace-mcp:8003/mcp"
-    },
-    "browser": {
-      "type": "url",
-      "url": "http://bede-browser-mcp:8004/mcp"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Removes `workspace` and `browser` MCP server entries from `bede-core/mcp.json`
- These services don't exist yet (no repos, no GHCR images) — only `personal-data` (bede-data-mcp) is built and deployed
- Prevents Claude CLI startup errors from trying to connect to non-existent servers

## Test plan
- [ ] Verify `mcp.json` only contains `personal-data` entry
- [ ] bede-core container starts without MCP connection errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)