### PR TITLE
fix: pass date strings to OwnTracks API instead of Unix timestamps

### DIFF
--- a/bede-data/src/bede_data/api/location.py
+++ b/bede-data/src/bede_data/api/location.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Query
@@ -15,17 +15,19 @@ from bede_data.live.location import (
 router = APIRouter(prefix="/api/location", tags=["location"])
 
 
-def _resolve_date(date_str: str) -> str:
+def _resolve_date(date_str: str, tz: ZoneInfo) -> str:
     if date_str == "today":
-        return date.today().isoformat()
+        return datetime.now(tz).strftime("%Y-%m-%d")
     if date_str == "yesterday":
-        return (date.today() - timedelta(days=1)).isoformat()
+        return (datetime.now(tz) - timedelta(days=1)).strftime("%Y-%m-%d")
     return date_str
 
 
-def _date_to_timestamps(date_str: str) -> tuple[int, int]:
-    d = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
-    return int(d.timestamp()), int((d + timedelta(days=1)).timestamp())
+def _local_day_to_utc_range(date_str: str, tz: ZoneInfo) -> tuple[int, int]:
+    """Return (from_ts, to_ts) UTC epoch seconds for a local calendar day."""
+    local_start = datetime.strptime(date_str, "%Y-%m-%d").replace(tzinfo=tz)
+    local_end = local_start + timedelta(days=1)
+    return int(local_start.timestamp()), int(local_end.timestamp())
 
 
 @router.get("/summary")
@@ -33,14 +35,14 @@ async def get_location_summary(
     date: str = Query(...),
     tz: str = Query("Australia/Sydney"),
 ):
-    d = _resolve_date(date)
-    from_ts, to_ts = _date_to_timestamps(d)
+    tz_info = ZoneInfo(tz)
+    d = _resolve_date(date, tz_info)
+    from_ts, to_ts = _local_day_to_utc_range(d, tz_info)
     try:
         points = await fetch_owntracks_points(from_ts, to_ts)
     except OwnTracksNotConfiguredError as e:
         return JSONResponse(status_code=503, content={"error": str(e)})
     clusters = cluster_points(points)
-    tz_info = ZoneInfo(tz)
 
     stops = []
     for c in clusters:
@@ -71,9 +73,13 @@ async def get_location_summary(
 async def get_location_raw(
     from_date: str = Query(...),
     to_date: str = Query(...),
+    tz: str = Query("Australia/Sydney"),
 ):
-    from_ts, _ = _date_to_timestamps(_resolve_date(from_date))
-    _, to_ts = _date_to_timestamps(_resolve_date(to_date))
+    tz_info = ZoneInfo(tz)
+    resolved_from = _resolve_date(from_date, tz_info)
+    resolved_to = _resolve_date(to_date, tz_info)
+    from_ts, _ = _local_day_to_utc_range(resolved_from, tz_info)
+    _, to_ts = _local_day_to_utc_range(resolved_to, tz_info)
     try:
         points = await fetch_owntracks_points(from_ts, to_ts)
     except OwnTracksNotConfiguredError as e:

--- a/bede-data/src/bede_data/live/location.py
+++ b/bede-data/src/bede_data/live/location.py
@@ -102,23 +102,37 @@ class OwnTracksNotConfiguredError(Exception):
 
 
 async def fetch_owntracks_points(from_ts: int, to_ts: int) -> list[dict]:
+    """Fetch points from OwnTracks recorder for a UTC timestamp range.
+
+    Converts timestamps to date strings for the API (which only accepts
+    YYYY-MM-DD), queries with a wide enough date window, then filters to
+    the exact timestamp range.
+    """
     if not settings.owntracks_user or not settings.owntracks_device:
         raise OwnTracksNotConfiguredError(
             "OWNTRACKS_USER and OWNTRACKS_DEVICE must be set"
         )
+    from datetime import datetime, timedelta, timezone
+
+    from_date = datetime.fromtimestamp(from_ts, tz=timezone.utc).strftime("%Y-%m-%d")
+    to_date = (
+        datetime.fromtimestamp(to_ts, tz=timezone.utc) + timedelta(days=1)
+    ).strftime("%Y-%m-%d")
+
     url = f"{settings.owntracks_url}/api/0/locations"
     params = {
         "user": settings.owntracks_user,
         "device": settings.owntracks_device,
-        "from": from_ts,
-        "to": to_ts,
+        "from": from_date,
+        "to": to_date,
     }
     async with httpx.AsyncClient(timeout=15) as client:
         resp = await client.get(url, params=params)
         if resp.status_code == 416:
             return []
         resp.raise_for_status()
-        return resp.json().get("data", [])
+        points = resp.json().get("data", [])
+    return [p for p in points if from_ts <= p.get("tst", 0) < to_ts]
 
 
 async def reverse_geocode(lat: float, lon: float) -> str:


### PR DESCRIPTION
## Summary

Two bugs in the location API that caused empty results:

- **Wrong parameter format:** OwnTracks recorder expects `YYYY-MM-DD` date strings for `from`/`to`, not Unix timestamps. Timestamps caused 416 responses silently treated as "no data"
- **Wrong timezone handling:** Date queries used UTC day boundaries instead of local time. "today" in Australia/Sydney (UTC+10) queried the wrong 24-hour window. `_resolve_date("today")` also used server time (UTC) instead of the caller's timezone

### Changes

- `fetch_owntracks_points` now converts UTC timestamps → spanning date strings for the OwnTracks API, then filters results to the exact timestamp range
- `_resolve_date` takes a `tz` parameter and uses `datetime.now(tz)` for "today"/"yesterday"
- New `_local_day_to_utc_range` computes correct UTC epoch boundaries for a local calendar day
- `/api/location/raw` gains a `tz` query param (default `Australia/Sydney`) for consistency with `/summary`

## Related

- josephradford/home-server-stack@fcdebf2 added `OWNTRACKS_*` env vars and `location` network to bede-data (prerequisite for this fix to work)

## Test plan

- [x] All 162 bede-data tests pass
- [ ] Deploy to test server, verify `/api/location/summary?date=today` returns stops
- [ ] Verify bede-core can answer "where am I?" via Telegram

🤖 Generated with [Claude Code](https://claude.com/claude-code)