### PR TITLE
fix: handle OwnTracks 416 when no data for date range

### DIFF
--- a/bede-data/src/bede_data/live/location.py
+++ b/bede-data/src/bede_data/live/location.py
@@ -115,6 +115,8 @@ async def fetch_owntracks_points(from_ts: int, to_ts: int) -> list[dict]:
     }
     async with httpx.AsyncClient(timeout=15) as client:
         resp = await client.get(url, params=params)
+        if resp.status_code == 416:
+            return []
         resp.raise_for_status()
         return resp.json().get("data", [])
 

--- a/bede-data/tests/test_live_location.py
+++ b/bede-data/tests/test_live_location.py
@@ -1,3 +1,4 @@
+import httpx
 import pytest
 
 from bede_data.live.location import (
@@ -86,3 +87,26 @@ async def test_fetch_owntracks_raises_when_device_not_configured(monkeypatch):
     monkeypatch.setattr(config.settings, "owntracks_device", "")
     with pytest.raises(OwnTracksNotConfiguredError):
         await fetch_owntracks_points(0, 1000)
+
+
+@pytest.mark.asyncio
+async def test_fetch_owntracks_returns_empty_on_416(monkeypatch):
+    from unittest.mock import AsyncMock
+
+    from bede_data import config
+
+    monkeypatch.setattr(config.settings, "owntracks_user", "joe")
+    monkeypatch.setattr(config.settings, "owntracks_device", "phone")
+    monkeypatch.setattr(config.settings, "owntracks_url", "http://owntracks-test:8083")
+
+    mock_response = AsyncMock()
+    mock_response.status_code = 416
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = AsyncMock(return_value=mock_response)
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **kwargs: mock_client)
+    result = await fetch_owntracks_points(0, 1000)
+    assert result == []


### PR DESCRIPTION
## Summary

- OwnTracks recorder returns 416 "Range Not Satisfiable" when there is no location data for the requested time range
- Previously this caused an unhandled `httpx.HTTPStatusError` and a 500 from the location API
- Now `fetch_owntracks_points` returns an empty list on 416, so the endpoint returns `{"stops": []}` instead of crashing

Follow-on from #39 — discovered during live verification after deploying the location env var fix.

## Test plan

- [x] 139 tests pass (including new `test_fetch_owntracks_returns_empty_on_416`)
- [x] Lint + format clean
- [ ] Deploy and verify location endpoint returns empty stops for dates with no OwnTracks data

🤖 Generated with [Claude Code](https://claude.com/claude-code)