### PR TITLE
feat(bede-core): add browser MCP server

### DIFF
--- a/bede-core/mcp.json
+++ b/bede-core/mcp.json
@@ -7,6 +7,10 @@
     "google-workspace": {
       "type": "http",
       "url": "http://bede-workspace-mcp:8003/mcp"
+    },
+    "browser": {
+      "type": "http",
+      "url": "http://bede-browser-mcp:8004/mcp"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add browser MCP server entry to bede-core's mcp.json
- Points to `http://bede-browser-mcp:8004/mcp` (streamable-http)
- Uses the official `mcr.microsoft.com/playwright/mcp` Docker image (wired in home-server-stack)

## Context
This enables bede-core to access headless Chromium browser tools via `@playwright/mcp`. The Docker container is wired in the companion home-server-stack PR using Microsoft's official image — no custom Dockerfile needed.

## Test plan
- [ ] After deploy: bede-core can discover browser MCP tools
- [ ] Browser tools work (navigate to URL, take screenshot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)