### PR TITLE
fix: restore step count summing across timestamps

### DIFF
--- a/bede-data/src/bede_data/api/health.py
+++ b/bede-data/src/bede_data/api/health.py
@@ -114,10 +114,14 @@ def get_activity(
     d = _resolve_date(date)
     cursor = conn.execute(
         """
-        SELECT metric, MAX(value) AS value
-        FROM health_metrics
-        WHERE date = ?
-          AND metric IN ('step_count', 'active_energy', 'apple_exercise_time', 'apple_stand_hour')
+        SELECT metric, SUM(max_val) AS value
+        FROM (
+            SELECT metric, recorded_at, MAX(value) AS max_val
+            FROM health_metrics
+            WHERE date = ?
+              AND metric IN ('step_count', 'active_energy', 'apple_exercise_time', 'apple_stand_hour')
+            GROUP BY metric, recorded_at
+        )
         GROUP BY metric
         """,
         (d,),

--- a/bede-data/tests/test_api_health.py
+++ b/bede-data/tests/test_api_health.py
@@ -106,8 +106,8 @@ def test_get_activity(client, db):
     assert data["stand_hours"] == 10
 
 
-def test_get_activity_uses_daily_aggregate(client, db):
-    """Daily aggregate (largest value) should be used over individual readings."""
+def test_get_activity_sums_multiple_readings(client, db):
+    """Step count should be the sum of all readings, not just the max."""
     db.execute(
         "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
         ("2026-04-30", "step_count", 100, "Apple Watch", "2026-04-30T08:00:00Z"),
@@ -118,36 +118,40 @@ def test_get_activity_uses_daily_aggregate(client, db):
     )
     db.execute(
         "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
-        ("2026-04-30", "step_count", 8500, "Apple Watch", "2026-04-30T00:00:00Z"),
+        ("2026-04-30", "step_count", 400, "Apple Watch", "2026-04-30T10:00:00Z"),
     )
     db.commit()
     response = client.get("/api/health/activity", params={"date": "2026-04-30"})
     assert response.status_code == 200
     data = response.json()
-    assert data["steps"] == 8500
+    assert data["steps"] == 750
 
 
-def test_get_activity_ignores_duplicate_sources(client, db):
-    """Multiple sources for the same metric should not inflate the value."""
+def test_get_activity_deduplicates_across_sources(client, db):
+    """Same reading from multiple sources should not be double-counted."""
     db.execute(
         "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
-        ("2026-04-30", "step_count", 8500, "Apple Watch", "2026-04-30T00:00:00Z"),
+        ("2026-04-30", "step_count", 100, "Apple Watch", "2026-04-30T08:00:00Z"),
     )
     db.execute(
         "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
         (
             "2026-04-30",
             "step_count",
-            8500,
+            100,
             "GymKit|Apple Watch|iPhone",
-            "2026-04-30T00:00:00Z",
+            "2026-04-30T08:00:00Z",
         ),
+    )
+    db.execute(
+        "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
+        ("2026-04-30", "step_count", 200, "Apple Watch", "2026-04-30T09:00:00Z"),
     )
     db.commit()
     response = client.get("/api/health/activity", params={"date": "2026-04-30"})
     assert response.status_code == 200
     data = response.json()
-    assert data["steps"] == 8500
+    assert data["steps"] == 300
 
 
 def test_get_workouts(client, db):


### PR DESCRIPTION
## Summary
- Reverts the activity query regression from 67b931e which replaced `SUM(MAX per timestamp)` with `MAX(value)`
- Step counts were reporting only the largest single reading (e.g. 978) instead of the daily total (e.g. 3364)
- Restores tests for summing across timestamps and deduplication across sources

## Test plan
- [x] All 167 bede-data tests pass
- [ ] Verify step count in next Bede reflection matches Apple Health

🤖 Generated with [Claude Code](https://claude.com/claude-code)