### PR TITLE
chore: pin uv base image to 0.11.10

### DIFF
--- a/bede-core/Dockerfile
+++ b/bede-core/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+FROM ghcr.io/astral-sh/uv:0.11.10-python3.12-bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git curl ca-certificates openssh-client \

--- a/bede-data-mcp/Dockerfile
+++ b/bede-data-mcp/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+FROM ghcr.io/astral-sh/uv:0.11.10-python3.12-bookworm-slim
 
 WORKDIR /app
 

--- a/bede-data/Dockerfile
+++ b/bede-data/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+FROM ghcr.io/astral-sh/uv:0.11.10-python3.12-bookworm-slim
 
 WORKDIR /app
 

--- a/bede-workspace-mcp/Dockerfile
+++ b/bede-workspace-mcp/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+FROM ghcr.io/astral-sh/uv:0.11.10-python3.12-bookworm-slim
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary

Pin `ghcr.io/astral-sh/uv` base image from `python3.12-bookworm-slim` to `0.11.10-python3.12-bookworm-slim` across all four Dockerfiles for deterministic builds.

Part of josephradford/home-server-stack#181.

## Test plan

- [ ] GHCR build completes successfully after merge
- [ ] `make bede-pull && make bede-restart` on server
- [ ] `make bede-status` shows all services healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)