### PR TITLE
fix: parse HAE medications export format

### DIFF
--- a/bede-data/src/bede_data/api/health.py
+++ b/bede-data/src/bede_data/api/health.py
@@ -264,7 +264,7 @@ def get_medications(
 ):
     d = _resolve_date(date, timezone)
     cursor = conn.execute(
-        "SELECT medication, quantity, unit, recorded_at FROM medications WHERE date = ? ORDER BY recorded_at",
+        "SELECT medication, quantity, unit, recorded_at, status FROM medications WHERE date = ? ORDER BY recorded_at",
         (d,),
     )
     meds = [dict(row) for row in cursor.fetchall()]

--- a/bede-data/src/bede_data/db/connection.py
+++ b/bede-data/src/bede_data/db/connection.py
@@ -42,6 +42,12 @@ def init_db() -> None:
                 except sqlite3.OperationalError:
                     pass
             conn.commit()
+        if existing is not None and existing < 7:
+            try:
+                conn.execute("ALTER TABLE medications ADD COLUMN status TEXT")
+                conn.commit()
+            except sqlite3.OperationalError:
+                pass
         conn.commit()
         conn.executescript(SCHEMA_SQL)
         existing = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()[0]

--- a/bede-data/src/bede_data/db/schema.py
+++ b/bede-data/src/bede_data/db/schema.py
@@ -1,4 +1,4 @@
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 # Tables whose column names changed from the prototype bede schema.
 # init_db drops these if they have old-style columns, then SCHEMA_SQL recreates them.
@@ -87,6 +87,7 @@ CREATE TABLE IF NOT EXISTS medications (
     quantity    REAL,
     unit        TEXT,
     recorded_at TEXT,
+    status      TEXT,
     UNIQUE (date, medication, recorded_at)
 );
 

--- a/bede-data/src/bede_data/ingest/health_parser.py
+++ b/bede-data/src/bede_data/ingest/health_parser.py
@@ -313,7 +313,9 @@ def parse_health_payload(payload: dict) -> dict:
         )
 
     result["state_of_mind"].extend(
-        _process_state_of_mind(data.get("stateOfMind", []) or payload.get("stateOfMind", []))
+        _process_state_of_mind(
+            data.get("stateOfMind", []) or payload.get("stateOfMind", [])
+        )
     )
 
     for med in data.get("medications", []) or payload.get("medications", []):

--- a/bede-data/src/bede_data/ingest/health_parser.py
+++ b/bede-data/src/bede_data/ingest/health_parser.py
@@ -314,4 +314,20 @@ def parse_health_payload(payload: dict) -> dict:
 
     result["state_of_mind"].extend(_process_state_of_mind(data.get("stateOfMind", [])))
 
+    for med in data.get("medications", []) or payload.get("medications", []):
+        if med.get("isArchived"):
+            continue
+        ts = med.get("scheduledDate", "") or med.get("start", "")
+        date = _parse_date(ts)
+        result["medications"].append(
+            {
+                "date": date,
+                "medication": med.get("displayText", ""),
+                "quantity": med.get("dosage"),
+                "unit": med.get("form"),
+                "recorded_at": _parse_datetime(ts),
+                "status": med.get("status"),
+            }
+        )
+
     return result

--- a/bede-data/src/bede_data/ingest/health_parser.py
+++ b/bede-data/src/bede_data/ingest/health_parser.py
@@ -294,7 +294,7 @@ def parse_health_payload(payload: dict) -> dict:
                     }
                 )
 
-    for workout in data.get("workouts", []):
+    for workout in data.get("workouts", []) or payload.get("workouts", []):
         start_str = workout.get("start", "")
         end_str = workout.get("end", "")
         duration = _hours_between(start_str, end_str) * 60
@@ -312,7 +312,9 @@ def parse_health_payload(payload: dict) -> dict:
             }
         )
 
-    result["state_of_mind"].extend(_process_state_of_mind(data.get("stateOfMind", [])))
+    result["state_of_mind"].extend(
+        _process_state_of_mind(data.get("stateOfMind", []) or payload.get("stateOfMind", []))
+    )
 
     for med in data.get("medications", []) or payload.get("medications", []):
         if med.get("isArchived"):

--- a/bede-data/tests/test_app.py
+++ b/bede-data/tests/test_app.py
@@ -3,4 +3,4 @@ def test_health_check(client):
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "ok"
-    assert data["schema_version"] == 6
+    assert data["schema_version"] == 7

--- a/bede-data/tests/test_db.py
+++ b/bede-data/tests/test_db.py
@@ -48,7 +48,7 @@ def test_wal_mode_enabled(db):
 def test_schema_version_is_set(db):
     cursor = db.execute("SELECT MAX(version) FROM schema_version")
     version = cursor.fetchone()[0]
-    assert version == 6
+    assert version == 7
 
 
 def test_health_metrics_upsert_by_natural_key(db):

--- a/bede-data/tests/test_ingest_health.py
+++ b/bede-data/tests/test_ingest_health.py
@@ -327,6 +327,25 @@ def test_parse_state_of_mind_top_level():
     assert json.loads(result["state_of_mind"][0]["associations"]) == ["Work"]
 
 
+def test_parse_state_of_mind_top_level_payload():
+    """HAE may send stateOfMind at the payload root, not inside data."""
+    payload = {
+        "stateOfMind": [
+            {
+                "start": "2026-05-05 10:00:00 +1000",
+                "kind": "mood",
+                "valence": -0.3,
+                "labels": ["Anxious"],
+                "associations": ["Health"],
+            }
+        ]
+    }
+    result = parse_health_payload(payload)
+    assert len(result["state_of_mind"]) == 1
+    assert result["state_of_mind"][0]["valence"] == -0.3
+    assert result["state_of_mind"][0]["date"] == "2026-05-05"
+
+
 def test_parse_skips_metrics_with_no_qty():
     payload = {
         "data": {

--- a/bede-data/tests/test_ingest_health.py
+++ b/bede-data/tests/test_ingest_health.py
@@ -244,6 +244,63 @@ def test_parse_medications_regex():
     assert result["medications"][0]["unit"] == "tablet"
 
 
+def test_parse_hae_medications():
+    """HAE sends medications as a top-level array in data with displayText/dosage/form/status."""
+    payload = {
+        "data": {
+            "medications": [
+                {
+                    "displayText": "Aspirin",
+                    "nickname": "Daily Aspirin",
+                    "start": "2026-01-01 08:00:00 +1100",
+                    "end": None,
+                    "scheduledDate": "2026-04-29 08:00:00 +1000",
+                    "form": "Tablet",
+                    "status": "Taken",
+                    "isArchived": False,
+                    "dosage": 81,
+                },
+                {
+                    "displayText": "Old Med",
+                    "scheduledDate": "2026-04-29 09:00:00 +1000",
+                    "form": "Capsule",
+                    "status": "Taken",
+                    "isArchived": True,
+                    "dosage": 1,
+                },
+            ]
+        }
+    }
+    result = parse_health_payload(payload)
+    assert len(result["medications"]) == 1
+    assert result["medications"][0]["medication"] == "Aspirin"
+    assert result["medications"][0]["quantity"] == 81
+    assert result["medications"][0]["unit"] == "Tablet"
+    assert result["medications"][0]["status"] == "Taken"
+    assert result["medications"][0]["date"] == "2026-04-29"
+
+
+def test_parse_hae_medications_skipped():
+    """Skipped medications are still stored so Bede can report on adherence."""
+    payload = {
+        "data": {
+            "medications": [
+                {
+                    "displayText": "Vitamin D",
+                    "scheduledDate": "2026-04-29 08:00:00 +1000",
+                    "form": "Tablet",
+                    "status": "Skipped",
+                    "isArchived": False,
+                    "dosage": 1,
+                },
+            ]
+        }
+    }
+    result = parse_health_payload(payload)
+    assert len(result["medications"]) == 1
+    assert result["medications"][0]["status"] == "Skipped"
+
+
 def test_parse_state_of_mind_top_level():
     """stateOfMind is a top-level array in data, not inside metrics."""
     payload = {


### PR DESCRIPTION
## Summary
- HAE exports medications as a `data.medications[]` array with `displayText`, `dosage`, `form`, `status`, `scheduledDate` — not as metrics with "medication" in the name. The old regex path never matched, so zero medication data was being ingested.
- Adds parser for the real HAE format, filtering out archived medications
- Adds `status` column to medications table (schema v7 with ALTER TABLE migration) so Bede can distinguish Taken/Skipped/Not Logged
- API `GET /api/health/medications` now returns the `status` field

## Test plan
- [x] 173/173 tests pass locally including 2 new parser tests
- [ ] Merge, wait for GHCR build, deploy to server
- [ ] Verify next HAE export populates the medications table
- [ ] Confirm Bede's daily digest reports medication data

🤖 Generated with [Claude Code](https://claude.com/claude-code)