### PR TITLE
fix: normalize device filter in vault API

### DIFF
--- a/bede-data/src/bede_data/api/vault_data.py
+++ b/bede-data/src/bede_data/api/vault_data.py
@@ -10,6 +10,12 @@ from bede_data.tz import utc_to_local
 
 router = APIRouter(prefix="/api/vault", tags=["vault"])
 
+_DEVICE_ALIASES = {"phone": "iphone", "mobile": "iphone"}
+
+
+def _normalize_device(device: str) -> str:
+    return _DEVICE_ALIASES.get(device.lower(), device.lower())
+
 
 def _resolve_date(date_str: str, tz_name: str = settings.timezone) -> str:
     tz = ZoneInfo(tz_name)
@@ -32,8 +38,8 @@ def get_screen_time(
     query = "SELECT device, entry_type, name, seconds FROM screen_time WHERE date = ?"
     params: list = [d]
     if device:
-        query += " AND device = ?"
-        params.append(device)
+        query += " AND LOWER(device) = ?"
+        params.append(_normalize_device(device))
     query += " ORDER BY seconds DESC"
     if top_n:
         query += " LIMIT ?"
@@ -56,8 +62,8 @@ def get_safari(
     query = "SELECT device, domain, title, url, visited_at FROM safari_history WHERE date = ?"
     params: list = [d]
     if device:
-        query += " AND device = ?"
-        params.append(device)
+        query += " AND LOWER(device) = ?"
+        params.append(_normalize_device(device))
     if domain:
         query += " AND domain = ?"
         params.append(domain)

--- a/bede-data/tests/test_api_vault_data.py
+++ b/bede-data/tests/test_api_vault_data.py
@@ -96,6 +96,42 @@ def test_get_screen_time_filter_device(client, db):
     assert all(e["device"] == "mac" for e in data["entries"])
 
 
+def test_get_screen_time_device_alias(client, db):
+    _seed_vault_data(db)
+    response = client.get(
+        "/api/vault/screen-time", params={"date": "2026-04-29", "device": "phone"}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["entries"]) == 1
+    assert data["entries"][0]["device"] == "iphone"
+
+
+def test_get_screen_time_device_case_insensitive(client, db):
+    _seed_vault_data(db)
+    response = client.get(
+        "/api/vault/screen-time", params={"date": "2026-04-29", "device": "Mac"}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["entries"]) == 3
+
+
+def test_get_safari_device_case_insensitive(client, db):
+    db.execute(
+        "INSERT INTO safari_history (date, device, domain, title, url, visited_at) VALUES (?, ?, ?, ?, ?, ?)",
+        ("2026-04-29", "iPhone", "example.com", "Example", "https://example.com", "2026-04-29T12:00:00Z"),
+    )
+    db.commit()
+    response = client.get(
+        "/api/vault/safari", params={"date": "2026-04-29", "device": "phone"}
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["entries"]) == 1
+    assert data["entries"][0]["device"] == "iPhone"
+
+
 def test_get_screen_time_top_n(client, db):
     _seed_vault_data(db)
     response = client.get(

--- a/bede-data/tests/test_api_vault_data.py
+++ b/bede-data/tests/test_api_vault_data.py
@@ -120,7 +120,14 @@ def test_get_screen_time_device_case_insensitive(client, db):
 def test_get_safari_device_case_insensitive(client, db):
     db.execute(
         "INSERT INTO safari_history (date, device, domain, title, url, visited_at) VALUES (?, ?, ?, ?, ?, ?)",
-        ("2026-04-29", "iPhone", "example.com", "Example", "https://example.com", "2026-04-29T12:00:00Z"),
+        (
+            "2026-04-29",
+            "iPhone",
+            "example.com",
+            "Example",
+            "https://example.com",
+            "2026-04-29T12:00:00Z",
+        ),
     )
     db.commit()
     response = client.get(


### PR DESCRIPTION
## Summary
- Add device alias map (`phone`/`mobile` → `iphone`) and case-insensitive matching (`LOWER(device)`) to `/api/vault/screen-time` and `/api/vault/safari` endpoints
- Fixes empty results when LLM passes `device=phone` or `device=Mac` but DB stores `iphone`/`mac`/`iPhone`

Closes #63

## Test plan
- [x] Existing device filter tests still pass
- [x] New test: `device=phone` returns iphone screen time data
- [x] New test: `device=Mac` (uppercase) matches lowercase DB values
- [x] New test: `device=phone` matches TitleCase `iPhone` in safari_history

🤖 Generated with [Claude Code](https://claude.com/claude-code)