### PR TITLE
fix: bede-data location, step count, and sleep session bugs

### DIFF
--- a/bede-data/src/bede_data/api/health.py
+++ b/bede-data/src/bede_data/api/health.py
@@ -34,7 +34,11 @@ def _group_into_sessions(phases: list[dict]) -> list[list[dict]]:
     for phase in phases[1:]:
         prev_end = _parse_utc(sessions[-1][-1]["end_time"])
         curr_start = _parse_utc(phase["start_time"])
-        if prev_end and curr_start and (curr_start - prev_end).total_seconds() > SESSION_GAP_HOURS * 3600:
+        if (
+            prev_end
+            and curr_start
+            and (curr_start - prev_end).total_seconds() > SESSION_GAP_HOURS * 3600
+        ):
             sessions.append([phase])
         else:
             sessions[-1].append(phase)

--- a/bede-data/src/bede_data/api/health.py
+++ b/bede-data/src/bede_data/api/health.py
@@ -1,5 +1,5 @@
 import sqlite3
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timedelta
 
 from fastapi import APIRouter, Depends, Query
 

--- a/bede-data/src/bede_data/api/health.py
+++ b/bede-data/src/bede_data/api/health.py
@@ -50,15 +50,26 @@ def get_activity(
 ):
     d = _resolve_date(date)
     cursor = conn.execute(
-        "SELECT metric, value FROM health_metrics WHERE date = ?", (d,)
+        """
+        SELECT metric, SUM(max_val) AS value
+        FROM (
+            SELECT metric, recorded_at, MAX(value) AS max_val
+            FROM health_metrics
+            WHERE date = ?
+              AND metric IN ('step_count', 'active_energy', 'apple_exercise_time', 'apple_stand_hour')
+            GROUP BY metric, recorded_at
+        )
+        GROUP BY metric
+        """,
+        (d,),
     )
     metrics = {row["metric"]: row["value"] for row in cursor.fetchall()}
     return {
         "date": d,
-        "steps": metrics.get("step_count", 0),
-        "active_energy": metrics.get("active_energy", 0),
-        "exercise_minutes": metrics.get("apple_exercise_time", 0),
-        "stand_hours": metrics.get("apple_stand_hour", 0),
+        "steps": round(metrics.get("step_count", 0)),
+        "active_energy": round(metrics.get("active_energy", 0), 1),
+        "exercise_minutes": round(metrics.get("apple_exercise_time", 0)),
+        "stand_hours": round(metrics.get("apple_stand_hour", 0)),
     }
 
 

--- a/bede-data/src/bede_data/api/health.py
+++ b/bede-data/src/bede_data/api/health.py
@@ -1,9 +1,11 @@
 import sqlite3
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends, Query
 
 from bede_data.db.connection import get_db
+
+SESSION_GAP_HOURS = 2
 
 router = APIRouter(prefix="/api/health", tags=["health"])
 
@@ -14,6 +16,39 @@ def _resolve_date(date_str: str) -> str:
     if date_str == "yesterday":
         return (date.today() - timedelta(days=1)).isoformat()
     return date_str
+
+
+def _parse_utc(ts: str | None) -> datetime | None:
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _group_into_sessions(phases: list[dict]) -> list[list[dict]]:
+    if not phases:
+        return []
+    sessions: list[list[dict]] = [[phases[0]]]
+    for phase in phases[1:]:
+        prev_end = _parse_utc(sessions[-1][-1]["end_time"])
+        curr_start = _parse_utc(phase["start_time"])
+        if prev_end and curr_start and (curr_start - prev_end).total_seconds() > SESSION_GAP_HOURS * 3600:
+            sessions.append([phase])
+        else:
+            sessions[-1].append(phase)
+    return sessions
+
+
+def _build_session(phases: list[dict]) -> dict:
+    total_hours = round(sum(p["hours"] for p in phases), 2)
+    return {
+        "total_hours": total_hours,
+        "bedtime": phases[0]["start_time"],
+        "wake_time": phases[-1]["end_time"],
+        "phases": phases,
+    }
 
 
 @router.get("/sleep")
@@ -28,16 +63,19 @@ def get_sleep(
         (d,),
     )
     phases = [dict(row) for row in cursor.fetchall()]
-    total_hours = round(sum(p["hours"] for p in phases), 2)
+    session_groups = _group_into_sessions(phases)
+    sessions = [_build_session(s) for s in session_groups]
 
-    bedtime = phases[0]["start_time"] if phases else None
-    wake_time = phases[-1]["end_time"] if phases else None
+    total_hours = round(sum(s["total_hours"] for s in sessions), 2)
+    bedtime = sessions[0]["bedtime"] if sessions else None
+    wake_time = sessions[0]["wake_time"] if sessions else None
 
     return {
         "date": d,
         "total_hours": total_hours,
         "bedtime": bedtime,
         "wake_time": wake_time,
+        "sessions": sessions,
         "phases": phases,
     }
 

--- a/bede-data/src/bede_data/api/location.py
+++ b/bede-data/src/bede_data/api/location.py
@@ -3,7 +3,10 @@ from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Query
 
+from fastapi.responses import JSONResponse
+
 from bede_data.live.location import (
+    OwnTracksNotConfiguredError,
     cluster_points,
     fetch_owntracks_points,
     reverse_geocode,
@@ -32,7 +35,10 @@ async def get_location_summary(
 ):
     d = _resolve_date(date)
     from_ts, to_ts = _date_to_timestamps(d)
-    points = await fetch_owntracks_points(from_ts, to_ts)
+    try:
+        points = await fetch_owntracks_points(from_ts, to_ts)
+    except OwnTracksNotConfiguredError as e:
+        return JSONResponse(status_code=503, content={"error": str(e)})
     clusters = cluster_points(points)
     tz_info = ZoneInfo(tz)
 
@@ -68,5 +74,8 @@ async def get_location_raw(
 ):
     from_ts, _ = _date_to_timestamps(_resolve_date(from_date))
     _, to_ts = _date_to_timestamps(_resolve_date(to_date))
-    points = await fetch_owntracks_points(from_ts, to_ts)
+    try:
+        points = await fetch_owntracks_points(from_ts, to_ts)
+    except OwnTracksNotConfiguredError as e:
+        return JSONResponse(status_code=503, content={"error": str(e)})
     return {"from_date": from_date, "to_date": to_date, "points": points}

--- a/bede-data/src/bede_data/live/location.py
+++ b/bede-data/src/bede_data/live/location.py
@@ -97,7 +97,15 @@ def _finish_cluster(c: dict) -> dict:
     }
 
 
+class OwnTracksNotConfiguredError(Exception):
+    pass
+
+
 async def fetch_owntracks_points(from_ts: int, to_ts: int) -> list[dict]:
+    if not settings.owntracks_user or not settings.owntracks_device:
+        raise OwnTracksNotConfiguredError(
+            "OWNTRACKS_USER and OWNTRACKS_DEVICE must be set"
+        )
     url = f"{settings.owntracks_url}/api/0/locations"
     params = {
         "user": settings.owntracks_user,

--- a/bede-data/tests/test_api_health.py
+++ b/bede-data/tests/test_api_health.py
@@ -90,6 +90,8 @@ def test_get_sleep(client, db):
     assert data["date"] == "2026-04-29"
     assert data["total_hours"] == 7.0
     assert len(data["phases"]) == 3
+    assert len(data["sessions"]) == 1
+    assert data["sessions"][0]["total_hours"] == 7.0
 
 
 def test_get_activity(client, db):
@@ -184,9 +186,45 @@ def test_get_medications(client, db):
     assert data["medications"][0]["medication"] == "Lexapro"
 
 
+def test_get_sleep_separates_nap_from_overnight(client, db):
+    """Overnight sleep + afternoon nap should be separate sessions."""
+    # Overnight: 11:18 PM -> phases through ~6:20 AM (UTC times)
+    db.execute(
+        "INSERT INTO sleep_phases (date, phase, hours, start_time, end_time, source) VALUES (?, ?, ?, ?, ?, ?)",
+        ("2026-04-30", "core", 4.0, "2026-04-29T13:18:00Z", "2026-04-29T17:18:00Z", "Apple Watch"),
+    )
+    db.execute(
+        "INSERT INTO sleep_phases (date, phase, hours, start_time, end_time, source) VALUES (?, ?, ?, ?, ?, ?)",
+        ("2026-04-30", "rem", 1.5, "2026-04-29T17:18:00Z", "2026-04-29T18:48:00Z", "Apple Watch"),
+    )
+    db.execute(
+        "INSERT INTO sleep_phases (date, phase, hours, start_time, end_time, source) VALUES (?, ?, ?, ?, ?, ?)",
+        ("2026-04-30", "deep", 0.5, "2026-04-29T18:48:00Z", "2026-04-29T19:18:00Z", "Apple Watch"),
+    )
+    # Afternoon nap: 3:12 PM -> 4:20 PM AEST = 05:12 -> 06:20 UTC (3h+ gap from overnight)
+    db.execute(
+        "INSERT INTO sleep_phases (date, phase, hours, start_time, end_time, source) VALUES (?, ?, ?, ?, ?, ?)",
+        ("2026-04-30", "asleep", 1.1, "2026-04-30T05:12:00Z", "2026-04-30T06:18:00Z", "Apple Watch"),
+    )
+    db.commit()
+
+    response = client.get("/api/health/sleep", params={"date": "2026-04-30"})
+    assert response.status_code == 200
+    data = response.json()
+
+    assert len(data["sessions"]) == 2
+    assert data["sessions"][0]["total_hours"] == 6.0
+    assert data["sessions"][1]["total_hours"] == 1.1
+    assert data["total_hours"] == 7.1
+    # bedtime/wake_time should be from the primary (first) session
+    assert data["bedtime"] == "2026-04-29T13:18:00Z"
+    assert data["wake_time"] == "2026-04-29T19:18:00Z"
+
+
 def test_get_sleep_no_data(client, db):
     response = client.get("/api/health/sleep", params={"date": "2026-04-29"})
     assert response.status_code == 200
     data = response.json()
     assert data["total_hours"] == 0
     assert data["phases"] == []
+    assert data["sessions"] == []

--- a/bede-data/tests/test_api_health.py
+++ b/bede-data/tests/test_api_health.py
@@ -104,6 +104,48 @@ def test_get_activity(client, db):
     assert data["stand_hours"] == 10
 
 
+def test_get_activity_sums_multiple_readings(client, db):
+    """Step count should be the sum of all readings, not just the last one."""
+    db.execute(
+        "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
+        ("2026-04-30", "step_count", 100, "Apple Watch", "2026-04-30T08:00:00Z"),
+    )
+    db.execute(
+        "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
+        ("2026-04-30", "step_count", 250, "Apple Watch", "2026-04-30T09:00:00Z"),
+    )
+    db.execute(
+        "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
+        ("2026-04-30", "step_count", 400, "Apple Watch", "2026-04-30T10:00:00Z"),
+    )
+    db.commit()
+    response = client.get("/api/health/activity", params={"date": "2026-04-30"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["steps"] == 750
+
+
+def test_get_activity_deduplicates_across_sources(client, db):
+    """Same reading from multiple sources should not be double-counted."""
+    db.execute(
+        "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
+        ("2026-04-30", "step_count", 100, "Apple Watch", "2026-04-30T08:00:00Z"),
+    )
+    db.execute(
+        "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
+        ("2026-04-30", "step_count", 100, "GymKit|Apple Watch|iPhone", "2026-04-30T08:00:00Z"),
+    )
+    db.execute(
+        "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
+        ("2026-04-30", "step_count", 200, "Apple Watch", "2026-04-30T09:00:00Z"),
+    )
+    db.commit()
+    response = client.get("/api/health/activity", params={"date": "2026-04-30"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["steps"] == 300
+
+
 def test_get_workouts(client, db):
     _seed_health_data(db)
     response = client.get("/api/health/workouts", params={"date": "2026-04-29"})

--- a/bede-data/tests/test_api_health.py
+++ b/bede-data/tests/test_api_health.py
@@ -135,7 +135,13 @@ def test_get_activity_deduplicates_across_sources(client, db):
     )
     db.execute(
         "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
-        ("2026-04-30", "step_count", 100, "GymKit|Apple Watch|iPhone", "2026-04-30T08:00:00Z"),
+        (
+            "2026-04-30",
+            "step_count",
+            100,
+            "GymKit|Apple Watch|iPhone",
+            "2026-04-30T08:00:00Z",
+        ),
     )
     db.execute(
         "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
@@ -191,20 +197,48 @@ def test_get_sleep_separates_nap_from_overnight(client, db):
     # Overnight: 11:18 PM -> phases through ~6:20 AM (UTC times)
     db.execute(
         "INSERT INTO sleep_phases (date, phase, hours, start_time, end_time, source) VALUES (?, ?, ?, ?, ?, ?)",
-        ("2026-04-30", "core", 4.0, "2026-04-29T13:18:00Z", "2026-04-29T17:18:00Z", "Apple Watch"),
+        (
+            "2026-04-30",
+            "core",
+            4.0,
+            "2026-04-29T13:18:00Z",
+            "2026-04-29T17:18:00Z",
+            "Apple Watch",
+        ),
     )
     db.execute(
         "INSERT INTO sleep_phases (date, phase, hours, start_time, end_time, source) VALUES (?, ?, ?, ?, ?, ?)",
-        ("2026-04-30", "rem", 1.5, "2026-04-29T17:18:00Z", "2026-04-29T18:48:00Z", "Apple Watch"),
+        (
+            "2026-04-30",
+            "rem",
+            1.5,
+            "2026-04-29T17:18:00Z",
+            "2026-04-29T18:48:00Z",
+            "Apple Watch",
+        ),
     )
     db.execute(
         "INSERT INTO sleep_phases (date, phase, hours, start_time, end_time, source) VALUES (?, ?, ?, ?, ?, ?)",
-        ("2026-04-30", "deep", 0.5, "2026-04-29T18:48:00Z", "2026-04-29T19:18:00Z", "Apple Watch"),
+        (
+            "2026-04-30",
+            "deep",
+            0.5,
+            "2026-04-29T18:48:00Z",
+            "2026-04-29T19:18:00Z",
+            "Apple Watch",
+        ),
     )
     # Afternoon nap: 3:12 PM -> 4:20 PM AEST = 05:12 -> 06:20 UTC (3h+ gap from overnight)
     db.execute(
         "INSERT INTO sleep_phases (date, phase, hours, start_time, end_time, source) VALUES (?, ?, ?, ?, ?, ?)",
-        ("2026-04-30", "asleep", 1.1, "2026-04-30T05:12:00Z", "2026-04-30T06:18:00Z", "Apple Watch"),
+        (
+            "2026-04-30",
+            "asleep",
+            1.1,
+            "2026-04-30T05:12:00Z",
+            "2026-04-30T06:18:00Z",
+            "Apple Watch",
+        ),
     )
     db.commit()
 

--- a/bede-data/tests/test_api_location.py
+++ b/bede-data/tests/test_api_location.py
@@ -1,0 +1,30 @@
+from unittest.mock import AsyncMock, patch
+
+from bede_data.live.location import OwnTracksNotConfiguredError
+
+
+def test_location_summary_returns_503_when_not_configured(client):
+    with patch(
+        "bede_data.api.location.fetch_owntracks_points",
+        new_callable=AsyncMock,
+        side_effect=OwnTracksNotConfiguredError("OWNTRACKS_USER and OWNTRACKS_DEVICE must be set"),
+    ):
+        response = client.get(
+            "/api/location/summary", params={"date": "2026-04-30"}
+        )
+    assert response.status_code == 503
+    assert "OWNTRACKS_USER" in response.json()["error"]
+
+
+def test_location_raw_returns_503_when_not_configured(client):
+    with patch(
+        "bede_data.api.location.fetch_owntracks_points",
+        new_callable=AsyncMock,
+        side_effect=OwnTracksNotConfiguredError("OWNTRACKS_USER and OWNTRACKS_DEVICE must be set"),
+    ):
+        response = client.get(
+            "/api/location/raw",
+            params={"from_date": "2026-04-30", "to_date": "2026-04-30"},
+        )
+    assert response.status_code == 503
+    assert "OWNTRACKS_USER" in response.json()["error"]

--- a/bede-data/tests/test_api_location.py
+++ b/bede-data/tests/test_api_location.py
@@ -7,11 +7,11 @@ def test_location_summary_returns_503_when_not_configured(client):
     with patch(
         "bede_data.api.location.fetch_owntracks_points",
         new_callable=AsyncMock,
-        side_effect=OwnTracksNotConfiguredError("OWNTRACKS_USER and OWNTRACKS_DEVICE must be set"),
+        side_effect=OwnTracksNotConfiguredError(
+            "OWNTRACKS_USER and OWNTRACKS_DEVICE must be set"
+        ),
     ):
-        response = client.get(
-            "/api/location/summary", params={"date": "2026-04-30"}
-        )
+        response = client.get("/api/location/summary", params={"date": "2026-04-30"})
     assert response.status_code == 503
     assert "OWNTRACKS_USER" in response.json()["error"]
 
@@ -20,7 +20,9 @@ def test_location_raw_returns_503_when_not_configured(client):
     with patch(
         "bede_data.api.location.fetch_owntracks_points",
         new_callable=AsyncMock,
-        side_effect=OwnTracksNotConfiguredError("OWNTRACKS_USER and OWNTRACKS_DEVICE must be set"),
+        side_effect=OwnTracksNotConfiguredError(
+            "OWNTRACKS_USER and OWNTRACKS_DEVICE must be set"
+        ),
     ):
         response = client.get(
             "/api/location/raw",

--- a/bede-data/tests/test_live_location.py
+++ b/bede-data/tests/test_live_location.py
@@ -1,6 +1,10 @@
+import pytest
+
 from bede_data.live.location import (
     GeoCache,
+    OwnTracksNotConfiguredError,
     cluster_points,
+    fetch_owntracks_points,
     haversine_m,
 )
 
@@ -62,3 +66,23 @@ def test_geocache_rounds_coordinates():
 def test_geocache_miss():
     cache = GeoCache()
     assert cache.get(-33.8688, 151.2093) is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_owntracks_raises_when_user_not_configured(monkeypatch):
+    from bede_data import config
+
+    monkeypatch.setattr(config.settings, "owntracks_user", "")
+    monkeypatch.setattr(config.settings, "owntracks_device", "phone")
+    with pytest.raises(OwnTracksNotConfiguredError):
+        await fetch_owntracks_points(0, 1000)
+
+
+@pytest.mark.asyncio
+async def test_fetch_owntracks_raises_when_device_not_configured(monkeypatch):
+    from bede_data import config
+
+    monkeypatch.setattr(config.settings, "owntracks_user", "joe")
+    monkeypatch.setattr(config.settings, "owntracks_device", "")
+    with pytest.raises(OwnTracksNotConfiguredError):
+        await fetch_owntracks_points(0, 1000)


### PR DESCRIPTION
## Summary

Fixes three bugs discovered during live testing of bede-core on 2026-05-01:

- **Location 503 (#36):** `bede-data` container was missing `OWNTRACKS_USER`, `OWNTRACKS_DEVICE`, and `OWNTRACKS_URL` env vars, causing `fetch_owntracks_points` to send empty user/device params and get a 416 from OwnTracks recorder. Added validation that raises `OwnTracksNotConfiguredError` before making the HTTP call, and the API returns a clear 503 instead of a 500. The docker-compose.ai.yml fix (adding env vars + `location` network to the `bede-data` service) is in a separate home-server-stack commit.

- **Step count (#37):** The activity endpoint used a dict comprehension (`{metric: value}`) that kept only the last row per metric. With hundreds of individual step readings from Watch and GymKit sources, it returned a single tiny value (e.g. 17 steps) instead of the daily total. Fixed the SQL to SUM values, deduplicating across sources by taking MAX per `recorded_at` timestamp.

- **Sleep sessions (#38):** The sleep endpoint merged all phases into one session, so overnight sleep + afternoon nap showed as 12.3h with wrong bed/wake times. Added session grouping that splits phases into separate sessions when there's a 2+ hour gap. Returns `sessions` array alongside the flat `phases` list. Top-level `bedtime`/`wake_time` now come from the primary (first) session.

## Test plan

- [x] All 138 existing tests pass
- [x] New tests for location 503 response (summary + raw endpoints)
- [x] New tests for step count summing and cross-source deduplication
- [x] New test for sleep session separation (overnight + nap)
- [x] Updated existing sleep test to verify `sessions` field
- [ ] After merge + GHCR build: deploy to server, add OwnTracks env vars to bede-data in docker-compose.ai.yml, verify all three endpoints return correct data

🤖 Generated with [Claude Code](https://claude.com/claude-code)