### PR TITLE
feat: bede-core prototype parity — interactive sessions, reflection, multi-step tasks

### DIFF
--- a/bede-core/src/bede_core/bot.py
+++ b/bede-core/src/bede_core/bot.py
@@ -102,7 +102,9 @@ def create_message_handler(
     return handle_message
 
 
-def create_reset_handler(session_manager: SessionManager, allowed_user_id: int, runner=None):
+def create_reset_handler(
+    session_manager: SessionManager, allowed_user_id: int, runner=None
+):
     async def handle_reset(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if update.effective_user.id != allowed_user_id:
             return
@@ -111,9 +113,13 @@ def create_reset_handler(session_manager: SessionManager, allowed_user_id: int, 
         cancelled = runner.cancel_all() if runner else []
         if cancelled:
             names = ", ".join(cancelled)
-            await update.message.reply_text(f"Session cleared. Cancelled running tasks: {names}")
+            await update.message.reply_text(
+                f"Session cleared. Cancelled running tasks: {names}"
+            )
         else:
-            await update.message.reply_text("Session cleared. Next message starts fresh.")
+            await update.message.reply_text(
+                "Session cleared. Next message starts fresh."
+            )
 
     return handle_reset
 

--- a/bede-core/src/bede_core/bot.py
+++ b/bede-core/src/bede_core/bot.py
@@ -35,9 +35,11 @@ async def _keep_typing(bot, chat_id: int, max_duration: float = TYPING_MAX_DURAT
 async def _send_response(message, text: str):
     for c in chunk_text(text):
         try:
-            await message.reply_text(md_to_html(c), parse_mode="HTML")
+            await message.reply_text(
+                md_to_html(c), parse_mode="HTML", disable_web_page_preview=True
+            )
         except Exception:
-            await message.reply_text(c)
+            await message.reply_text(c, disable_web_page_preview=True)
 
 
 def create_message_handler(

--- a/bede-core/src/bede_core/bot.py
+++ b/bede-core/src/bede_core/bot.py
@@ -45,6 +45,7 @@ def create_message_handler(
     allowed_user_id: int,
     timezone: str,
     data_client=None,
+    append_correction_fn=None,
 ):
     async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if update.effective_user.id != allowed_user_id:
@@ -90,6 +91,9 @@ def create_message_handler(
             response_text += (
                 "\n\n⚠️ _Response was truncated (output token limit reached)._"
             )
+
+        if session_manager.is_interactive and append_correction_fn:
+            await asyncio.to_thread(append_correction_fn, text)
 
         await _send_response(update.message, response_text)
 

--- a/bede-core/src/bede_core/bot.py
+++ b/bede-core/src/bede_core/bot.py
@@ -100,12 +100,18 @@ def create_message_handler(
     return handle_message
 
 
-def create_reset_handler(session_manager: SessionManager, allowed_user_id: int):
+def create_reset_handler(session_manager: SessionManager, allowed_user_id: int, runner=None):
     async def handle_reset(update: Update, context: ContextTypes.DEFAULT_TYPE):
         if update.effective_user.id != allowed_user_id:
             return
         await session_manager.clear_daily_session()
-        await update.message.reply_text("Session cleared. Next message starts fresh.")
+        session_manager.clear_interactive()
+        cancelled = runner.cancel_all() if runner else []
+        if cancelled:
+            names = ", ".join(cancelled)
+            await update.message.reply_text(f"Session cleared. Cancelled running tasks: {names}")
+        else:
+            await update.message.reply_text("Session cleared. Next message starts fresh.")
 
     return handle_reset
 

--- a/bede-core/src/bede_core/main.py
+++ b/bede-core/src/bede_core/main.py
@@ -165,7 +165,10 @@ def main():
     )
     app.add_handler(
         CommandHandler(
-            "reset", create_reset_handler(session_manager, settings.allowed_user_id, runner=runner)
+            "reset",
+            create_reset_handler(
+                session_manager, settings.allowed_user_id, runner=runner
+            ),
         )
     )
     app.add_handler(

--- a/bede-core/src/bede_core/main.py
+++ b/bede-core/src/bede_core/main.py
@@ -1,4 +1,5 @@
 import logging
+from functools import partial
 
 from telegram import BotCommand, BotCommandScopeAllPrivateChats
 from telegram.ext import Application, CommandHandler, MessageHandler, filters
@@ -13,6 +14,7 @@ from bede_core.claude_cli import ClaudeCli
 from bede_core.config import Settings
 from bede_core.data_client import DataClient
 from bede_core.memory_manager import MemoryManager
+from bede_core.reflection import append_correction
 from bede_core.scheduler import TaskRunner, reload_schedules, setup_scheduler
 from bede_core.session_manager import SessionManager
 from bede_core.telegram_format import md_to_html, chunk_text
@@ -94,6 +96,12 @@ def main():
                     )
                 except Exception as e:
                     log.error("Failed to send Telegram message: %s", e)
+
+    correction_fn = partial(
+        append_correction,
+        vault_path=settings.vault_path,
+        timezone=settings.timezone,
+    )
 
     runner = TaskRunner(
         data_client=data_client,
@@ -194,6 +202,7 @@ def main():
                 settings.allowed_user_id,
                 settings.timezone,
                 data_client=data_client,
+                append_correction_fn=correction_fn,
             ),
         )
     )

--- a/bede-core/src/bede_core/main.py
+++ b/bede-core/src/bede_core/main.py
@@ -1,4 +1,6 @@
+import asyncio
 import logging
+import time
 from functools import partial
 
 from telegram import BotCommand, BotCommandScopeAllPrivateChats
@@ -103,6 +105,17 @@ def main():
         timezone=settings.timezone,
     )
 
+    async def keep_typing():
+        deadline = time.monotonic() + 3600
+        while time.monotonic() < deadline:
+            try:
+                await app.bot.send_chat_action(
+                    chat_id=settings.allowed_user_id, action="typing"
+                )
+            except Exception:
+                pass
+            await asyncio.sleep(4)
+
     runner = TaskRunner(
         data_client=data_client,
         session_manager=session_manager,
@@ -110,6 +123,7 @@ def main():
         timezone=settings.timezone,
         quiet_hours_start=settings.quiet_hours_start,
         quiet_hours_end=settings.quiet_hours_end,
+        typing_fn=keep_typing,
     )
 
     scheduler = setup_scheduler(data_client, runner, settings.timezone)

--- a/bede-core/src/bede_core/main.py
+++ b/bede-core/src/bede_core/main.py
@@ -72,6 +72,8 @@ def main():
         timezone=settings.timezone,
         model=settings.claude_model,
         vault_path=settings.vault_path,
+        interactive_idle_timeout=settings.interactive_idle_timeout_minutes * 60,
+        interactive_max_age=settings.interactive_max_age_hours * 3600,
     )
 
     async def send_telegram(text: str):

--- a/bede-core/src/bede_core/main.py
+++ b/bede-core/src/bede_core/main.py
@@ -151,7 +151,7 @@ def main():
     )
     app.add_handler(
         CommandHandler(
-            "reset", create_reset_handler(session_manager, settings.allowed_user_id)
+            "reset", create_reset_handler(session_manager, settings.allowed_user_id, runner=runner)
         )
     )
     app.add_handler(

--- a/bede-core/src/bede_core/reflection.py
+++ b/bede-core/src/bede_core/reflection.py
@@ -20,15 +20,18 @@ def _git_commit_push(vault_path: str, file_path: str):
     try:
         subprocess.run(
             ["git", "-C", vault_path, "add", file_path],
-            capture_output=True, timeout=10,
+            capture_output=True,
+            timeout=10,
         )
         subprocess.run(
             ["git", "-C", vault_path, "commit", "-m", "reflection: save correction"],
-            capture_output=True, timeout=10,
+            capture_output=True,
+            timeout=10,
         )
         subprocess.run(
             ["git", "-C", vault_path, "push"],
-            capture_output=True, timeout=30,
+            capture_output=True,
+            timeout=30,
         )
     except Exception as e:
         log.warning("Failed to commit reflection correction: %s", e)

--- a/bede-core/src/bede_core/reflection.py
+++ b/bede-core/src/bede_core/reflection.py
@@ -1,0 +1,50 @@
+import logging
+import os
+import subprocess
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+log = logging.getLogger(__name__)
+
+REFLECTION_REL_PATH = os.path.join("Bede", "reflection-memory.md")
+
+_HEADER = (
+    "# Reflection Memory\n\n"
+    "Corrections and preferences Joe has provided about Evening Reflections.\n"
+    "Bede reads this at the start of each reflection to avoid repeating mistakes.\n\n"
+    "## Corrections\n\n"
+)
+
+
+def _git_commit_push(vault_path: str, file_path: str):
+    try:
+        subprocess.run(
+            ["git", "-C", vault_path, "add", file_path],
+            capture_output=True, timeout=10,
+        )
+        subprocess.run(
+            ["git", "-C", vault_path, "commit", "-m", "reflection: save correction"],
+            capture_output=True, timeout=10,
+        )
+        subprocess.run(
+            ["git", "-C", vault_path, "push"],
+            capture_output=True, timeout=30,
+        )
+    except Exception as e:
+        log.warning("Failed to commit reflection correction: %s", e)
+
+
+def append_correction(text: str, vault_path: str, timezone: str):
+    full_path = os.path.join(vault_path, REFLECTION_REL_PATH)
+    now = datetime.now(ZoneInfo(timezone))
+    timestamp = now.strftime("%Y-%m-%d %H:%M")
+
+    if not os.path.isfile(full_path):
+        os.makedirs(os.path.dirname(full_path), exist_ok=True)
+        with open(full_path, "w") as f:
+            f.write(_HEADER)
+
+    with open(full_path, "a") as f:
+        f.write(f"- [{timestamp}] {text}\n")
+
+    _git_commit_push(vault_path, full_path)

--- a/bede-core/src/bede_core/scheduler.py
+++ b/bede-core/src/bede_core/scheduler.py
@@ -97,6 +97,7 @@ class TaskRunner:
         prompt = task["prompt"]
         model = task.get("model")
         timeout = task.get("timeout_seconds", 300)
+        interactive = task.get("interactive", False)
 
         now = datetime.now(self._tz)
         now_str = now.strftime("%H:%M")
@@ -138,6 +139,9 @@ class TaskRunner:
             log.info("Task '%s' output queued (quiet hours).", name)
         else:
             await self._send(output)
+
+        if interactive and model and not result.timed_out:
+            self._session.register_interactive(model)
 
     def is_running(self, name: str) -> bool:
         return name in self._running

--- a/bede-core/src/bede_core/scheduler.py
+++ b/bede-core/src/bede_core/scheduler.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import time
 from datetime import datetime, timezone
@@ -33,6 +34,7 @@ class TaskRunner:
         timezone: str,
         quiet_hours_start: int = 22,
         quiet_hours_end: int = 7,
+        typing_fn=None,
     ):
         self._data = data_client
         self._session = session_manager
@@ -41,6 +43,7 @@ class TaskRunner:
         self._running: set[str] = set()
         self._quiet_start = quiet_hours_start
         self._quiet_end = quiet_hours_end
+        self._typing_fn = typing_fn
 
     async def _log_start(self, task_name: str) -> int | None:
         now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -80,6 +83,10 @@ class TaskRunner:
         start = time.monotonic()
         exec_id = await self._log_start(name)
 
+        typing_task = None
+        if self._typing_fn:
+            typing_task = asyncio.create_task(self._typing_fn())
+
         try:
             await self._run_task_inner(task)
             duration = time.monotonic() - start
@@ -90,6 +97,8 @@ class TaskRunner:
             await self._log_end(exec_id, "failure", duration, error=str(e))
             await self._send(f"⚠️ *{name}* failed: {e}")
         finally:
+            if typing_task:
+                typing_task.cancel()
             self._running.discard(name)
 
     async def _run_task_inner(self, task: dict):

--- a/bede-core/src/bede_core/scheduler.py
+++ b/bede-core/src/bede_core/scheduler.py
@@ -146,6 +146,11 @@ class TaskRunner:
     def is_running(self, name: str) -> bool:
         return name in self._running
 
+    def cancel_all(self) -> list[str]:
+        cancelled = list(self._running)
+        self._running.clear()
+        return cancelled
+
     def cancel_task(self, name: str):
         self._running.discard(name)
 

--- a/bede-core/src/bede_core/scheduler.py
+++ b/bede-core/src/bede_core/scheduler.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import logging
 import time
 from datetime import datetime, timezone
@@ -102,6 +103,25 @@ class TaskRunner:
             self._running.discard(name)
 
     async def _run_task_inner(self, task: dict):
+        task_config_raw = task.get("task_config")
+
+        if task_config_raw:
+            try:
+                config = (
+                    json.loads(task_config_raw)
+                    if isinstance(task_config_raw, str)
+                    else task_config_raw
+                )
+            except (json.JSONDecodeError, TypeError):
+                config = {}
+            steps = config.get("steps")
+            if steps:
+                await self._run_multistep(task, config)
+                return
+
+        await self._run_single_step(task)
+
+    async def _run_single_step(self, task: dict):
         name = task["task_name"]
         prompt = task["prompt"]
         model = task.get("model")
@@ -151,6 +171,84 @@ class TaskRunner:
 
         if interactive and model and not result.timed_out:
             self._session.register_interactive(model)
+
+    async def _run_multistep(self, task: dict, config: dict):
+        name = task["task_name"]
+        preamble = task.get("prompt", "")
+        model = task.get("model")
+        timeout = task.get("timeout_seconds", 300)
+        steps = config["steps"]
+        parallel = config.get("parallel", False)
+
+        now = datetime.now(self._tz)
+        now_str = now.strftime("%H:%M")
+        now_date_str = now.strftime("%A, %d %B %Y")
+        cron = task.get("cron_expression", "")
+        next_str = _next_run_str(cron, self._tz, now)
+
+        step_names = [s["name"] for s in steps if not s.get("silent")]
+        header = f"📅 *{name}* ({now_str})"
+        if next_str:
+            header += f"\n↻ Next: {next_str}"
+        header += f"\n{len(step_names)} sections: {', '.join(step_names)}"
+        if parallel:
+            header += " ⚡"
+        await self._send(header)
+
+        date_prefix = f"Today is {now_date_str}.\n\n"
+
+        async def run_one_step(step: dict) -> tuple[str, str, bool]:
+            step_name = step.get("name", "Step")
+            step_prompt = step.get("prompt", "")
+            silent = step.get("silent", False)
+            step_model = step.get("model") or model
+
+            full_prompt = date_prefix
+            if preamble:
+                full_prompt += preamble + "\n\n"
+            full_prompt += step_prompt
+
+            step_timeout = step.get("timeout_seconds", timeout)
+
+            log.info("Running step '%s' for task '%s'", step_name, name)
+            result = await self._session.send_task(
+                full_prompt, model=step_model, timeout=step_timeout
+            )
+
+            if result.timed_out:
+                return step_name, f"⚠️ *{step_name}* — timed out", silent
+            text = result.text or "No output."
+            if result.stop_reason == "max_tokens":
+                text += "\n\n⚠️ _Response was truncated._"
+            return step_name, text, silent
+
+        if parallel:
+            non_silent = [s for s in steps if not s.get("silent")]
+            silent_steps = [s for s in steps if s.get("silent")]
+
+            results = await asyncio.gather(
+                *(run_one_step(s) for s in non_silent),
+                return_exceptions=True,
+            )
+            for r in results:
+                if isinstance(r, Exception):
+                    log.error("Parallel step failed: %s", r)
+                else:
+                    step_name, text, _ = r
+                    await self._send(text)
+
+            for s in silent_steps:
+                step_name, text, _ = await run_one_step(s)
+                log.info("Silent step '%s' completed.", step_name)
+        else:
+            for step in steps:
+                step_name, text, silent = await run_one_step(step)
+                if not silent and text:
+                    await self._send(text)
+                elif silent:
+                    log.info("Silent step '%s' completed.", step_name)
+
+        await self._send(f"✅ *{name}* complete.")
 
     def is_running(self, name: str) -> bool:
         return name in self._running

--- a/bede-core/src/bede_core/session_manager.py
+++ b/bede-core/src/bede_core/session_manager.py
@@ -1,5 +1,6 @@
 import logging
 import subprocess
+import time
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
@@ -19,6 +20,8 @@ class SessionManager:
         timezone: str,
         model: str,
         vault_path: str,
+        interactive_idle_timeout: float = 1800,
+        interactive_max_age: float = 7200,
     ):
         self._data = data_client
         self._cli = claude_cli
@@ -27,6 +30,37 @@ class SessionManager:
         self._model = model
         self._vault_path = vault_path
         self._session_cleared = False
+        self._idle_timeout = interactive_idle_timeout
+        self._max_age = interactive_max_age
+        self._interactive: dict | None = None
+
+    def register_interactive(self, model: str):
+        now = time.monotonic()
+        self._interactive = {"model": model, "idle_ts": now, "created_ts": now}
+        log.info("Interactive session registered (model: %s)", model)
+
+    def clear_interactive(self):
+        self._interactive = None
+
+    @property
+    def is_interactive(self) -> bool:
+        return self._get_interactive_model() is not None
+
+    @property
+    def interactive_model(self) -> str | None:
+        return self._get_interactive_model()
+
+    def _get_interactive_model(self) -> str | None:
+        if self._interactive is None:
+            return None
+        now = time.monotonic()
+        idle_ok = (now - self._interactive["idle_ts"]) < self._idle_timeout
+        age_ok = (now - self._interactive["created_ts"]) < self._max_age
+        if idle_ok and age_ok:
+            return self._interactive["model"]
+        log.info("Interactive session expired (idle_ok=%s, age_ok=%s).", idle_ok, age_ok)
+        self._interactive = None
+        return None
 
     def _today(self) -> str:
         return datetime.now(self._tz).strftime("%Y-%m-%d")
@@ -115,7 +149,12 @@ class SessionManager:
 
         await asyncio.to_thread(self._pull_vault)
 
-        effective_model = model or self._model
+        interactive_model = self._get_interactive_model()
+        if interactive_model:
+            effective_model = model or interactive_model
+        else:
+            effective_model = model or self._model
+
         session_id = await self._get_daily_session_id()
         is_new_session = session_id is None
 
@@ -148,6 +187,9 @@ class SessionManager:
         if result.text and not result.timed_out and not result.auth_failure:
             summary = f"User: {message[:100]}\nBede: {result.text[:200]}"
             await self._append_scratchpad(summary)
+
+        if self._interactive and not result.timed_out and not result.auth_failure:
+            self._interactive["idle_ts"] = time.monotonic()
 
         return result
 

--- a/bede-core/src/bede_core/session_manager.py
+++ b/bede-core/src/bede_core/session_manager.py
@@ -58,7 +58,9 @@ class SessionManager:
         age_ok = (now - self._interactive["created_ts"]) < self._max_age
         if idle_ok and age_ok:
             return self._interactive["model"]
-        log.info("Interactive session expired (idle_ok=%s, age_ok=%s).", idle_ok, age_ok)
+        log.info(
+            "Interactive session expired (idle_ok=%s, age_ok=%s).", idle_ok, age_ok
+        )
         self._interactive = None
         return None
 

--- a/bede-core/tests/test_bot.py
+++ b/bede-core/tests/test_bot.py
@@ -137,9 +137,7 @@ class TestInteractiveCorrections:
     async def test_appends_correction_during_interactive(self, session_manager):
         from bede_core.bot import create_message_handler
 
-        session_manager.send.return_value = ClaudeResult(
-            text="Noted!", session_id="s1"
-        )
+        session_manager.send.return_value = ClaudeResult(text="Noted!", session_id="s1")
         session_manager.is_interactive = True
 
         correction_calls = []
@@ -164,9 +162,7 @@ class TestInteractiveCorrections:
     async def test_no_correction_when_not_interactive(self, session_manager):
         from bede_core.bot import create_message_handler
 
-        session_manager.send.return_value = ClaudeResult(
-            text="Hello!", session_id="s1"
-        )
+        session_manager.send.return_value = ClaudeResult(text="Hello!", session_id="s1")
         session_manager.is_interactive = False
 
         correction_calls = []

--- a/bede-core/tests/test_bot.py
+++ b/bede-core/tests/test_bot.py
@@ -186,3 +186,42 @@ class TestInteractiveCorrections:
         await handler(update, context)
 
         assert len(correction_calls) == 0
+
+
+class TestResetCancellation:
+    async def test_reset_cancels_running_tasks(self, session_manager):
+        from bede_core.bot import create_reset_handler
+
+        runner = MagicMock()
+        runner.cancel_all.return_value = ["Morning Briefing", "Deal Scout"]
+
+        handler = create_reset_handler(
+            session_manager, allowed_user_id=12345, runner=runner
+        )
+
+        update = FakeUpdate("/reset", user_id=12345)
+        context = FakeContext()
+        await handler(update, context)
+
+        runner.cancel_all.assert_called_once()
+        session_manager.clear_interactive.assert_called_once()
+        reply_text = update.message.reply_text.call_args.args[0]
+        assert "Morning Briefing" in reply_text
+        assert "Deal Scout" in reply_text
+
+    async def test_reset_no_tasks_running(self, session_manager):
+        from bede_core.bot import create_reset_handler
+
+        runner = MagicMock()
+        runner.cancel_all.return_value = []
+
+        handler = create_reset_handler(
+            session_manager, allowed_user_id=12345, runner=runner
+        )
+
+        update = FakeUpdate("/reset", user_id=12345)
+        context = FakeContext()
+        await handler(update, context)
+
+        reply_text = update.message.reply_text.call_args.args[0]
+        assert "cleared" in reply_text.lower()

--- a/bede-core/tests/test_bot.py
+++ b/bede-core/tests/test_bot.py
@@ -131,3 +131,58 @@ class TestResetHandler:
         await handler(update, context)
 
         session_manager.clear_daily_session.assert_not_called()
+
+
+class TestInteractiveCorrections:
+    async def test_appends_correction_during_interactive(self, session_manager):
+        from bede_core.bot import create_message_handler
+
+        session_manager.send.return_value = ClaudeResult(
+            text="Noted!", session_id="s1"
+        )
+        session_manager.is_interactive = True
+
+        correction_calls = []
+
+        def fake_append(text):
+            correction_calls.append(text)
+
+        handler = create_message_handler(
+            session_manager,
+            allowed_user_id=12345,
+            timezone="Australia/Sydney",
+            append_correction_fn=fake_append,
+        )
+
+        update = FakeUpdate("Actually the tone was wrong", user_id=12345)
+        context = FakeContext()
+        await handler(update, context)
+
+        assert len(correction_calls) == 1
+        assert "tone was wrong" in correction_calls[0]
+
+    async def test_no_correction_when_not_interactive(self, session_manager):
+        from bede_core.bot import create_message_handler
+
+        session_manager.send.return_value = ClaudeResult(
+            text="Hello!", session_id="s1"
+        )
+        session_manager.is_interactive = False
+
+        correction_calls = []
+
+        def fake_append(text):
+            correction_calls.append(text)
+
+        handler = create_message_handler(
+            session_manager,
+            allowed_user_id=12345,
+            timezone="Australia/Sydney",
+            append_correction_fn=fake_append,
+        )
+
+        update = FakeUpdate("Hello", user_id=12345)
+        context = FakeContext()
+        await handler(update, context)
+
+        assert len(correction_calls) == 0

--- a/bede-core/tests/test_reflection.py
+++ b/bede-core/tests/test_reflection.py
@@ -1,5 +1,4 @@
 import os
-import pytest
 from unittest.mock import patch
 
 from bede_core.reflection import append_correction
@@ -23,7 +22,9 @@ class TestReflection:
         bede_dir = tmp_path / "Bede"
         bede_dir.mkdir()
         path = bede_dir / "reflection-memory.md"
-        path.write_text("# Reflection Memory\n\n## Corrections\n\n- [2026-04-30 21:00] Old correction\n")
+        path.write_text(
+            "# Reflection Memory\n\n## Corrections\n\n- [2026-04-30 21:00] Old correction\n"
+        )
 
         with patch("bede_core.reflection._git_commit_push"):
             append_correction("New correction", str(tmp_path), "Australia/Sydney")

--- a/bede-core/tests/test_reflection.py
+++ b/bede-core/tests/test_reflection.py
@@ -1,0 +1,43 @@
+import os
+import pytest
+from unittest.mock import patch
+
+from bede_core.reflection import append_correction
+
+
+class TestReflection:
+    def test_creates_file_if_missing(self, tmp_path):
+        bede_dir = tmp_path / "Bede"
+        bede_dir.mkdir()
+        path = str(bede_dir / "reflection-memory.md")
+
+        with patch("bede_core.reflection._git_commit_push"):
+            append_correction("Fix the tone", str(tmp_path), "Australia/Sydney")
+
+        assert os.path.isfile(path)
+        content = open(path).read()
+        assert "Fix the tone" in content
+        assert "# Reflection Memory" in content
+
+    def test_appends_to_existing_file(self, tmp_path):
+        bede_dir = tmp_path / "Bede"
+        bede_dir.mkdir()
+        path = bede_dir / "reflection-memory.md"
+        path.write_text("# Reflection Memory\n\n## Corrections\n\n- [2026-04-30 21:00] Old correction\n")
+
+        with patch("bede_core.reflection._git_commit_push"):
+            append_correction("New correction", str(tmp_path), "Australia/Sydney")
+
+        content = path.read_text()
+        assert "Old correction" in content
+        assert "New correction" in content
+
+    def test_includes_timestamp(self, tmp_path):
+        bede_dir = tmp_path / "Bede"
+        bede_dir.mkdir()
+
+        with patch("bede_core.reflection._git_commit_push"):
+            append_correction("Something", str(tmp_path), "Australia/Sydney")
+
+        content = (bede_dir / "reflection-memory.md").read_text()
+        assert "2026-" in content

--- a/bede-core/tests/test_scheduler.py
+++ b/bede-core/tests/test_scheduler.py
@@ -145,3 +145,62 @@ class TestTaskRunner:
         await runner.run_task(task)
 
         session_manager.send_task.assert_not_called()
+
+
+class TestInteractiveHandoff:
+    async def test_interactive_task_registers_session(
+        self, runner, data_client, session_manager, send_fn
+    ):
+        task = {
+            "task_name": "Evening Reflection",
+            "cron_expression": "0 21 * * *",
+            "prompt": "Write the evening reflection",
+            "model": "claude-sonnet-4-5-20250514",
+            "timeout_seconds": 300,
+            "interactive": True,
+        }
+        data_client.post.return_value = {"id": 1, "status": "running"}
+        data_client.put.return_value = {"id": 1, "status": "success"}
+
+        await runner.run_task(task)
+
+        session_manager.register_interactive.assert_called_once_with(
+            "claude-sonnet-4-5-20250514"
+        )
+
+    async def test_non_interactive_task_does_not_register(
+        self, runner, data_client, session_manager, send_fn
+    ):
+        task = {
+            "task_name": "Morning Briefing",
+            "cron_expression": "0 8 * * 1-5",
+            "prompt": "Give me a briefing",
+            "model": None,
+            "timeout_seconds": 300,
+            "interactive": False,
+        }
+        data_client.post.return_value = {"id": 1, "status": "running"}
+        data_client.put.return_value = {"id": 1, "status": "success"}
+
+        await runner.run_task(task)
+
+        session_manager.register_interactive.assert_not_called()
+
+    async def test_interactive_not_registered_on_timeout(
+        self, runner, data_client, session_manager, send_fn
+    ):
+        task = {
+            "task_name": "Evening Reflection",
+            "cron_expression": "0 21 * * *",
+            "prompt": "Write the evening reflection",
+            "model": "claude-sonnet-4-5-20250514",
+            "timeout_seconds": 60,
+            "interactive": True,
+        }
+        session_manager.send_task.return_value = ClaudeResult(timed_out=True)
+        data_client.post.return_value = {"id": 1, "status": "running"}
+        data_client.put.return_value = {"id": 1, "status": "timeout"}
+
+        await runner.run_task(task)
+
+        session_manager.register_interactive.assert_not_called()

--- a/bede-core/tests/test_scheduler.py
+++ b/bede-core/tests/test_scheduler.py
@@ -204,3 +204,18 @@ class TestInteractiveHandoff:
         await runner.run_task(task)
 
         session_manager.register_interactive.assert_not_called()
+
+
+class TestCancelTasks:
+    def test_cancel_all_returns_running_names(self, runner):
+        runner._running.add("Morning Briefing")
+        runner._running.add("Deal Scout")
+
+        cancelled = runner.cancel_all()
+
+        assert set(cancelled) == {"Morning Briefing", "Deal Scout"}
+        assert len(runner._running) == 0
+
+    def test_cancel_all_empty_when_nothing_running(self, runner):
+        cancelled = runner.cancel_all()
+        assert cancelled == []

--- a/bede-core/tests/test_scheduler.py
+++ b/bede-core/tests/test_scheduler.py
@@ -219,3 +219,33 @@ class TestCancelTasks:
     def test_cancel_all_empty_when_nothing_running(self, runner):
         cancelled = runner.cancel_all()
         assert cancelled == []
+
+
+class TestTypingIndicator:
+    async def test_typing_called_during_task(
+        self, data_client, session_manager, send_fn
+    ):
+        typing_fn = AsyncMock()
+        runner = TaskRunner(
+            data_client=data_client,
+            session_manager=session_manager,
+            send_fn=send_fn,
+            timezone="Australia/Sydney",
+            quiet_hours_start=0,
+            quiet_hours_end=0,
+            typing_fn=typing_fn,
+        )
+        task = {
+            "task_name": "Test Task",
+            "cron_expression": "0 8 * * *",
+            "prompt": "Do something",
+            "model": None,
+            "timeout_seconds": 300,
+            "interactive": False,
+        }
+        data_client.post.return_value = {"id": 1, "status": "running"}
+        data_client.put.return_value = {"id": 1, "status": "success"}
+
+        await runner.run_task(task)
+
+        typing_fn.assert_called()

--- a/bede-core/tests/test_scheduler.py
+++ b/bede-core/tests/test_scheduler.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 from unittest.mock import AsyncMock
 from zoneinfo import ZoneInfo
@@ -249,3 +251,158 @@ class TestTypingIndicator:
         await runner.run_task(task)
 
         typing_fn.assert_called()
+
+
+class TestMultiStepTasks:
+    def _make_task(self, steps, parallel=False, preamble="Context for all steps"):
+        config = {"steps": steps}
+        if parallel:
+            config["parallel"] = True
+        return {
+            "task_name": "Multi Step",
+            "cron_expression": "0 14 * * 0",
+            "prompt": preamble,
+            "model": "claude-sonnet-4-5-20250514",
+            "timeout_seconds": 600,
+            "interactive": False,
+            "task_config": json.dumps(config),
+        }
+
+    async def test_sequential_steps(self, data_client, session_manager, send_fn):
+        runner = TaskRunner(
+            data_client=data_client,
+            session_manager=session_manager,
+            send_fn=send_fn,
+            timezone="Australia/Sydney",
+            quiet_hours_start=0,
+            quiet_hours_end=0,
+        )
+        session_manager.send_task.side_effect = [
+            ClaudeResult(text="Step 1 result", session_id="s1"),
+            ClaudeResult(text="Step 2 result", session_id="s2"),
+        ]
+        data_client.post.return_value = {"id": 1, "status": "running"}
+        data_client.put.return_value = {"id": 1, "status": "success"}
+
+        task = self._make_task(
+            [
+                {"name": "Step 1", "prompt": "Do step 1"},
+                {"name": "Step 2", "prompt": "Do step 2"},
+            ]
+        )
+
+        await runner.run_task(task)
+
+        assert session_manager.send_task.call_count == 2
+        calls = [
+            c.kwargs.get("prompt", c.args[0] if c.args else "")
+            for c in session_manager.send_task.call_args_list
+        ]
+        assert any("step 1" in c.lower() for c in calls)
+        assert any("step 2" in c.lower() for c in calls)
+
+    async def test_parallel_steps(self, data_client, session_manager, send_fn):
+        runner = TaskRunner(
+            data_client=data_client,
+            session_manager=session_manager,
+            send_fn=send_fn,
+            timezone="Australia/Sydney",
+            quiet_hours_start=0,
+            quiet_hours_end=0,
+        )
+        session_manager.send_task.return_value = ClaudeResult(
+            text="Result", session_id="s1"
+        )
+        data_client.post.return_value = {"id": 1, "status": "running"}
+        data_client.put.return_value = {"id": 1, "status": "success"}
+
+        task = self._make_task(
+            [
+                {"name": "Cat 1", "prompt": "Check cat 1"},
+                {"name": "Cat 2", "prompt": "Check cat 2"},
+            ],
+            parallel=True,
+        )
+
+        await runner.run_task(task)
+
+        assert session_manager.send_task.call_count == 2
+
+    async def test_silent_step_not_sent_to_telegram(
+        self, data_client, session_manager, send_fn
+    ):
+        runner = TaskRunner(
+            data_client=data_client,
+            session_manager=session_manager,
+            send_fn=send_fn,
+            timezone="Australia/Sydney",
+            quiet_hours_start=0,
+            quiet_hours_end=0,
+        )
+        session_manager.send_task.side_effect = [
+            ClaudeResult(text="Visible result", session_id="s1"),
+            ClaudeResult(text="Silent result", session_id="s2"),
+        ]
+        data_client.post.return_value = {"id": 1, "status": "running"}
+        data_client.put.return_value = {"id": 1, "status": "success"}
+
+        task = self._make_task(
+            [
+                {"name": "Visible", "prompt": "Show this"},
+                {"name": "Silent", "prompt": "Hide this", "silent": True},
+            ]
+        )
+
+        await runner.run_task(task)
+
+        sent_texts = " ".join(str(c) for c in send_fn.call_args_list)
+        assert "Visible result" in sent_texts
+        assert "Silent result" not in sent_texts
+
+    async def test_preamble_injected_into_steps(
+        self, data_client, session_manager, send_fn
+    ):
+        runner = TaskRunner(
+            data_client=data_client,
+            session_manager=session_manager,
+            send_fn=send_fn,
+            timezone="Australia/Sydney",
+            quiet_hours_start=0,
+            quiet_hours_end=0,
+        )
+        session_manager.send_task.return_value = ClaudeResult(
+            text="Done", session_id="s1"
+        )
+        data_client.post.return_value = {"id": 1, "status": "running"}
+        data_client.put.return_value = {"id": 1, "status": "success"}
+
+        task = self._make_task(
+            [{"name": "S1", "prompt": "Do the thing"}],
+            preamble="You are a deal scout",
+        )
+
+        await runner.run_task(task)
+
+        prompt = session_manager.send_task.call_args.kwargs.get(
+            "prompt", session_manager.send_task.call_args.args[0]
+        )
+        assert "deal scout" in prompt.lower()
+
+    async def test_no_task_config_runs_single_step(
+        self, runner, data_client, session_manager, send_fn
+    ):
+        """Tasks without task_config still work as single-step (backward compat)."""
+        task = {
+            "task_name": "Simple Task",
+            "cron_expression": "0 8 * * *",
+            "prompt": "Do something",
+            "model": None,
+            "timeout_seconds": 300,
+            "interactive": False,
+        }
+        data_client.post.return_value = {"id": 1, "status": "running"}
+        data_client.put.return_value = {"id": 1, "status": "success"}
+
+        await runner.run_task(task)
+
+        session_manager.send_task.assert_called_once()

--- a/bede-core/tests/test_session_manager.py
+++ b/bede-core/tests/test_session_manager.py
@@ -182,9 +182,7 @@ class TestInteractiveSession:
         self, sm, data_client, claude_cli
     ):
         data_client.get.return_value = {"date": "2026-05-01", "session_id": "sess-1"}
-        claude_cli.run.return_value = ClaudeResult(
-            text="Reply!", session_id="sess-1"
-        )
+        claude_cli.run.return_value = ClaudeResult(text="Reply!", session_id="sess-1")
 
         sm.register_interactive("claude-sonnet-4-5-20250514")
         await sm.send("Hello")
@@ -196,9 +194,7 @@ class TestInteractiveSession:
         self, sm, data_client, claude_cli
     ):
         data_client.get.return_value = {"date": "2026-05-01", "session_id": "sess-1"}
-        claude_cli.run.return_value = ClaudeResult(
-            text="Reply!", session_id="sess-1"
-        )
+        claude_cli.run.return_value = ClaudeResult(text="Reply!", session_id="sess-1")
 
         sm.register_interactive("claude-sonnet-4-5-20250514")
         await sm.send("Message 1")
@@ -222,9 +218,7 @@ class TestInteractiveSession:
             interactive_max_age=3600,
         )
         data_client.get.return_value = {"date": "2026-05-01", "session_id": "sess-1"}
-        claude_cli.run.return_value = ClaudeResult(
-            text="Reply!", session_id="sess-1"
-        )
+        claude_cli.run.return_value = ClaudeResult(text="Reply!", session_id="sess-1")
 
         sm.register_interactive("claude-sonnet-4-5-20250514")
         time.sleep(0.02)
@@ -247,9 +241,7 @@ class TestInteractiveSession:
             interactive_max_age=0.01,
         )
         data_client.get.return_value = {"date": "2026-05-01", "session_id": "sess-1"}
-        claude_cli.run.return_value = ClaudeResult(
-            text="Reply!", session_id="sess-1"
-        )
+        claude_cli.run.return_value = ClaudeResult(text="Reply!", session_id="sess-1")
 
         sm.register_interactive("claude-sonnet-4-5-20250514")
         time.sleep(0.02)
@@ -260,9 +252,7 @@ class TestInteractiveSession:
 
     async def test_clear_interactive(self, sm, data_client, claude_cli):
         data_client.get.return_value = {"date": "2026-05-01", "session_id": "sess-1"}
-        claude_cli.run.return_value = ClaudeResult(
-            text="Reply!", session_id="sess-1"
-        )
+        claude_cli.run.return_value = ClaudeResult(text="Reply!", session_id="sess-1")
 
         sm.register_interactive("claude-sonnet-4-5-20250514")
         sm.clear_interactive()

--- a/bede-core/tests/test_session_manager.py
+++ b/bede-core/tests/test_session_manager.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 from unittest.mock import AsyncMock
 from zoneinfo import ZoneInfo
@@ -173,3 +175,105 @@ class TestSessionManager:
             if c.args and c.args[0] == "/api/scratchpad"
         ]
         assert len(scratchpad_calls) == 0
+
+
+class TestInteractiveSession:
+    async def test_register_interactive_overrides_model(
+        self, sm, data_client, claude_cli
+    ):
+        data_client.get.return_value = {"date": "2026-05-01", "session_id": "sess-1"}
+        claude_cli.run.return_value = ClaudeResult(
+            text="Reply!", session_id="sess-1"
+        )
+
+        sm.register_interactive("claude-sonnet-4-5-20250514")
+        await sm.send("Hello")
+
+        call_kwargs = claude_cli.run.call_args.kwargs
+        assert call_kwargs["model"] == "claude-sonnet-4-5-20250514"
+
+    async def test_interactive_refreshes_idle_on_send(
+        self, sm, data_client, claude_cli
+    ):
+        data_client.get.return_value = {"date": "2026-05-01", "session_id": "sess-1"}
+        claude_cli.run.return_value = ClaudeResult(
+            text="Reply!", session_id="sess-1"
+        )
+
+        sm.register_interactive("claude-sonnet-4-5-20250514")
+        await sm.send("Message 1")
+        await sm.send("Message 2")
+
+        assert claude_cli.run.call_count == 2
+        for call in claude_cli.run.call_args_list:
+            assert call.kwargs["model"] == "claude-sonnet-4-5-20250514"
+
+    async def test_interactive_expires_after_idle_timeout(
+        self, data_client, claude_cli, memory_manager
+    ):
+        sm = SessionManager(
+            data_client=data_client,
+            claude_cli=claude_cli,
+            memory_manager=memory_manager,
+            timezone="Australia/Sydney",
+            model="claude-haiku-4-5-20251001",
+            vault_path="/vault",
+            interactive_idle_timeout=0.01,
+            interactive_max_age=3600,
+        )
+        data_client.get.return_value = {"date": "2026-05-01", "session_id": "sess-1"}
+        claude_cli.run.return_value = ClaudeResult(
+            text="Reply!", session_id="sess-1"
+        )
+
+        sm.register_interactive("claude-sonnet-4-5-20250514")
+        time.sleep(0.02)
+        await sm.send("Hello")
+
+        call_kwargs = claude_cli.run.call_args.kwargs
+        assert call_kwargs["model"] == "claude-haiku-4-5-20251001"
+
+    async def test_interactive_expires_after_max_age(
+        self, data_client, claude_cli, memory_manager
+    ):
+        sm = SessionManager(
+            data_client=data_client,
+            claude_cli=claude_cli,
+            memory_manager=memory_manager,
+            timezone="Australia/Sydney",
+            model="claude-haiku-4-5-20251001",
+            vault_path="/vault",
+            interactive_idle_timeout=3600,
+            interactive_max_age=0.01,
+        )
+        data_client.get.return_value = {"date": "2026-05-01", "session_id": "sess-1"}
+        claude_cli.run.return_value = ClaudeResult(
+            text="Reply!", session_id="sess-1"
+        )
+
+        sm.register_interactive("claude-sonnet-4-5-20250514")
+        time.sleep(0.02)
+        await sm.send("Hello")
+
+        call_kwargs = claude_cli.run.call_args.kwargs
+        assert call_kwargs["model"] == "claude-haiku-4-5-20251001"
+
+    async def test_clear_interactive(self, sm, data_client, claude_cli):
+        data_client.get.return_value = {"date": "2026-05-01", "session_id": "sess-1"}
+        claude_cli.run.return_value = ClaudeResult(
+            text="Reply!", session_id="sess-1"
+        )
+
+        sm.register_interactive("claude-sonnet-4-5-20250514")
+        sm.clear_interactive()
+        await sm.send("Hello")
+
+        call_kwargs = claude_cli.run.call_args.kwargs
+        assert call_kwargs["model"] == "claude-sonnet-4-5-20250514"
+
+    def test_is_interactive(self, sm):
+        assert sm.is_interactive is False
+        sm.register_interactive("claude-sonnet-4-5-20250514")
+        assert sm.is_interactive is True
+        sm.clear_interactive()
+        assert sm.is_interactive is False

--- a/bede-data/src/bede_data/api/config_api.py
+++ b/bede-data/src/bede_data/api/config_api.py
@@ -23,6 +23,7 @@ class ScheduleCreate(BaseModel):
     model: str | None = None
     timeout_seconds: int = 300
     interactive: bool = False
+    task_config: str | None = None
     enabled: bool = True
 
 
@@ -32,6 +33,7 @@ class ScheduleUpdate(BaseModel):
     model: str | None = None
     timeout_seconds: int | None = None
     interactive: bool | None = None
+    task_config: str | None = None
     enabled: bool | None = None
 
 
@@ -39,8 +41,8 @@ class ScheduleUpdate(BaseModel):
 def create_schedule(body: ScheduleCreate, conn: sqlite3.Connection = Depends(get_db)):
     now = _now()
     cursor = conn.execute(
-        """INSERT INTO schedules (task_name, cron_expression, prompt, model, timeout_seconds, interactive, enabled, created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        """INSERT INTO schedules (task_name, cron_expression, prompt, model, timeout_seconds, interactive, task_config, enabled, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
         (
             body.task_name,
             body.cron_expression,
@@ -48,6 +50,7 @@ def create_schedule(body: ScheduleCreate, conn: sqlite3.Connection = Depends(get
             body.model,
             body.timeout_seconds,
             int(body.interactive),
+            body.task_config,
             int(body.enabled),
             now,
             now,
@@ -60,7 +63,7 @@ def create_schedule(body: ScheduleCreate, conn: sqlite3.Connection = Depends(get
 @router.get("/schedules")
 def list_schedules(conn: sqlite3.Connection = Depends(get_db)):
     cursor = conn.execute(
-        "SELECT id, task_name, cron_expression, prompt, model, timeout_seconds, interactive, enabled, created_at, updated_at FROM schedules ORDER BY task_name"
+        "SELECT id, task_name, cron_expression, prompt, model, timeout_seconds, interactive, task_config, enabled, created_at, updated_at FROM schedules ORDER BY task_name"
     )
     rows = [dict(r) for r in cursor.fetchall()]
     for r in rows:
@@ -78,7 +81,7 @@ def update_schedule(
         raise HTTPException(status_code=404, detail="Schedule not found")
 
     updates: dict = {"updated_at": _now()}
-    for field in ("cron_expression", "prompt", "model", "timeout_seconds"):
+    for field in ("cron_expression", "prompt", "model", "timeout_seconds", "task_config"):
         val = getattr(body, field)
         if val is not None:
             updates[field] = val
@@ -98,7 +101,7 @@ def update_schedule(
 
 def _get_schedule(conn: sqlite3.Connection, sid: int) -> dict | None:
     cursor = conn.execute(
-        "SELECT id, task_name, cron_expression, prompt, model, timeout_seconds, interactive, enabled, created_at, updated_at FROM schedules WHERE id = ?",
+        "SELECT id, task_name, cron_expression, prompt, model, timeout_seconds, interactive, task_config, enabled, created_at, updated_at FROM schedules WHERE id = ?",
         (sid,),
     )
     row = cursor.fetchone()

--- a/bede-data/src/bede_data/api/config_api.py
+++ b/bede-data/src/bede_data/api/config_api.py
@@ -81,7 +81,13 @@ def update_schedule(
         raise HTTPException(status_code=404, detail="Schedule not found")
 
     updates: dict = {"updated_at": _now()}
-    for field in ("cron_expression", "prompt", "model", "timeout_seconds", "task_config"):
+    for field in (
+        "cron_expression",
+        "prompt",
+        "model",
+        "timeout_seconds",
+        "task_config",
+    ):
         val = getattr(body, field)
         if val is not None:
             updates[field] = val

--- a/bede-data/src/bede_data/db/connection.py
+++ b/bede-data/src/bede_data/db/connection.py
@@ -27,6 +27,12 @@ def init_db() -> None:
             existing = None
         if existing is not None and existing < 3:
             conn.execute("DROP TABLE IF EXISTS health_metrics")
+        if existing is not None and existing < 4:
+            try:
+                conn.execute("ALTER TABLE schedules ADD COLUMN task_config TEXT")
+                conn.commit()
+            except sqlite3.OperationalError:
+                pass
         conn.commit()
         conn.executescript(SCHEMA_SQL)
         existing = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()[0]

--- a/bede-data/src/bede_data/db/schema.py
+++ b/bede-data/src/bede_data/db/schema.py
@@ -1,4 +1,4 @@
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 # Tables whose column names changed from the prototype bede schema.
 # init_db drops these if they have old-style columns, then SCHEMA_SQL recreates them.
@@ -221,6 +221,7 @@ CREATE TABLE IF NOT EXISTS schedules (
     model            TEXT,
     timeout_seconds  INTEGER DEFAULT 300,
     interactive      INTEGER NOT NULL DEFAULT 0,
+    task_config      TEXT,
     enabled          INTEGER NOT NULL DEFAULT 1,
     created_at       TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at       TEXT NOT NULL DEFAULT (datetime('now'))

--- a/bede-data/tests/test_api_config.py
+++ b/bede-data/tests/test_api_config.py
@@ -106,13 +106,16 @@ class TestScheduleTaskConfig:
             ],
             "parallel": True,
         }
-        resp = client.post("/api/config/schedules", json={
-            "task_name": "Multi Step Task",
-            "cron_expression": "0 14 * * 0",
-            "prompt": "Preamble for all steps",
-            "model": "claude-sonnet-4-5-20250514",
-            "task_config": json.dumps(config),
-        })
+        resp = client.post(
+            "/api/config/schedules",
+            json={
+                "task_name": "Multi Step Task",
+                "cron_expression": "0 14 * * 0",
+                "prompt": "Preamble for all steps",
+                "model": "claude-sonnet-4-5-20250514",
+                "task_config": json.dumps(config),
+            },
+        )
         assert resp.status_code == 201
         data = resp.json()
         assert data["task_name"] == "Multi Step Task"
@@ -121,23 +124,29 @@ class TestScheduleTaskConfig:
         assert parsed["parallel"] is True
 
     def test_create_schedule_without_task_config(self, client):
-        resp = client.post("/api/config/schedules", json={
-            "task_name": "Simple Task",
-            "cron_expression": "0 8 * * *",
-            "prompt": "Do the thing",
-        })
+        resp = client.post(
+            "/api/config/schedules",
+            json={
+                "task_name": "Simple Task",
+                "cron_expression": "0 8 * * *",
+                "prompt": "Do the thing",
+            },
+        )
         assert resp.status_code == 201
         data = resp.json()
         assert data["task_config"] is None
 
     def test_list_schedules_includes_task_config(self, client):
         config = json.dumps({"steps": [{"name": "S1", "prompt": "P1"}]})
-        client.post("/api/config/schedules", json={
-            "task_name": "Config Task",
-            "cron_expression": "0 8 * * *",
-            "prompt": "test",
-            "task_config": config,
-        })
+        client.post(
+            "/api/config/schedules",
+            json={
+                "task_name": "Config Task",
+                "cron_expression": "0 8 * * *",
+                "prompt": "test",
+                "task_config": config,
+            },
+        )
         resp = client.get("/api/config/schedules")
         schedules = resp.json()["schedules"]
         found = [s for s in schedules if s["task_name"] == "Config Task"]

--- a/bede-data/tests/test_api_config.py
+++ b/bede-data/tests/test_api_config.py
@@ -1,3 +1,6 @@
+import json
+
+
 def test_create_schedule(client):
     response = client.post(
         "/api/config/schedules",
@@ -91,9 +94,6 @@ def test_delete_monitored_item(client):
     response = client.delete(f"/api/config/monitored-items/{item_id}")
     assert response.status_code == 200
     assert len(client.get("/api/config/monitored-items").json()["items"]) == 0
-
-
-import json
 
 
 class TestScheduleTaskConfig:

--- a/bede-data/tests/test_api_config.py
+++ b/bede-data/tests/test_api_config.py
@@ -91,3 +91,55 @@ def test_delete_monitored_item(client):
     response = client.delete(f"/api/config/monitored-items/{item_id}")
     assert response.status_code == 200
     assert len(client.get("/api/config/monitored-items").json()["items"]) == 0
+
+
+import json
+
+
+class TestScheduleTaskConfig:
+    def test_create_schedule_with_task_config(self, client):
+        config = {
+            "steps": [
+                {"name": "Category 1", "prompt": "Check category 1"},
+                {"name": "Category 2", "prompt": "Check category 2"},
+                {"name": "Update Memory", "prompt": "Update...", "silent": True},
+            ],
+            "parallel": True,
+        }
+        resp = client.post("/api/config/schedules", json={
+            "task_name": "Multi Step Task",
+            "cron_expression": "0 14 * * 0",
+            "prompt": "Preamble for all steps",
+            "model": "claude-sonnet-4-5-20250514",
+            "task_config": json.dumps(config),
+        })
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["task_name"] == "Multi Step Task"
+        parsed = json.loads(data["task_config"])
+        assert len(parsed["steps"]) == 3
+        assert parsed["parallel"] is True
+
+    def test_create_schedule_without_task_config(self, client):
+        resp = client.post("/api/config/schedules", json={
+            "task_name": "Simple Task",
+            "cron_expression": "0 8 * * *",
+            "prompt": "Do the thing",
+        })
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["task_config"] is None
+
+    def test_list_schedules_includes_task_config(self, client):
+        config = json.dumps({"steps": [{"name": "S1", "prompt": "P1"}]})
+        client.post("/api/config/schedules", json={
+            "task_name": "Config Task",
+            "cron_expression": "0 8 * * *",
+            "prompt": "test",
+            "task_config": config,
+        })
+        resp = client.get("/api/config/schedules")
+        schedules = resp.json()["schedules"]
+        found = [s for s in schedules if s["task_name"] == "Config Task"]
+        assert len(found) == 1
+        assert found[0]["task_config"] == config

--- a/bede-data/tests/test_app.py
+++ b/bede-data/tests/test_app.py
@@ -3,4 +3,4 @@ def test_health_check(client):
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "ok"
-    assert data["schema_version"] == 3
+    assert data["schema_version"] == 4

--- a/bede-data/tests/test_db.py
+++ b/bede-data/tests/test_db.py
@@ -48,7 +48,7 @@ def test_wal_mode_enabled(db):
 def test_schema_version_is_set(db):
     cursor = db.execute("SELECT MAX(version) FROM schema_version")
     version = cursor.fetchone()[0]
-    assert version == 3
+    assert version == 4
 
 
 def test_health_metrics_upsert_by_natural_key(db):


### PR DESCRIPTION
## Summary

Closes the feature gaps between the bede-core implementation and the working prototype:

- **Interactive session tracking** — model override with idle (30min) and max-age (2hr) timeouts after `interactive: true` tasks
- **Interactive task handoff** — scheduler registers interactive session in SessionManager after successful interactive tasks
- **Reflection memory** — user corrections during interactive sessions appended to `Bede/reflection-memory.md` in the vault, committed and pushed
- **Cancel on /reset** — `cancel_all()` on TaskRunner, `/reset` clears interactive state and reports cancelled tasks
- **Typing indicator** — Telegram typing action during scheduled task execution
- **Bot UX** — `disable_web_page_preview=True` on all bot replies
- **Multi-step task schema** (bede-data) — `task_config` TEXT column on `schedules` table, schema v3→v4 migration
- **Multi-step task execution** — sequential or parallel (`parallel: true`) step execution with silent step support and preamble injection

## Test Plan

- [x] 88 bede-core tests pass (14 new)
- [x] 141 bede-data tests pass (3 new + 2 updated schema version assertions)
- [ ] Deploy to test server: `make bede-pull && make bede-restart`
- [ ] Verify `/reset` reports cancelled tasks
- [ ] Trigger `/evening` and confirm interactive session activates
- [ ] Send correction during interactive session and verify `reflection-memory.md` updated
- [ ] Create a multi-step schedule via API and verify parallel execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)