### PR TITLE
fix: use timezone-aware dates in health, vault, and analytics APIs

### DIFF
--- a/bede-data/src/bede_data/analytics/signals.py
+++ b/bede-data/src/bede_data/analytics/signals.py
@@ -3,7 +3,9 @@ from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
 
-def _today_str(reference_date: str | None = None, tz_name: str = "Australia/Sydney") -> str:
+def _today_str(
+    reference_date: str | None = None, tz_name: str = "Australia/Sydney"
+) -> str:
     return reference_date or datetime.now(ZoneInfo(tz_name)).strftime("%Y-%m-%d")
 
 

--- a/bede-data/src/bede_data/analytics/signals.py
+++ b/bede-data/src/bede_data/analytics/signals.py
@@ -1,9 +1,10 @@
 import sqlite3
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 
 
-def _today_str(reference_date: str | None = None) -> str:
-    return reference_date or date.today().isoformat()
+def _today_str(reference_date: str | None = None, tz_name: str = "Australia/Sydney") -> str:
+    return reference_date or datetime.now(ZoneInfo(tz_name)).strftime("%Y-%m-%d")
 
 
 def _date_range(reference: str, window_days: int) -> tuple[str, str]:

--- a/bede-data/src/bede_data/analytics/signals.py
+++ b/bede-data/src/bede_data/analytics/signals.py
@@ -2,9 +2,11 @@ import sqlite3
 from datetime import datetime, timedelta
 from zoneinfo import ZoneInfo
 
+from bede_data.config import settings
+
 
 def _today_str(
-    reference_date: str | None = None, tz_name: str = "Australia/Sydney"
+    reference_date: str | None = None, tz_name: str = settings.timezone
 ) -> str:
     return reference_date or datetime.now(ZoneInfo(tz_name)).strftime("%Y-%m-%d")
 

--- a/bede-data/src/bede_data/api/health.py
+++ b/bede-data/src/bede_data/api/health.py
@@ -1,5 +1,5 @@
 import sqlite3
-from datetime import date, datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Depends, Query
@@ -13,11 +13,12 @@ _AGGREGATED_PHASES = ("core", "deep", "rem", "awake", "asleep", "inBed")
 router = APIRouter(prefix="/api/health", tags=["health"])
 
 
-def _resolve_date(date_str: str) -> str:
+def _resolve_date(date_str: str, tz_name: str = "Australia/Sydney") -> str:
+    tz = ZoneInfo(tz_name)
     if date_str == "today":
-        return date.today().isoformat()
+        return datetime.now(tz).strftime("%Y-%m-%d")
     if date_str == "yesterday":
-        return (date.today() - timedelta(days=1)).isoformat()
+        return (datetime.now(tz) - timedelta(days=1)).strftime("%Y-%m-%d")
     return date_str
 
 
@@ -76,7 +77,7 @@ def get_sleep(
     timezone: str = Query("Australia/Sydney"),
     conn: sqlite3.Connection = Depends(get_db),
 ):
-    d = _resolve_date(date)
+    d = _resolve_date(date, timezone)
     placeholders = ",".join("?" for _ in _AGGREGATED_PHASES)
     cursor = conn.execute(
         f"SELECT phase, hours, start_time, end_time, source FROM sleep_phases WHERE date = ? AND phase IN ({placeholders}) ORDER BY start_time",
@@ -177,7 +178,7 @@ def get_activity(
     timezone: str = Query("Australia/Sydney"),
     conn: sqlite3.Connection = Depends(get_db),
 ):
-    d = _resolve_date(date)
+    d = _resolve_date(date, timezone)
     metrics = _aggregate_activity(d, timezone, conn)
     return {
         "date": d,
@@ -194,7 +195,7 @@ def get_workouts(
     timezone: str = Query("Australia/Sydney"),
     conn: sqlite3.Connection = Depends(get_db),
 ):
-    d = _resolve_date(date)
+    d = _resolve_date(date, timezone)
     cursor = conn.execute(
         "SELECT workout_type, duration_minutes, active_energy_kj, avg_heart_rate, max_heart_rate, start_time FROM workouts WHERE date = ? ORDER BY start_time",
         (d,),
@@ -211,7 +212,7 @@ def get_heart_rate(
     timezone: str = Query("Australia/Sydney"),
     conn: sqlite3.Connection = Depends(get_db),
 ):
-    d = _resolve_date(date)
+    d = _resolve_date(date, timezone)
     cursor = conn.execute(
         "SELECT metric, value FROM health_metrics WHERE date = ? AND metric IN ('resting_heart_rate', 'heart_rate_variability')",
         (d,),
@@ -230,7 +231,7 @@ def get_wellbeing(
     timezone: str = Query("Australia/Sydney"),
     conn: sqlite3.Connection = Depends(get_db),
 ):
-    d = _resolve_date(date)
+    d = _resolve_date(date, timezone)
 
     cursor = conn.execute(
         "SELECT value FROM health_metrics WHERE date = ? AND metric = 'mindful_minutes'",
@@ -260,7 +261,7 @@ def get_medications(
     timezone: str = Query("Australia/Sydney"),
     conn: sqlite3.Connection = Depends(get_db),
 ):
-    d = _resolve_date(date)
+    d = _resolve_date(date, timezone)
     cursor = conn.execute(
         "SELECT medication, quantity, unit, recorded_at FROM medications WHERE date = ? ORDER BY recorded_at",
         (d,),

--- a/bede-data/src/bede_data/api/health.py
+++ b/bede-data/src/bede_data/api/health.py
@@ -4,6 +4,7 @@ from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Depends, Query
 
+from bede_data.config import settings
 from bede_data.db.connection import get_db
 from bede_data.tz import utc_to_local
 
@@ -13,7 +14,7 @@ _AGGREGATED_PHASES = ("core", "deep", "rem", "awake", "asleep", "inBed")
 router = APIRouter(prefix="/api/health", tags=["health"])
 
 
-def _resolve_date(date_str: str, tz_name: str = "Australia/Sydney") -> str:
+def _resolve_date(date_str: str, tz_name: str = settings.timezone) -> str:
     tz = ZoneInfo(tz_name)
     if date_str == "today":
         return datetime.now(tz).strftime("%Y-%m-%d")

--- a/bede-data/src/bede_data/api/vault_data.py
+++ b/bede-data/src/bede_data/api/vault_data.py
@@ -4,13 +4,14 @@ from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Depends, Query
 
+from bede_data.config import settings
 from bede_data.db.connection import get_db
 from bede_data.tz import utc_to_local
 
 router = APIRouter(prefix="/api/vault", tags=["vault"])
 
 
-def _resolve_date(date_str: str, tz_name: str = "Australia/Sydney") -> str:
+def _resolve_date(date_str: str, tz_name: str = settings.timezone) -> str:
     tz = ZoneInfo(tz_name)
     if date_str == "today":
         return datetime.now(tz).strftime("%Y-%m-%d")

--- a/bede-data/src/bede_data/api/vault_data.py
+++ b/bede-data/src/bede_data/api/vault_data.py
@@ -1,5 +1,6 @@
 import sqlite3
-from datetime import date, timedelta
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Depends, Query
 
@@ -9,11 +10,12 @@ from bede_data.tz import utc_to_local
 router = APIRouter(prefix="/api/vault", tags=["vault"])
 
 
-def _resolve_date(date_str: str) -> str:
+def _resolve_date(date_str: str, tz_name: str = "Australia/Sydney") -> str:
+    tz = ZoneInfo(tz_name)
     if date_str == "today":
-        return date.today().isoformat()
+        return datetime.now(tz).strftime("%Y-%m-%d")
     if date_str == "yesterday":
-        return (date.today() - timedelta(days=1)).isoformat()
+        return (datetime.now(tz) - timedelta(days=1)).strftime("%Y-%m-%d")
     return date_str
 
 
@@ -25,7 +27,7 @@ def get_screen_time(
     timezone: str = Query("Australia/Sydney"),
     conn: sqlite3.Connection = Depends(get_db),
 ):
-    d = _resolve_date(date)
+    d = _resolve_date(date, timezone)
     query = "SELECT device, entry_type, name, seconds FROM screen_time WHERE date = ?"
     params: list = [d]
     if device:
@@ -49,7 +51,7 @@ def get_safari(
     timezone: str = Query("Australia/Sydney"),
     conn: sqlite3.Connection = Depends(get_db),
 ):
-    d = _resolve_date(date)
+    d = _resolve_date(date, timezone)
     query = "SELECT device, domain, title, url, visited_at FROM safari_history WHERE date = ?"
     params: list = [d]
     if device:
@@ -76,7 +78,7 @@ def get_youtube(
     timezone: str = Query("Australia/Sydney"),
     conn: sqlite3.Connection = Depends(get_db),
 ):
-    d = _resolve_date(date)
+    d = _resolve_date(date, timezone)
     cursor = conn.execute(
         "SELECT title, url, visited_at FROM youtube_history WHERE date = ? ORDER BY visited_at DESC",
         (d,),
@@ -93,7 +95,7 @@ def get_podcasts(
     timezone: str = Query("Australia/Sydney"),
     conn: sqlite3.Connection = Depends(get_db),
 ):
-    d = _resolve_date(date)
+    d = _resolve_date(date, timezone)
     cursor = conn.execute(
         "SELECT podcast, episode, duration_seconds, playhead_seconds, play_count, played_at FROM podcasts WHERE date = ? ORDER BY played_at DESC",
         (d,),
@@ -110,7 +112,7 @@ def get_claude_sessions(
     timezone: str = Query("Australia/Sydney"),
     conn: sqlite3.Connection = Depends(get_db),
 ):
-    d = _resolve_date(date)
+    d = _resolve_date(date, timezone)
     cursor = conn.execute(
         "SELECT project, start_time, end_time, duration_min, turns, summary FROM claude_sessions WHERE date = ? ORDER BY start_time",
         (d,),
@@ -124,7 +126,7 @@ def get_bede_sessions(
     timezone: str = Query("Australia/Sydney"),
     conn: sqlite3.Connection = Depends(get_db),
 ):
-    d = _resolve_date(date)
+    d = _resolve_date(date, timezone)
     cursor = conn.execute(
         "SELECT task_name, start_time, end_time, duration_min, turns, summary FROM bede_sessions WHERE date = ? ORDER BY start_time",
         (d,),

--- a/bede-data/tests/test_api_analytics.py
+++ b/bede-data/tests/test_api_analytics.py
@@ -5,9 +5,10 @@ def test_get_analytics_flags_empty(client):
 
 
 def test_run_analytics_and_get_flags(client, db):
-    from datetime import date, timedelta
+    from datetime import datetime, timedelta
+    from zoneinfo import ZoneInfo
 
-    today = date.today()
+    today = datetime.now(ZoneInfo("Australia/Sydney")).date()
     for offset in range(3):
         d = (today - timedelta(days=2 - offset)).isoformat()
         db.execute(


### PR DESCRIPTION
## Summary
- `_resolve_date()` in `health.py` and `vault_data.py` used `date.today()` (UTC), so at 8am Sydney time "yesterday" resolved to two days ago — causing the morning reflection to show stale step/activity data
- `_today_str()` in `signals.py` (analytics) had the same bug, shifting analytics windows by a day
- All three now use `datetime.now(ZoneInfo(tz_name))`, matching the pattern already in `location.py`

## Test plan
- [x] All 171 existing tests pass
- [ ] Verify morning reflection shows correct yesterday data after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)