### PR TITLE
fix: use max of midnight aggregate and per-minute SUM for steps

### DIFF
--- a/bede-data/src/bede_data/api/health.py
+++ b/bede-data/src/bede_data/api/health.py
@@ -124,9 +124,10 @@ def _midnight_utc(local_date: str, tz_name: str) -> str:
 def _aggregate_activity(
     d: str, tz_name: str, conn: sqlite3.Connection
 ) -> dict[str, float]:
-    """Return activity metrics for a date. Prefer HAE's daily aggregate
-    (the entry at midnight local time) when available; fall back to
-    SUM(MAX per timestamp) for metrics without an aggregate."""
+    """Return activity metrics for a date. Takes the larger of HAE's
+    midnight aggregate and the SUM of non-midnight per-minute readings.
+    The aggregate is authoritative for past days but stale for the
+    current day; the SUM overcounts slightly but stays fresh."""
     midnight = _midnight_utc(d, tz_name)
     placeholders = ",".join("?" for _ in _ACTIVITY_METRICS)
 
@@ -135,26 +136,29 @@ def _aggregate_activity(
         f"WHERE date = ? AND recorded_at = ? AND metric IN ({placeholders})",
         (d, midnight, *_ACTIVITY_METRICS),
     )
-    metrics = {row["metric"]: row["value"] for row in agg_cursor.fetchall()}
+    aggregates = {row["metric"]: row["value"] for row in agg_cursor.fetchall()}
 
-    missing = [m for m in _ACTIVITY_METRICS if m not in metrics]
-    if missing:
-        mp = ",".join("?" for _ in missing)
-        fallback = conn.execute(
-            f"""
-            SELECT metric, SUM(max_val) AS value
-            FROM (
-                SELECT metric, recorded_at, MAX(value) AS max_val
-                FROM health_metrics
-                WHERE date = ? AND metric IN ({mp})
-                GROUP BY metric, recorded_at
-            )
-            GROUP BY metric
-            """,
-            (d, *missing),
+    sum_cursor = conn.execute(
+        f"""
+        SELECT metric, SUM(max_val) AS value
+        FROM (
+            SELECT metric, recorded_at, MAX(value) AS max_val
+            FROM health_metrics
+            WHERE date = ? AND (recorded_at IS NULL OR recorded_at != ?) AND metric IN ({placeholders})
+            GROUP BY metric, recorded_at
         )
-        for row in fallback.fetchall():
-            metrics[row["metric"]] = row["value"]
+        GROUP BY metric
+        """,
+        (d, midnight, *_ACTIVITY_METRICS),
+    )
+    sums = {row["metric"]: row["value"] for row in sum_cursor.fetchall()}
+
+    metrics: dict[str, float] = {}
+    for m in _ACTIVITY_METRICS:
+        agg = aggregates.get(m, 0)
+        s = sums.get(m, 0)
+        if agg or s:
+            metrics[m] = max(agg, s)
 
     return metrics
 

--- a/bede-data/src/bede_data/ingest/health_parser.py
+++ b/bede-data/src/bede_data/ingest/health_parser.py
@@ -4,6 +4,18 @@ from datetime import datetime, timezone
 
 _MEDICATION_RE = re.compile(r"medication", re.IGNORECASE)
 
+# Cumulative metrics where qty = total count and Avg = replicated rate.
+# For these, prefer qty. For rate metrics (heart_rate etc.), prefer Avg.
+_CUMULATIVE_METRICS = frozenset(
+    {
+        "step_count",
+        "active_energy",
+        "apple_exercise_time",
+        "apple_stand_hour",
+        "mindful_minutes",
+    }
+)
+
 _TS_PATTERNS = [
     r"(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2}) ([+-]\d{4})",
     r"(\d{4}-\d{2}-\d{2})T(\d{2}:\d{2}:\d{2})([+-]\d{2}:\d{2})",
@@ -259,8 +271,13 @@ def parse_health_payload(payload: dict) -> dict:
             for entry in metric.get("data", []):
                 date = _parse_date(entry.get("date", ""))
                 source = entry.get("source", "")
-                avg = entry.get("Avg")
-                qty = avg if avg is not None else entry.get("qty")
+                if name in _CUMULATIVE_METRICS:
+                    qty = entry.get("qty")
+                    if qty is None:
+                        qty = entry.get("Avg")
+                else:
+                    avg = entry.get("Avg")
+                    qty = avg if avg is not None else entry.get("qty")
                 if qty is None:
                     continue
                 try:

--- a/bede-data/tests/test_api_health.py
+++ b/bede-data/tests/test_api_health.py
@@ -106,14 +106,13 @@ def test_get_activity(client, db):
     assert data["stand_hours"] == 10
 
 
-def test_get_activity_prefers_midnight_aggregate(client, db):
-    """When HAE's daily aggregate exists at midnight local time, use it."""
+def test_get_activity_uses_aggregate_when_larger(client, db):
+    """Completed day: midnight aggregate > per-minute SUM, so use aggregate."""
     # Midnight AEST on Apr 30 = 2026-04-29T14:00:00Z
     db.execute(
         "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
         ("2026-04-30", "step_count", 5000, "Apple Watch", "2026-04-29T14:00:00Z"),
     )
-    # Per-minute readings that overlap with the aggregate
     db.execute(
         "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
         ("2026-04-30", "step_count", 50, "Apple Watch", "2026-04-30T00:00:00Z"),
@@ -127,6 +126,29 @@ def test_get_activity_prefers_midnight_aggregate(client, db):
     assert response.status_code == 200
     data = response.json()
     assert data["steps"] == 5000
+
+
+def test_get_activity_uses_sum_when_aggregate_stale(client, db):
+    """Current day: stale midnight aggregate < per-minute SUM, so use SUM."""
+    # Stale aggregate from early morning
+    db.execute(
+        "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
+        ("2026-04-30", "step_count", 200, "Apple Watch", "2026-04-29T14:00:00Z"),
+    )
+    # Per-minute readings accumulated throughout the day
+    db.execute(
+        "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
+        ("2026-04-30", "step_count", 500, "Apple Watch", "2026-04-30T00:00:00Z"),
+    )
+    db.execute(
+        "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
+        ("2026-04-30", "step_count", 800, "Apple Watch", "2026-04-30T03:00:00Z"),
+    )
+    db.commit()
+    response = client.get("/api/health/activity", params={"date": "2026-04-30"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["steps"] == 1300
 
 
 def test_get_activity_sums_when_no_aggregate(client, db):

--- a/bede-data/tests/test_ingest_health.py
+++ b/bede-data/tests/test_ingest_health.py
@@ -378,8 +378,8 @@ def test_parse_metric_avg_fallback():
     assert result["health_metrics"][0]["source"] == "Apple Watch"
 
 
-def test_parse_metric_avg_preferred_over_qty():
-    """When both Avg and qty are present, Avg should win (qty may be 0 in summarised mode)."""
+def test_parse_metric_avg_preferred_over_qty_for_rates():
+    """For rate metrics (heart_rate), Avg wins over qty (qty may be 0 in summarised mode)."""
     payload = {
         "data": {
             "metrics": [
@@ -403,6 +403,31 @@ def test_parse_metric_avg_preferred_over_qty():
     result = parse_health_payload(payload)
     assert len(result["health_metrics"]) == 1
     assert result["health_metrics"][0]["value"] == 72
+
+
+def test_parse_cumulative_metric_uses_qty_over_avg():
+    """For cumulative metrics (step_count), qty wins over Avg to avoid overcounting."""
+    payload = {
+        "data": {
+            "metrics": [
+                {
+                    "name": "step_count",
+                    "units": "count",
+                    "data": [
+                        {
+                            "date": "2026-04-29 08:30:00 +1000",
+                            "qty": 150,
+                            "Avg": 9.554,
+                            "source": "Apple Watch",
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+    result = parse_health_payload(payload)
+    assert len(result["health_metrics"]) == 1
+    assert result["health_metrics"][0]["value"] == 150
 
 
 def test_parse_sleep_unsummarised_phase_records():


### PR DESCRIPTION
## Summary
- The midnight aggregate is stale for the current day (HAE only finalises it at end of day)
- Yesterday showed 342 steps instead of 2121 because the code always preferred the midnight entry
- Now takes `MAX(midnight aggregate, SUM of non-midnight readings)` — whichever source is more complete wins

## Behaviour by scenario
| Scenario | Aggregate | SUM excl midnight | Result |
|----------|-----------|-------------------|--------|
| Past day (completed) | 5000 | 100 | 5000 (aggregate wins) |
| Current day (stale agg) | 200 | 1300 | 1300 (SUM wins) |
| No aggregate | — | 750 | 750 (SUM fallback) |

## Test plan
- [x] 169 tests pass (3 step-count scenarios covered)
- [ ] Check today's steps vs phone after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)