### PR TITLE
fix: skip cumulative metric entries without qty

### DIFF
--- a/bede-data/src/bede_data/api/health.py
+++ b/bede-data/src/bede_data/api/health.py
@@ -124,10 +124,9 @@ def _midnight_utc(local_date: str, tz_name: str) -> str:
 def _aggregate_activity(
     d: str, tz_name: str, conn: sqlite3.Connection
 ) -> dict[str, float]:
-    """Return activity metrics for a date. Takes the larger of HAE's
-    midnight aggregate and the SUM of non-midnight per-minute readings.
-    The aggregate is authoritative for past days but stale for the
-    current day; the SUM overcounts slightly but stays fresh."""
+    """Return activity metrics for a date. Prefer HAE's daily aggregate
+    (the entry at midnight local time) when available; fall back to
+    SUM(MAX per timestamp) for metrics without an aggregate."""
     midnight = _midnight_utc(d, tz_name)
     placeholders = ",".join("?" for _ in _ACTIVITY_METRICS)
 
@@ -136,29 +135,26 @@ def _aggregate_activity(
         f"WHERE date = ? AND recorded_at = ? AND metric IN ({placeholders})",
         (d, midnight, *_ACTIVITY_METRICS),
     )
-    aggregates = {row["metric"]: row["value"] for row in agg_cursor.fetchall()}
+    metrics = {row["metric"]: row["value"] for row in agg_cursor.fetchall()}
 
-    sum_cursor = conn.execute(
-        f"""
-        SELECT metric, SUM(max_val) AS value
-        FROM (
-            SELECT metric, recorded_at, MAX(value) AS max_val
-            FROM health_metrics
-            WHERE date = ? AND (recorded_at IS NULL OR recorded_at != ?) AND metric IN ({placeholders})
-            GROUP BY metric, recorded_at
+    missing = [m for m in _ACTIVITY_METRICS if m not in metrics]
+    if missing:
+        mp = ",".join("?" for _ in missing)
+        fallback = conn.execute(
+            f"""
+            SELECT metric, SUM(max_val) AS value
+            FROM (
+                SELECT metric, recorded_at, MAX(value) AS max_val
+                FROM health_metrics
+                WHERE date = ? AND metric IN ({mp})
+                GROUP BY metric, recorded_at
+            )
+            GROUP BY metric
+            """,
+            (d, *missing),
         )
-        GROUP BY metric
-        """,
-        (d, midnight, *_ACTIVITY_METRICS),
-    )
-    sums = {row["metric"]: row["value"] for row in sum_cursor.fetchall()}
-
-    metrics: dict[str, float] = {}
-    for m in _ACTIVITY_METRICS:
-        agg = aggregates.get(m, 0)
-        s = sums.get(m, 0)
-        if agg or s:
-            metrics[m] = max(agg, s)
+        for row in fallback.fetchall():
+            metrics[row["metric"]] = row["value"]
 
     return metrics
 

--- a/bede-data/src/bede_data/ingest/health_parser.py
+++ b/bede-data/src/bede_data/ingest/health_parser.py
@@ -273,8 +273,6 @@ def parse_health_payload(payload: dict) -> dict:
                 source = entry.get("source", "")
                 if name in _CUMULATIVE_METRICS:
                     qty = entry.get("qty")
-                    if qty is None:
-                        qty = entry.get("Avg")
                 else:
                     avg = entry.get("Avg")
                     qty = avg if avg is not None else entry.get("qty")

--- a/bede-data/tests/test_api_health.py
+++ b/bede-data/tests/test_api_health.py
@@ -106,8 +106,8 @@ def test_get_activity(client, db):
     assert data["stand_hours"] == 10
 
 
-def test_get_activity_uses_aggregate_when_larger(client, db):
-    """Completed day: midnight aggregate > per-minute SUM, so use aggregate."""
+def test_get_activity_prefers_aggregate_over_sum(client, db):
+    """Midnight aggregate is authoritative — per-minute readings are ignored."""
     # Midnight AEST on Apr 30 = 2026-04-29T14:00:00Z
     db.execute(
         "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
@@ -126,29 +126,6 @@ def test_get_activity_uses_aggregate_when_larger(client, db):
     assert response.status_code == 200
     data = response.json()
     assert data["steps"] == 5000
-
-
-def test_get_activity_uses_sum_when_aggregate_stale(client, db):
-    """Current day: stale midnight aggregate < per-minute SUM, so use SUM."""
-    # Stale aggregate from early morning
-    db.execute(
-        "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
-        ("2026-04-30", "step_count", 200, "Apple Watch", "2026-04-29T14:00:00Z"),
-    )
-    # Per-minute readings accumulated throughout the day
-    db.execute(
-        "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
-        ("2026-04-30", "step_count", 500, "Apple Watch", "2026-04-30T00:00:00Z"),
-    )
-    db.execute(
-        "INSERT INTO health_metrics (date, metric, value, source, recorded_at) VALUES (?, ?, ?, ?, ?)",
-        ("2026-04-30", "step_count", 800, "Apple Watch", "2026-04-30T03:00:00Z"),
-    )
-    db.commit()
-    response = client.get("/api/health/activity", params={"date": "2026-04-30"})
-    assert response.status_code == 200
-    data = response.json()
-    assert data["steps"] == 1300
 
 
 def test_get_activity_sums_when_no_aggregate(client, db):

--- a/bede-data/tests/test_ingest_health.py
+++ b/bede-data/tests/test_ingest_health.py
@@ -430,6 +430,29 @@ def test_parse_cumulative_metric_uses_qty_over_avg():
     assert result["health_metrics"][0]["value"] == 150
 
 
+def test_parse_cumulative_metric_skips_avg_only():
+    """Cumulative metrics without qty are skipped entirely (Avg is not a valid fallback)."""
+    payload = {
+        "data": {
+            "metrics": [
+                {
+                    "name": "step_count",
+                    "units": "count",
+                    "data": [
+                        {
+                            "date": "2026-04-29 08:30:00 +1000",
+                            "Avg": 9.554,
+                            "source": "Apple Watch",
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+    result = parse_health_payload(payload)
+    assert result["health_metrics"] == []
+
+
 def test_parse_sleep_unsummarised_phase_records():
     """Unsummarised sleep: data[] entries that ARE phase records with value/qty."""
     payload = {


### PR DESCRIPTION
## Summary
- HAE midnight aggregates for the current day may lack a `qty` field — the parser was falling back to `Avg`, inflating the stored value (5990 vs 2121 actual)
- For cumulative metrics (step_count, active_energy, etc.), entries without `qty` are now skipped entirely
- Combined with PR #52's prefer-aggregate query logic, this means: aggregate is used when HAE provides qty for it, SUM of per-minute qty entries is the fallback

## Test plan
- [x] 38 tests pass (API + ingest)
- [ ] Deploy, purge cumulative metrics again, re-export from HAE
- [ ] Verify both days match phone

🤖 Generated with [Claude Code](https://claude.com/claude-code)