### PR TITLE
fix: prefer midnight aggregate over SUM for activity metrics

### DIFF
--- a/bede-data/src/bede_data/api/health.py
+++ b/bede-data/src/bede_data/api/health.py
@@ -124,10 +124,9 @@ def _midnight_utc(local_date: str, tz_name: str) -> str:
 def _aggregate_activity(
     d: str, tz_name: str, conn: sqlite3.Connection
 ) -> dict[str, float]:
-    """Return activity metrics for a date. Takes the larger of HAE's
-    midnight aggregate and the SUM of non-midnight per-minute readings.
-    The aggregate is authoritative for past days but stale for the
-    current day; the SUM overcounts slightly but stays fresh."""
+    """Return activity metrics for a date. Prefer HAE's daily aggregate
+    (the entry at midnight local time) when available; fall back to
+    SUM(MAX per timestamp) for metrics without an aggregate."""
     midnight = _midnight_utc(d, tz_name)
     placeholders = ",".join("?" for _ in _ACTIVITY_METRICS)
 
@@ -136,29 +135,26 @@ def _aggregate_activity(
         f"WHERE date = ? AND recorded_at = ? AND metric IN ({placeholders})",
         (d, midnight, *_ACTIVITY_METRICS),
     )
-    aggregates = {row["metric"]: row["value"] for row in agg_cursor.fetchall()}
+    metrics = {row["metric"]: row["value"] for row in agg_cursor.fetchall()}
 
-    sum_cursor = conn.execute(
-        f"""
-        SELECT metric, SUM(max_val) AS value
-        FROM (
-            SELECT metric, recorded_at, MAX(value) AS max_val
-            FROM health_metrics
-            WHERE date = ? AND (recorded_at IS NULL OR recorded_at != ?) AND metric IN ({placeholders})
-            GROUP BY metric, recorded_at
+    missing = [m for m in _ACTIVITY_METRICS if m not in metrics]
+    if missing:
+        mp = ",".join("?" for _ in missing)
+        fallback = conn.execute(
+            f"""
+            SELECT metric, SUM(max_val) AS value
+            FROM (
+                SELECT metric, recorded_at, MAX(value) AS max_val
+                FROM health_metrics
+                WHERE date = ? AND metric IN ({mp})
+                GROUP BY metric, recorded_at
+            )
+            GROUP BY metric
+            """,
+            (d, *missing),
         )
-        GROUP BY metric
-        """,
-        (d, midnight, *_ACTIVITY_METRICS),
-    )
-    sums = {row["metric"]: row["value"] for row in sum_cursor.fetchall()}
-
-    metrics: dict[str, float] = {}
-    for m in _ACTIVITY_METRICS:
-        agg = aggregates.get(m, 0)
-        s = sums.get(m, 0)
-        if agg or s:
-            metrics[m] = max(agg, s)
+        for row in fallback.fetchall():
+            metrics[row["metric"]] = row["value"]
 
     return metrics
 

--- a/bede-data/tests/test_api_health.py
+++ b/bede-data/tests/test_api_health.py
@@ -106,8 +106,8 @@ def test_get_activity(client, db):
     assert data["stand_hours"] == 10
 
 
-def test_get_activity_uses_aggregate_when_larger(client, db):
-    """Completed day: midnight aggregate > per-minute SUM, so use aggregate."""
+def test_get_activity_prefers_aggregate_over_sum(client, db):
+    """Midnight aggregate is authoritative — per-minute readings are ignored."""
     # Midnight AEST on Apr 30 = 2026-04-29T14:00:00Z
     db.execute(
         "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
@@ -126,29 +126,6 @@ def test_get_activity_uses_aggregate_when_larger(client, db):
     assert response.status_code == 200
     data = response.json()
     assert data["steps"] == 5000
-
-
-def test_get_activity_uses_sum_when_aggregate_stale(client, db):
-    """Current day: stale midnight aggregate < per-minute SUM, so use SUM."""
-    # Stale aggregate from early morning
-    db.execute(
-        "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
-        ("2026-04-30", "step_count", 200, "Apple Watch", "2026-04-29T14:00:00Z"),
-    )
-    # Per-minute readings accumulated throughout the day
-    db.execute(
-        "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
-        ("2026-04-30", "step_count", 500, "Apple Watch", "2026-04-30T00:00:00Z"),
-    )
-    db.execute(
-        "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
-        ("2026-04-30", "step_count", 800, "Apple Watch", "2026-04-30T03:00:00Z"),
-    )
-    db.commit()
-    response = client.get("/api/health/activity", params={"date": "2026-04-30"})
-    assert response.status_code == 200
-    data = response.json()
-    assert data["steps"] == 1300
 
 
 def test_get_activity_sums_when_no_aggregate(client, db):


### PR DESCRIPTION
## Summary
- Reverts the MAX(aggregate, SUM) logic from PR #51 — it picked overcounted per-minute SUM values over the correct midnight aggregate
- Midnight aggregate is now authoritative when present; SUM(MAX per timestamp) is only used as a fallback when no aggregate exists
- Also need to purge corrupted cumulative metric data from DB after merge (old Avg-based parser data)

## Test plan
- [x] All 17 API health tests pass
- [ ] Deploy, purge old step_count data from DB, re-export from HAE
- [ ] Verify yesterday's steps match phone
- [ ] Verify today's steps match phone (after HAE export)

🤖 Generated with [Claude Code](https://claude.com/claude-code)