### PR TITLE
fix: resolve SQLite concurrency issues on concurrent ingest

### DIFF
--- a/bede-data/Dockerfile
+++ b/bede-data/Dockerfile
@@ -17,4 +17,4 @@ EXPOSE 8001
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8001/health')" || exit 1
 
-CMD [".venv/bin/uvicorn", "bede_data.app:create_app", "--factory", "--host", "0.0.0.0", "--port", "8001"]
+CMD [".venv/bin/uvicorn", "bede_data.app:create_app", "--factory", "--host", "0.0.0.0", "--port", "8001", "--workers", "2"]

--- a/bede-data/src/bede_data/db/connection.py
+++ b/bede-data/src/bede_data/db/connection.py
@@ -6,9 +6,10 @@ from bede_data.db.schema import SCHEMA_SQL, SCHEMA_VERSION, tables_needing_reset
 
 
 def get_connection() -> sqlite3.Connection:
-    conn = sqlite3.connect(settings.sqlite_db_path)
+    conn = sqlite3.connect(settings.sqlite_db_path, check_same_thread=False, timeout=60)
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("PRAGMA busy_timeout = 30000")
     return conn
 
 

--- a/bede-data/src/bede_data/ingest/router.py
+++ b/bede-data/src/bede_data/ingest/router.py
@@ -19,8 +19,7 @@ def _upsert_rows(conn: sqlite3.Connection, table: str, rows: list[dict]) -> int:
     placeholders = ", ".join("?" for _ in columns)
     col_names = ", ".join(columns)
     sql = f"INSERT OR REPLACE INTO [{table}] ({col_names}) VALUES ({placeholders})"
-    for row in rows:
-        conn.execute(sql, [row[c] for c in columns])
+    conn.executemany(sql, [[row[c] for c in columns] for row in rows])
     return len(rows)
 
 


### PR DESCRIPTION
## Summary

Fixes the recurring issue where concurrent health/vault ingest requests cascade into 504 gateway timeouts.

- **`check_same_thread=False` + `timeout=60`** on `sqlite3.connect()` — prevents Python's threading safety check from rejecting connections used across FastAPI's threadpool
- **`PRAGMA busy_timeout = 30000`** — concurrent writers wait up to 30s for the lock instead of failing immediately with "database is locked"
- **`executemany`** in `_upsert_rows` — reduces lock hold time by batching inserts instead of looping
- **`--workers 2`** in Dockerfile — second uvicorn worker ensures health checks and other endpoints respond while one worker processes a large ingest

## Evidence

From Traefik access logs today (2026-05-05):
- 09:20, 09:41: `POST /ingest/vault` → 504 at exactly 30s
- 09:46: 6x `POST /ingest/health` → all 504 at 30s  
- 10:01–10:05: 12x `POST /ingest/health` → 499 (client disconnect) at 5–25s

Fixes #60

## Test plan

- [x] All 174 existing tests pass
- [ ] Deploy and trigger concurrent health exports from HAE
- [ ] Verify no 504s in Traefik access log after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)