### PR TITLE
fix: sleep overestimation and location tool clarity

### DIFF
--- a/bede-data-mcp/src/bede_data_mcp/server.py
+++ b/bede-data-mcp/src/bede_data_mcp/server.py
@@ -274,9 +274,10 @@ async def get_bede_sessions(date: str, timezone: str = "Australia/Sydney") -> di
 
 @mcp.tool()
 async def get_location_summary(date: str, timezone: str = "Australia/Sydney") -> dict:
-    """Return summarised stops for a given local date with place names and arrival/departure times.
+    """Return where Joe was during a given day as a list of named stops with local arrival/departure times.
 
-    Clusters GPS points into named locations via reverse geocoding.
+    This is the primary location tool. It clusters GPS points, reverse geocodes coordinates into
+    place names, and converts all timestamps to the requested timezone.
 
     Args:
         date: Local date -- 'YYYY-MM-DD', 'today', or 'yesterday'.
@@ -287,7 +288,10 @@ async def get_location_summary(date: str, timezone: str = "Australia/Sydney") ->
 
 @mcp.tool()
 async def get_location_raw(from_date: str, to_date: str) -> dict:
-    """Return raw GPS points for a local date range without summarisation.
+    """Return raw OwnTracks GPS points for debugging or custom analysis.
+
+    Prefer get_location_summary for normal use — it returns named stops with local times.
+    This tool returns unsummarised points with UTC epoch timestamps and bare lat/lon coordinates.
 
     Args:
         from_date: Start local date ('YYYY-MM-DD').

--- a/bede-data/src/bede_data/api/health.py
+++ b/bede-data/src/bede_data/api/health.py
@@ -48,10 +48,22 @@ def _group_into_sessions(phases: list[dict]) -> list[list[dict]]:
     return sessions
 
 
+_SLEEP_STAGES = frozenset(("core", "deep", "rem"))
+
+
+def _sleep_hours(phases: list[dict]) -> float:
+    stage_phases = [p for p in phases if p["phase"] in _SLEEP_STAGES]
+    if stage_phases:
+        return sum(p["hours"] for p in stage_phases)
+    asleep_phases = [p for p in phases if p["phase"] == "asleep"]
+    if asleep_phases:
+        return sum(p["hours"] for p in asleep_phases)
+    return sum(p["hours"] for p in phases)
+
+
 def _build_session(phases: list[dict]) -> dict:
-    total_hours = round(sum(p["hours"] for p in phases), 2)
     return {
-        "total_hours": total_hours,
+        "total_hours": round(_sleep_hours(phases), 2),
         "bedtime": phases[0]["start_time"],
         "wake_time": phases[-1]["end_time"],
         "phases": phases,

--- a/bede-data/tests/test_api_health.py
+++ b/bede-data/tests/test_api_health.py
@@ -380,6 +380,64 @@ def test_get_sleep_separates_nap_from_overnight(client, db):
     assert data["wake_time"] == "2026-04-30T05:18:00"
 
 
+def test_get_sleep_excludes_overlapping_phases_from_total(client, db):
+    """When HAE sends all six aggregated fields, total should only count
+    core+deep+rem — not awake, asleep, or inBed which overlap."""
+    for phase, hours in [
+        ("core", 3.5),
+        ("deep", 0.8),
+        ("rem", 2.0),
+        ("awake", 1.05),
+        ("asleep", 6.3),
+        ("inBed", 7.35),
+    ]:
+        db.execute(
+            "INSERT INTO sleep_phases (date, phase, hours, start_time, end_time, source) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                "2026-05-01",
+                phase,
+                hours,
+                "2026-04-30T13:00:00Z",
+                "2026-04-30T20:21:00Z",
+                "Apple Watch",
+            ),
+        )
+    db.commit()
+
+    response = client.get("/api/health/sleep", params={"date": "2026-05-01"})
+    assert response.status_code == 200
+    data = response.json()
+    # Only core + deep + rem = 6.3, NOT 20.0 (all six summed)
+    assert data["total_hours"] == 6.3
+    assert data["sessions"][0]["total_hours"] == 6.3
+
+
+def test_get_sleep_uses_asleep_when_no_stage_breakdown(client, db):
+    """When only asleep/awake/inBed are present (no core/deep/rem), use asleep."""
+    for phase, hours in [
+        ("asleep", 1.5),
+        ("awake", 0.2),
+        ("inBed", 1.7),
+    ]:
+        db.execute(
+            "INSERT INTO sleep_phases (date, phase, hours, start_time, end_time, source) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                "2026-05-01",
+                phase,
+                hours,
+                "2026-05-01T03:00:00Z",
+                "2026-05-01T04:42:00Z",
+                "Apple Watch",
+            ),
+        )
+    db.commit()
+
+    response = client.get("/api/health/sleep", params={"date": "2026-05-01"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total_hours"] == 1.5
+
+
 def test_get_sleep_no_data(client, db):
     response = client.get("/api/health/sleep", params={"date": "2026-04-29"})
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- **Sleep total fix**: `_build_session` was summing all six HAE aggregated phases (core, deep, rem, awake, asleep, inBed) which overlap. Now only sums core+deep+rem for actual sleep time, falling back to `asleep` when no stage breakdown exists. Reported as 8.54h when actual was 7h21m.
- **Location tool descriptions**: Updated MCP tool docstrings so Claude strongly prefers `get_location_summary` (pre-processed named stops with local times) over `get_location_raw` (bare lat/lon + UTC epochs). Evening reflection was calling the raw endpoint and manually parsing coordinates.

## Test plan
- [x] Added `test_get_sleep_excludes_overlapping_phases_from_total` — seeds all six overlapping phases, asserts only core+deep+rem counted
- [x] Added `test_get_sleep_uses_asleep_when_no_stage_breakdown` — seeds only asleep/awake/inBed, asserts fallback to asleep
- [x] All 171 existing tests pass
- [ ] Deploy and verify tonight's evening reflection reports correct sleep duration
- [ ] Verify evening reflection uses `get_location_summary` instead of `get_location_raw`

🤖 Generated with [Claude Code](https://claude.com/claude-code)