### PR TITLE
fix(bede-core): use correct MCP config type

### DIFF
--- a/bede-core/mcp.json
+++ b/bede-core/mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "personal-data": {
-      "type": "url",
+      "type": "http",
       "url": "http://bede-data-mcp:8002/mcp"
     }
   }


### PR DESCRIPTION
## Summary
- Changes `"type": "url"` to `"type": "http"` in `bede-core/mcp.json`
- Claude CLI 2.1.x expects `"type": "http"` for streamable HTTP MCP servers — `"url"` is not a valid schema value

## Test plan
- [ ] bede-core starts without MCP config error
- [ ] Claude CLI connects to bede-data-mcp successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)