### PR TITLE
fix: prefer HAE daily aggregate for step counts

### DIFF
--- a/bede-data/src/bede_data/api/health.py
+++ b/bede-data/src/bede_data/api/health.py
@@ -1,5 +1,6 @@
 import sqlite3
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Depends, Query
 
@@ -105,6 +106,54 @@ def get_sleep(
     }
 
 
+_ACTIVITY_METRICS = ("step_count", "active_energy", "apple_exercise_time", "apple_stand_hour")
+
+
+def _midnight_utc(local_date: str, tz_name: str) -> str:
+    """UTC ISO timestamp for midnight on local_date in the given timezone."""
+    tz = ZoneInfo(tz_name)
+    dt = datetime.strptime(local_date, "%Y-%m-%d").replace(tzinfo=tz)
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _aggregate_activity(
+    d: str, tz_name: str, conn: sqlite3.Connection
+) -> dict[str, float]:
+    """Return activity metrics for a date. Prefer HAE's daily aggregate
+    (the entry at midnight local time) when available; fall back to
+    SUM(MAX per timestamp) for metrics without an aggregate."""
+    midnight = _midnight_utc(d, tz_name)
+    placeholders = ",".join("?" for _ in _ACTIVITY_METRICS)
+
+    agg_cursor = conn.execute(
+        f"SELECT metric, value FROM health_metrics "
+        f"WHERE date = ? AND recorded_at = ? AND metric IN ({placeholders})",
+        (d, midnight, *_ACTIVITY_METRICS),
+    )
+    metrics = {row["metric"]: row["value"] for row in agg_cursor.fetchall()}
+
+    missing = [m for m in _ACTIVITY_METRICS if m not in metrics]
+    if missing:
+        mp = ",".join("?" for _ in missing)
+        fallback = conn.execute(
+            f"""
+            SELECT metric, SUM(max_val) AS value
+            FROM (
+                SELECT metric, recorded_at, MAX(value) AS max_val
+                FROM health_metrics
+                WHERE date = ? AND metric IN ({mp})
+                GROUP BY metric, recorded_at
+            )
+            GROUP BY metric
+            """,
+            (d, *missing),
+        )
+        for row in fallback.fetchall():
+            metrics[row["metric"]] = row["value"]
+
+    return metrics
+
+
 @router.get("/activity")
 def get_activity(
     date: str = Query(...),
@@ -112,21 +161,7 @@ def get_activity(
     conn: sqlite3.Connection = Depends(get_db),
 ):
     d = _resolve_date(date)
-    cursor = conn.execute(
-        """
-        SELECT metric, SUM(max_val) AS value
-        FROM (
-            SELECT metric, recorded_at, MAX(value) AS max_val
-            FROM health_metrics
-            WHERE date = ?
-              AND metric IN ('step_count', 'active_energy', 'apple_exercise_time', 'apple_stand_hour')
-            GROUP BY metric, recorded_at
-        )
-        GROUP BY metric
-        """,
-        (d,),
-    )
-    metrics = {row["metric"]: row["value"] for row in cursor.fetchall()}
+    metrics = _aggregate_activity(d, timezone, conn)
     return {
         "date": d,
         "steps": round(metrics.get("step_count", 0)),

--- a/bede-data/src/bede_data/api/health.py
+++ b/bede-data/src/bede_data/api/health.py
@@ -106,7 +106,12 @@ def get_sleep(
     }
 
 
-_ACTIVITY_METRICS = ("step_count", "active_energy", "apple_exercise_time", "apple_stand_hour")
+_ACTIVITY_METRICS = (
+    "step_count",
+    "active_energy",
+    "apple_exercise_time",
+    "apple_stand_hour",
+)
 
 
 def _midnight_utc(local_date: str, tz_name: str) -> str:

--- a/bede-data/tests/test_api_health.py
+++ b/bede-data/tests/test_api_health.py
@@ -106,8 +106,31 @@ def test_get_activity(client, db):
     assert data["stand_hours"] == 10
 
 
-def test_get_activity_sums_multiple_readings(client, db):
-    """Step count should be the sum of all readings, not just the max."""
+def test_get_activity_prefers_midnight_aggregate(client, db):
+    """When HAE's daily aggregate exists at midnight local time, use it."""
+    # Midnight AEST on Apr 30 = 2026-04-29T14:00:00Z
+    db.execute(
+        "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
+        ("2026-04-30", "step_count", 5000, "Apple Watch", "2026-04-29T14:00:00Z"),
+    )
+    # Per-minute readings that overlap with the aggregate
+    db.execute(
+        "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
+        ("2026-04-30", "step_count", 50, "Apple Watch", "2026-04-30T00:00:00Z"),
+    )
+    db.execute(
+        "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
+        ("2026-04-30", "step_count", 50, "Apple Watch", "2026-04-30T01:00:00Z"),
+    )
+    db.commit()
+    response = client.get("/api/health/activity", params={"date": "2026-04-30"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["steps"] == 5000
+
+
+def test_get_activity_sums_when_no_aggregate(client, db):
+    """Without a midnight aggregate, sum per-timestamp readings."""
     db.execute(
         "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
         ("2026-04-30", "step_count", 100, "Apple Watch", "2026-04-30T08:00:00Z"),


### PR DESCRIPTION
## Summary
- HAE sends both a daily aggregate (at midnight local time) and per-minute readings that overlap with it
- SUM double-counts everything (7980 vs phone's 3816); MAX undercounts before the aggregate arrives (978 vs 3364)
- New approach: check for the midnight aggregate entry first; fall back to SUM(MAX per timestamp) when no aggregate exists yet

## What changed
- `_aggregate_activity()` computes midnight UTC from the date + timezone, queries for the aggregate, then fills in any missing metrics via the SUM fallback
- New test `test_get_activity_prefers_midnight_aggregate` verifies aggregate is used when present
- Existing SUM and dedup tests still pass for the no-aggregate fallback path

## Data analysis
From the server DB for 2026-05-03:
| Approach | Result | Phone |
|----------|--------|-------|
| MAX (old) | 3793 | 3816 |
| SUM (current) | 7980 | 3816 |
| This PR (midnight agg) | 3793 | 3816 |

MAX via midnight aggregate is 99.4% accurate (23-step staleness from HAE export timing).

## Test plan
- [x] 168 tests pass
- [ ] Deploy and verify step count in next Bede reflection matches Apple Health

🤖 Generated with [Claude Code](https://claude.com/claude-code)