### PR TITLE
fix: add playhead_seconds and play_count to podcast pipeline

### DIFF
--- a/bede-data-mcp/src/bede_data_mcp/server.py
+++ b/bede-data-mcp/src/bede_data_mcp/server.py
@@ -234,6 +234,10 @@ async def get_youtube_history(date: str, timezone: str = "Australia/Sydney") -> 
 async def get_podcasts(date: str, timezone: str = "Australia/Sydney") -> dict:
     """Return podcast episodes played on a given local date.
 
+    Each entry includes playhead_seconds (how far the user listened) and play_count
+    (times fully completed). An episode with play_count=0 and low playhead_seconds
+    was only briefly sampled, not meaningfully listened to.
+
     Args:
         date: Local date -- 'YYYY-MM-DD', 'today', or 'yesterday'.
         timezone: Olson timezone name.

--- a/bede-data-mcp/tests/test_vault_tools.py
+++ b/bede-data-mcp/tests/test_vault_tools.py
@@ -74,7 +74,14 @@ async def test_get_youtube_history(api):
 async def test_get_podcasts(api):
     api.get.return_value = {
         "date": "2026-04-30",
-        "entries": [{"podcast": "The Daily", "episode": "Episode 1", "playhead_seconds": 0, "play_count": 1}],
+        "entries": [
+            {
+                "podcast": "The Daily",
+                "episode": "Episode 1",
+                "playhead_seconds": 0,
+                "play_count": 1,
+            }
+        ],
     }
     result = await get_podcasts("2026-04-30")
     api.get.assert_called_once_with(

--- a/bede-data-mcp/tests/test_vault_tools.py
+++ b/bede-data-mcp/tests/test_vault_tools.py
@@ -74,7 +74,7 @@ async def test_get_youtube_history(api):
 async def test_get_podcasts(api):
     api.get.return_value = {
         "date": "2026-04-30",
-        "entries": [{"podcast": "The Daily", "episode": "Episode 1"}],
+        "entries": [{"podcast": "The Daily", "episode": "Episode 1", "playhead_seconds": 0, "play_count": 1}],
     }
     result = await get_podcasts("2026-04-30")
     api.get.assert_called_once_with(

--- a/bede-data/src/bede_data/api/vault_data.py
+++ b/bede-data/src/bede_data/api/vault_data.py
@@ -95,7 +95,7 @@ def get_podcasts(
 ):
     d = _resolve_date(date)
     cursor = conn.execute(
-        "SELECT podcast, episode, duration_seconds, played_at FROM podcasts WHERE date = ? ORDER BY played_at DESC",
+        "SELECT podcast, episode, duration_seconds, playhead_seconds, play_count, played_at FROM podcasts WHERE date = ? ORDER BY played_at DESC",
         (d,),
     )
     entries = [dict(row) for row in cursor.fetchall()]

--- a/bede-data/src/bede_data/db/connection.py
+++ b/bede-data/src/bede_data/db/connection.py
@@ -33,6 +33,15 @@ def init_db() -> None:
                 conn.commit()
             except sqlite3.OperationalError:
                 pass
+        if existing is not None and existing < 6:
+            for col, default in [("playhead_seconds", 0), ("play_count", 0)]:
+                try:
+                    conn.execute(
+                        f"ALTER TABLE podcasts ADD COLUMN {col} INTEGER DEFAULT {default}"
+                    )
+                except sqlite3.OperationalError:
+                    pass
+            conn.commit()
         conn.commit()
         conn.executescript(SCHEMA_SQL)
         existing = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()[0]

--- a/bede-data/src/bede_data/db/schema.py
+++ b/bede-data/src/bede_data/db/schema.py
@@ -1,4 +1,4 @@
-SCHEMA_VERSION = 5
+SCHEMA_VERSION = 6
 
 # Tables whose column names changed from the prototype bede schema.
 # init_db drops these if they have old-style columns, then SCHEMA_SQL recreates them.
@@ -126,6 +126,8 @@ CREATE TABLE IF NOT EXISTS podcasts (
     podcast          TEXT NOT NULL,
     episode          TEXT NOT NULL,
     duration_seconds INTEGER,
+    playhead_seconds INTEGER DEFAULT 0,
+    play_count       INTEGER DEFAULT 0,
     played_at        TEXT NOT NULL,
     UNIQUE (episode, played_at)
 );

--- a/bede-data/src/bede_data/ingest/vault_parser.py
+++ b/bede-data/src/bede_data/ingest/vault_parser.py
@@ -90,6 +90,8 @@ def _parse_podcasts(date: str, content: str) -> list[dict]:
             "podcast": row.get("podcast", ""),
             "episode": row.get("episode", ""),
             "duration_seconds": _parse_csv_int(row.get("duration_seconds", "0")),
+            "playhead_seconds": _parse_csv_int(row.get("playhead_seconds", "0")),
+            "play_count": _parse_csv_int(row.get("play_count", "0")),
             "played_at": row.get("played_at", ""),
         }
         for row in rows

--- a/bede-data/tests/test_api_vault_data.py
+++ b/bede-data/tests/test_api_vault_data.py
@@ -47,8 +47,8 @@ def _seed_vault_data(db):
         ),
     )
     db.execute(
-        "INSERT INTO podcasts (date, podcast, episode, duration_seconds, played_at) VALUES (?, ?, ?, ?, ?)",
-        ("2026-04-29", "The Daily", "Episode 123", 1800, "2026-04-29T08:00:00Z"),
+        "INSERT INTO podcasts (date, podcast, episode, duration_seconds, playhead_seconds, play_count, played_at) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("2026-04-29", "The Daily", "Episode 123", 1800, 0, 1, "2026-04-29T08:00:00Z"),
     )
     db.execute(
         "INSERT INTO claude_sessions (date, project, start_time, end_time, duration_min, turns, summary) VALUES (?, ?, ?, ?, ?, ?, ?)",

--- a/bede-data/tests/test_app.py
+++ b/bede-data/tests/test_app.py
@@ -3,4 +3,4 @@ def test_health_check(client):
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "ok"
-    assert data["schema_version"] == 5
+    assert data["schema_version"] == 6

--- a/bede-data/tests/test_db.py
+++ b/bede-data/tests/test_db.py
@@ -48,7 +48,7 @@ def test_wal_mode_enabled(db):
 def test_schema_version_is_set(db):
     cursor = db.execute("SELECT MAX(version) FROM schema_version")
     version = cursor.fetchone()[0]
-    assert version == 5
+    assert version == 6
 
 
 def test_health_metrics_upsert_by_natural_key(db):

--- a/bede-data/tests/test_ingest_vault.py
+++ b/bede-data/tests/test_ingest_vault.py
@@ -71,8 +71,8 @@ def test_parse_podcasts_csv():
         "date": "2026-04-29",
         "files": {
             "podcasts.csv": (
-                "podcast,episode,duration_seconds,played_at\n"
-                "The Daily,Episode 123,1800,2026-04-29T08:00:00Z\n"
+                "podcast,episode,duration_seconds,playhead_seconds,play_count,played_at\n"
+                "The Daily,Episode 123,1800,0,1,2026-04-29T08:00:00Z\n"
             ),
         },
     }
@@ -80,6 +80,8 @@ def test_parse_podcasts_csv():
     assert len(result["podcasts"]) == 1
     assert result["podcasts"][0]["podcast"] == "The Daily"
     assert result["podcasts"][0]["duration_seconds"] == 1800
+    assert result["podcasts"][0]["playhead_seconds"] == 0
+    assert result["podcasts"][0]["play_count"] == 1
 
 
 def test_parse_claude_sessions_markdown():


### PR DESCRIPTION
## Summary
- Adds `playhead_seconds` and `play_count` columns to the podcasts table (schema v5 → v6 with ALTER TABLE migration)
- Threads new fields through ingest parser, API, and MCP tool
- MCP docstring guides Bede to distinguish briefly sampled episodes from meaningfully listened ones
- Companion PR: josephradford/dotfiles#7

## Test plan
- [ ] All bede-data tests pass (167/167)
- [ ] All bede-data-mcp tests pass (8/8)
- [ ] Deploy to server, verify schema migration adds columns to existing DB
- [ ] Ingest new podcast data and confirm `playhead_seconds`/`play_count` are stored and returned via API and MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)