### PR TITLE
fix: geocode with persistent cache and rate limiting

### DIFF
--- a/bede-data/src/bede_data/db/schema.py
+++ b/bede-data/src/bede_data/db/schema.py
@@ -1,4 +1,4 @@
-SCHEMA_VERSION = 4
+SCHEMA_VERSION = 5
 
 # Tables whose column names changed from the prototype bede schema.
 # init_db drops these if they have old-style columns, then SCHEMA_SQL recreates them.
@@ -289,5 +289,13 @@ CREATE TABLE IF NOT EXISTS retention_policies (
     data_type      TEXT PRIMARY KEY,
     retention_days INTEGER NOT NULL,
     updated_at     TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS geocode_cache (
+    lat_round   REAL NOT NULL,
+    lon_round   REAL NOT NULL,
+    place_name  TEXT NOT NULL,
+    created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+    PRIMARY KEY (lat_round, lon_round)
 );
 """

--- a/bede-data/src/bede_data/live/location.py
+++ b/bede-data/src/bede_data/live/location.py
@@ -1,8 +1,11 @@
+import asyncio
 import math
+import time
 
 import httpx
 
 from bede_data.config import settings
+from bede_data.db.connection import get_connection
 
 EARTH_RADIUS_M = 6_371_000
 
@@ -20,23 +23,50 @@ def haversine_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
 
 
 class GeoCache:
-    """In-memory cache for reverse geocode results, keyed by coordinates rounded to `precision` decimal places. Avoids redundant Nominatim calls for nearby points."""
+    """Two-tier cache for reverse geocode results. L1 is in-memory, L2 is SQLite.
+    Keyed by coordinates rounded to `precision` decimal places (~111m at 3dp)."""
 
     def __init__(self, precision: int = 3):
-        self._cache: dict[tuple[float, float], str] = {}
+        self._mem: dict[tuple[float, float], str] = {}
         self._precision = precision
 
     def _key(self, lat: float, lon: float) -> tuple[float, float]:
         return (round(lat, self._precision), round(lon, self._precision))
 
     def get(self, lat: float, lon: float) -> str | None:
-        return self._cache.get(self._key(lat, lon))
+        key = self._key(lat, lon)
+        if key in self._mem:
+            return self._mem[key]
+        conn = get_connection()
+        try:
+            row = conn.execute(
+                "SELECT place_name FROM geocode_cache WHERE lat_round = ? AND lon_round = ?",
+                key,
+            ).fetchone()
+        finally:
+            conn.close()
+        if row:
+            self._mem[key] = row["place_name"]
+            return row["place_name"]
+        return None
 
     def put(self, lat: float, lon: float, name: str) -> None:
-        self._cache[self._key(lat, lon)] = name
+        key = self._key(lat, lon)
+        self._mem[key] = name
+        conn = get_connection()
+        try:
+            conn.execute(
+                "INSERT OR REPLACE INTO geocode_cache (lat_round, lon_round, place_name) VALUES (?, ?, ?)",
+                (*key, name),
+            )
+            conn.commit()
+        finally:
+            conn.close()
 
 
 _geocache = GeoCache()
+_nominatim_lock = asyncio.Lock()
+_last_nominatim_call: float = 0.0
 
 
 def cluster_points(
@@ -136,18 +166,34 @@ async def fetch_owntracks_points(from_ts: int, to_ts: int) -> list[dict]:
 
 
 async def reverse_geocode(lat: float, lon: float) -> str:
-    """Resolve lat/lon to a place name via Nominatim, with GeoCache to deduplicate nearby lookups."""
+    """Resolve lat/lon to a place name via Nominatim, with persistent cache and 1 req/s rate limit."""
     cached = _geocache.get(lat, lon)
     if cached:
         return cached
-    async with httpx.AsyncClient(timeout=10) as client:
-        resp = await client.get(
-            settings.nominatim_url,
-            params={"lat": lat, "lon": lon, "format": "json", "zoom": 18},
-            headers={"User-Agent": "bede-data/1.0"},
-        )
-        resp.raise_for_status()
-        data = resp.json()
-    name = data.get("display_name", f"{lat:.4f}, {lon:.4f}")
-    _geocache.put(lat, lon, name)
-    return name
+
+    global _last_nominatim_call
+    async with _nominatim_lock:
+        cached = _geocache.get(lat, lon)
+        if cached:
+            return cached
+
+        elapsed = time.monotonic() - _last_nominatim_call
+        if elapsed < 1.0:
+            await asyncio.sleep(1.0 - elapsed)
+
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.get(
+                    settings.nominatim_url,
+                    params={"lat": lat, "lon": lon, "format": "json", "zoom": 18},
+                    headers={"User-Agent": "bede-data/1.0"},
+                )
+            _last_nominatim_call = time.monotonic()
+            resp.raise_for_status()
+            data = resp.json()
+        except (httpx.HTTPStatusError, httpx.RequestError):
+            return f"{lat:.4f}, {lon:.4f}"
+
+        name = data.get("display_name", f"{lat:.4f}, {lon:.4f}")
+        _geocache.put(lat, lon, name)
+        return name

--- a/bede-data/tests/test_app.py
+++ b/bede-data/tests/test_app.py
@@ -3,4 +3,4 @@ def test_health_check(client):
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "ok"
-    assert data["schema_version"] == 4
+    assert data["schema_version"] == 5

--- a/bede-data/tests/test_db.py
+++ b/bede-data/tests/test_db.py
@@ -48,7 +48,7 @@ def test_wal_mode_enabled(db):
 def test_schema_version_is_set(db):
     cursor = db.execute("SELECT MAX(version) FROM schema_version")
     version = cursor.fetchone()[0]
-    assert version == 4
+    assert version == 5
 
 
 def test_health_metrics_upsert_by_natural_key(db):

--- a/bede-data/tests/test_live_location.py
+++ b/bede-data/tests/test_live_location.py
@@ -156,9 +156,7 @@ async def test_reverse_geocode_rate_limits(tmp_db, monkeypatch):
         resp = MagicMock()
         resp.status_code = 200
         resp.raise_for_status = MagicMock()
-        resp.json.return_value = {
-            "display_name": f"Place {len(call_times)}"
-        }
+        resp.json.return_value = {"display_name": f"Place {len(call_times)}"}
         return resp
 
     mock_client = AsyncMock()

--- a/bede-data/tests/test_live_location.py
+++ b/bede-data/tests/test_live_location.py
@@ -1,3 +1,6 @@
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import httpx
 import pytest
 
@@ -7,6 +10,7 @@ from bede_data.live.location import (
     cluster_points,
     fetch_owntracks_points,
     haversine_m,
+    reverse_geocode,
 )
 
 
@@ -52,21 +56,124 @@ def test_cluster_points_time_gap_splits():
     assert len(clusters) == 2
 
 
-def test_geocache_stores_and_retrieves():
+def test_geocache_stores_and_retrieves(tmp_db):
     cache = GeoCache()
     cache.put(-33.8688, 151.2093, "Sydney Opera House")
     assert cache.get(-33.8688, 151.2093) == "Sydney Opera House"
 
 
-def test_geocache_rounds_coordinates():
+def test_geocache_rounds_coordinates(tmp_db):
     cache = GeoCache()
     cache.put(-33.86881234, 151.20931234, "Sydney Opera House")
     assert cache.get(-33.86889999, 151.20939999) == "Sydney Opera House"
 
 
-def test_geocache_miss():
+def test_geocache_miss(tmp_db):
     cache = GeoCache()
     assert cache.get(-33.8688, 151.2093) is None
+
+
+def test_geocache_persists_to_db(tmp_db):
+    cache1 = GeoCache()
+    cache1.put(-33.8688, 151.2093, "Sydney Opera House")
+    cache2 = GeoCache()
+    assert cache2.get(-33.8688, 151.2093) == "Sydney Opera House"
+
+
+@pytest.mark.asyncio
+async def test_reverse_geocode_caches_result(tmp_db, monkeypatch):
+    import bede_data.live.location as loc
+
+    monkeypatch.setattr(loc, "_geocache", GeoCache())
+    monkeypatch.setattr(loc, "_last_nominatim_call", 0.0)
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.raise_for_status = MagicMock()
+    mock_response.json.return_value = {"display_name": "Test Place"}
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = AsyncMock(return_value=mock_response)
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **kwargs: mock_client)
+
+    result = await reverse_geocode(-33.8688, 151.2093)
+    assert result == "Test Place"
+    assert mock_client.get.call_count == 1
+
+    result2 = await reverse_geocode(-33.8688, 151.2093)
+    assert result2 == "Test Place"
+    assert mock_client.get.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_reverse_geocode_fallback_on_error(tmp_db, monkeypatch):
+    import bede_data.live.location as loc
+
+    monkeypatch.setattr(loc, "_geocache", GeoCache())
+    monkeypatch.setattr(loc, "_last_nominatim_call", 0.0)
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = AsyncMock(side_effect=httpx.RequestError("connection failed"))
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **kwargs: mock_client)
+
+    result = await reverse_geocode(-33.8688, 151.2093)
+    assert result == "-33.8688, 151.2093"
+
+
+@pytest.mark.asyncio
+async def test_reverse_geocode_fallback_not_cached(tmp_db, monkeypatch):
+    import bede_data.live.location as loc
+
+    fresh_cache = GeoCache()
+    monkeypatch.setattr(loc, "_geocache", fresh_cache)
+    monkeypatch.setattr(loc, "_last_nominatim_call", 0.0)
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = AsyncMock(side_effect=httpx.RequestError("connection failed"))
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **kwargs: mock_client)
+
+    await reverse_geocode(-33.8688, 151.2093)
+    assert fresh_cache.get(-33.8688, 151.2093) is None
+
+
+@pytest.mark.asyncio
+async def test_reverse_geocode_rate_limits(tmp_db, monkeypatch):
+    import bede_data.live.location as loc
+
+    monkeypatch.setattr(loc, "_geocache", GeoCache())
+    monkeypatch.setattr(loc, "_last_nominatim_call", 0.0)
+
+    call_times: list[float] = []
+    original_get = None
+
+    async def tracking_get(*args, **kwargs):
+        call_times.append(time.monotonic())
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = {
+            "display_name": f"Place {len(call_times)}"
+        }
+        return resp
+
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get = tracking_get
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **kwargs: mock_client)
+
+    await reverse_geocode(-33.8688, 151.2093)
+    await reverse_geocode(-34.0000, 150.0000)
+
+    assert len(call_times) == 2
+    gap = call_times[1] - call_times[0]
+    assert gap >= 0.9
 
 
 @pytest.mark.asyncio

--- a/bede-data/tests/test_live_location.py
+++ b/bede-data/tests/test_live_location.py
@@ -1,5 +1,5 @@
 import time
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
@@ -150,7 +150,6 @@ async def test_reverse_geocode_rate_limits(tmp_db, monkeypatch):
     monkeypatch.setattr(loc, "_last_nominatim_call", 0.0)
 
     call_times: list[float] = []
-    original_get = None
 
     async def tracking_get(*args, **kwargs):
         call_times.append(time.monotonic())


### PR DESCRIPTION
## Summary

- **Persistent geocode cache**: `GeoCache` now uses SQLite as L2 behind the in-memory L1 dict, surviving process restarts. New `geocode_cache` table (schema v5).
- **Nominatim rate limiting**: `reverse_geocode` serializes calls with an asyncio lock and enforces 1-second delays between requests, respecting Nominatim's usage policy.
- **Graceful fallback**: On HTTP errors or connection failures, returns `"{lat:.4f}, {lon:.4f}"` instead of raising. Fallback values are not cached so real lookups retry next time.

Fixes the 500 on `/api/location/summary` caused by concurrent Nominatim calls getting 429'd.

## Test plan

- [x] Existing 162 tests still pass
- [x] New test: GeoCache persists across instances via DB
- [x] New test: `reverse_geocode` cache hit skips network call
- [x] New test: fallback returns coordinate string on error
- [x] New test: fallback values are not written to cache
- [x] New test: consecutive Nominatim calls are >= 1s apart

🤖 Generated with [Claude Code](https://claude.com/claude-code)