### PR TITLE
feat: deal monitoring and news curation

### DIFF
--- a/bede-core/src/bede_core/main.py
+++ b/bede-core/src/bede_core/main.py
@@ -213,6 +213,14 @@ def main():
         )
     )
     app.add_handler(
+        CommandHandler(
+            "digest",
+            create_task_trigger_handler(
+                "News Digest", runner, data_client, settings.allowed_user_id
+            ),
+        )
+    )
+    app.add_handler(
         MessageHandler(
             filters.TEXT & ~filters.COMMAND,
             create_message_handler(

--- a/bede-data-mcp/src/bede_data_mcp/server.py
+++ b/bede-data-mcp/src/bede_data_mcp/server.py
@@ -698,6 +698,31 @@ async def delete_monitored_item(item_id: int) -> dict:
     return await client.delete(f"/api/config/monitored-items/{item_id}")
 
 
+@mcp.tool()
+async def update_monitored_item(
+    item_id: int,
+    name: str | None = None,
+    config: str | None = None,
+    enabled: bool | None = None,
+) -> dict:
+    """Update a monitored item's name, config, or enabled status.
+
+    Args:
+        item_id: ID of the item to update.
+        name: New human-readable name.
+        config: New JSON config string.
+        enabled: Set enabled/disabled.
+    """
+    body: dict = {}
+    if name is not None:
+        body["name"] = name
+    if config is not None:
+        body["config"] = config
+    if enabled is not None:
+        body["enabled"] = enabled
+    return await client.put(f"/api/config/monitored-items/{item_id}", body)
+
+
 # ---------------------------------------------------------------------------
 # Data pipeline tools
 # ---------------------------------------------------------------------------

--- a/bede-data-mcp/src/bede_data_mcp/server.py
+++ b/bede-data-mcp/src/bede_data_mcp/server.py
@@ -845,6 +845,97 @@ async def update_dead_url(
 
 
 # ---------------------------------------------------------------------------
+# News curation tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def save_article(
+    url: str,
+    title: str,
+    source_name: str,
+    category: str | None = None,
+    summary: str | None = None,
+) -> dict:
+    """Save an article found during news curation.
+
+    Handles deduplication by URL — if the article already exists, returns
+    the existing record with already_existed=true instead of creating a
+    duplicate.
+
+    Args:
+        url: The article URL (used as dedup key).
+        title: Article headline.
+        source_name: Where it was found (e.g. 'Hacker News', 'TLDR AI').
+        category: Topic category (e.g. 'ai', 'public_sector', 'platform_tech').
+        summary: Brief summary of the article content.
+    """
+    body: dict = {"url": url, "title": title, "source_name": source_name}
+    if category is not None:
+        body["category"] = category
+    if summary is not None:
+        body["summary"] = summary
+    return await client.post("/api/news/articles", body)
+
+
+@mcp.tool()
+async def list_articles(
+    category: str | None = None,
+    source_name: str | None = None,
+    unsent: bool | None = None,
+    limit: int | None = None,
+) -> dict:
+    """List saved articles, optionally filtered.
+
+    Use unsent=true to get articles not yet included in any digest — this
+    is the primary query for building a news digest.
+
+    Args:
+        category: Filter by topic category.
+        source_name: Filter by source name.
+        unsent: If true, only return articles not yet in a digest.
+        limit: Max articles to return (default 50).
+    """
+    kwargs: dict = {}
+    if category is not None:
+        kwargs["category"] = category
+    if source_name is not None:
+        kwargs["source_name"] = source_name
+    if unsent is not None:
+        kwargs["unsent"] = unsent
+    if limit is not None:
+        kwargs["limit"] = limit
+    return await client.get("/api/news/articles", **kwargs)
+
+
+@mcp.tool()
+async def check_article_exists(url: str) -> dict:
+    """Check if an article URL has already been saved (deduplication check).
+
+    Args:
+        url: The article URL to check.
+    """
+    return await client.get("/api/news/articles/exists", url=url)
+
+
+@mcp.tool()
+async def mark_article_in_digest(article_id: int, digest_date: str) -> dict:
+    """Mark an article as included in a digest.
+
+    Call this after including an article in a news digest delivery so it
+    won't appear in future unsent queries.
+
+    Args:
+        article_id: ID of the article.
+        digest_date: The date of the digest (YYYY-MM-DD format).
+    """
+    return await client.put(
+        f"/api/news/articles/{article_id}/digest",
+        {"digest_date": digest_date},
+    )
+
+
+# ---------------------------------------------------------------------------
 # Data pipeline tools
 # ---------------------------------------------------------------------------
 

--- a/bede-data-mcp/src/bede_data_mcp/server.py
+++ b/bede-data-mcp/src/bede_data_mcp/server.py
@@ -724,6 +724,127 @@ async def update_monitored_item(
 
 
 # ---------------------------------------------------------------------------
+# Deal monitoring tools
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def record_price_check(
+    monitored_item_id: int,
+    url: str,
+    price: float | None = None,
+    currency: str | None = None,
+    in_stock: bool | None = None,
+    notes: str | None = None,
+) -> dict:
+    """Record a price check observation after scraping a retailer page.
+
+    Call this after visiting a product URL to persist the price and stock status.
+    The system tracks history so price drops and restocks can be detected.
+
+    Args:
+        monitored_item_id: ID of the monitored item this check belongs to.
+        url: The product page URL that was checked.
+        price: The observed price (omit if product page doesn't show a price).
+        currency: Currency code (e.g. 'AUD', 'USD'). Omit to use the API default (AUD).
+        in_stock: Whether the product is currently in stock.
+        notes: Optional notes (e.g. 'sale ends Friday', 'clearance').
+    """
+    body: dict = {"monitored_item_id": monitored_item_id, "url": url}
+    if price is not None:
+        body["price"] = price
+    if currency is not None:
+        body["currency"] = currency
+    if in_stock is not None:
+        body["in_stock"] = in_stock
+    if notes is not None:
+        body["notes"] = notes
+    return await client.post("/api/deals/price-checks", body)
+
+
+@mcp.tool()
+async def get_price_history(
+    monitored_item_id: int,
+    limit: int | None = None,
+    url: str | None = None,
+) -> dict:
+    """Get price check history for a monitored item.
+
+    Returns checks in reverse chronological order. Compare the most recent
+    check against previous ones to detect price drops or restocks.
+
+    Args:
+        monitored_item_id: ID of the monitored item.
+        limit: Max number of checks to return (default 50).
+        url: Filter to a specific product URL.
+    """
+    kwargs: dict = {}
+    if limit is not None:
+        kwargs["limit"] = limit
+    if url is not None:
+        kwargs["url"] = url
+    return await client.get(f"/api/deals/price-history/{monitored_item_id}", **kwargs)
+
+
+@mcp.tool()
+async def report_dead_url(url: str, category: str | None = None, error: str | None = None) -> dict:
+    """Report a URL that failed to load or returned an error.
+
+    Call this when a product page returns 404, 403, redirects to a homepage,
+    or otherwise fails. The system tracks failure counts — URLs with repeated
+    failures can be skipped in future checks.
+
+    Args:
+        url: The URL that failed.
+        category: Category for grouping (e.g. 'deal', 'news').
+        error: Description of the failure (e.g. '404 Not Found', 'redirect to homepage').
+    """
+    body: dict = {"url": url}
+    if category is not None:
+        body["category"] = category
+    if error is not None:
+        body["last_error"] = error
+    return await client.post("/api/deals/dead-urls", body)
+
+
+@mcp.tool()
+async def list_dead_urls(category: str | None = None) -> dict:
+    """List known dead URLs to skip during scraping.
+
+    Check this before attempting to scrape — URLs in this list have
+    previously failed and may waste time.
+
+    Args:
+        category: Filter by category (e.g. 'deal', 'news').
+    """
+    kwargs: dict = {}
+    if category is not None:
+        kwargs["category"] = category
+    return await client.get("/api/deals/dead-urls", **kwargs)
+
+
+@mcp.tool()
+async def update_dead_url(
+    url_id: int,
+    disabled: bool | None = None,
+    last_error: str | None = None,
+) -> dict:
+    """Update a dead URL entry (e.g. to disable it permanently).
+
+    Args:
+        url_id: ID of the dead URL entry.
+        disabled: Set to true to permanently skip this URL.
+        last_error: Update the error description.
+    """
+    body: dict = {}
+    if disabled is not None:
+        body["disabled"] = disabled
+    if last_error is not None:
+        body["last_error"] = last_error
+    return await client.put(f"/api/deals/dead-urls/{url_id}", body)
+
+
+# ---------------------------------------------------------------------------
 # Data pipeline tools
 # ---------------------------------------------------------------------------
 

--- a/bede-data-mcp/src/bede_data_mcp/server.py
+++ b/bede-data-mcp/src/bede_data_mcp/server.py
@@ -787,7 +787,9 @@ async def get_price_history(
 
 
 @mcp.tool()
-async def report_dead_url(url: str, category: str | None = None, error: str | None = None) -> dict:
+async def report_dead_url(
+    url: str, category: str | None = None, error: str | None = None
+) -> dict:
     """Report a URL that failed to load or returned an error.
 
     Call this when a product page returns 404, 403, redirects to a homepage,

--- a/bede-data-mcp/tests/test_config_tools.py
+++ b/bede-data-mcp/tests/test_config_tools.py
@@ -7,6 +7,7 @@ from bede_data_mcp.server import (
     list_schedules,
     list_settings,
     set_setting,
+    update_monitored_item,
     update_schedule,
 )
 
@@ -151,3 +152,26 @@ async def test_delete_monitored_item(api):
     result = await delete_monitored_item(1)
     api.delete.assert_called_once_with("/api/config/monitored-items/1")
     assert result["status"] == "deleted"
+
+
+async def test_update_monitored_item(api):
+    api.put.return_value = {
+        "id": 1,
+        "category": "deals",
+        "name": "updated name",
+        "config": '{"items": ["tent"]}',
+    }
+    result = await update_monitored_item(1, name="updated name", config='{"items": ["tent"]}')
+    api.put.assert_called_once_with(
+        "/api/config/monitored-items/1",
+        {"name": "updated name", "config": '{"items": ["tent"]}'},
+    )
+    assert result["name"] == "updated name"
+
+
+async def test_update_monitored_item_enabled(api):
+    api.put.return_value = {"id": 1, "enabled": False}
+    await update_monitored_item(1, enabled=False)
+    api.put.assert_called_once_with(
+        "/api/config/monitored-items/1", {"enabled": False}
+    )

--- a/bede-data-mcp/tests/test_config_tools.py
+++ b/bede-data-mcp/tests/test_config_tools.py
@@ -161,7 +161,9 @@ async def test_update_monitored_item(api):
         "name": "updated name",
         "config": '{"items": ["tent"]}',
     }
-    result = await update_monitored_item(1, name="updated name", config='{"items": ["tent"]}')
+    result = await update_monitored_item(
+        1, name="updated name", config='{"items": ["tent"]}'
+    )
     api.put.assert_called_once_with(
         "/api/config/monitored-items/1",
         {"name": "updated name", "config": '{"items": ["tent"]}'},
@@ -172,6 +174,4 @@ async def test_update_monitored_item(api):
 async def test_update_monitored_item_enabled(api):
     api.put.return_value = {"id": 1, "enabled": False}
     await update_monitored_item(1, enabled=False)
-    api.put.assert_called_once_with(
-        "/api/config/monitored-items/1", {"enabled": False}
-    )
+    api.put.assert_called_once_with("/api/config/monitored-items/1", {"enabled": False})

--- a/bede-data-mcp/tests/test_deals_tools.py
+++ b/bede-data-mcp/tests/test_deals_tools.py
@@ -45,7 +45,9 @@ async def test_record_price_check_out_of_stock(api):
 
 async def test_record_price_check_with_notes(api):
     api.post.return_value = {"id": 3}
-    await record_price_check(5, "https://example.com/p", price=99.0, notes="sale ends Friday")
+    await record_price_check(
+        5, "https://example.com/p", price=99.0, notes="sale ends Friday"
+    )
     call_body = api.post.call_args[0][1]
     assert call_body["notes"] == "sale ends Friday"
 
@@ -71,7 +73,9 @@ async def test_get_price_history_with_limit(api):
 async def test_get_price_history_with_url_filter(api):
     api.get.return_value = {"checks": []}
     await get_price_history(5, url="https://example.com/p")
-    api.get.assert_called_once_with("/api/deals/price-history/5", url="https://example.com/p")
+    api.get.assert_called_once_with(
+        "/api/deals/price-history/5", url="https://example.com/p"
+    )
 
 
 async def test_report_dead_url(api):

--- a/bede-data-mcp/tests/test_deals_tools.py
+++ b/bede-data-mcp/tests/test_deals_tools.py
@@ -1,0 +1,108 @@
+from bede_data_mcp.server import (
+    get_price_history,
+    list_dead_urls,
+    record_price_check,
+    report_dead_url,
+    update_dead_url,
+)
+
+
+async def test_record_price_check(api):
+    api.post.return_value = {
+        "id": 1,
+        "monitored_item_id": 5,
+        "url": "https://example.com/p",
+        "price": 149.95,
+        "in_stock": True,
+    }
+    result = await record_price_check(5, "https://example.com/p", 149.95, "AUD", True)
+    api.post.assert_called_once_with(
+        "/api/deals/price-checks",
+        {
+            "monitored_item_id": 5,
+            "url": "https://example.com/p",
+            "price": 149.95,
+            "currency": "AUD",
+            "in_stock": True,
+        },
+    )
+    assert result["price"] == 149.95
+
+
+async def test_record_price_check_out_of_stock(api):
+    api.post.return_value = {"id": 2, "price": None, "in_stock": False}
+    result = await record_price_check(5, "https://example.com/p", in_stock=False)
+    api.post.assert_called_once_with(
+        "/api/deals/price-checks",
+        {
+            "monitored_item_id": 5,
+            "url": "https://example.com/p",
+            "in_stock": False,
+        },
+    )
+    assert result["in_stock"] is False
+
+
+async def test_record_price_check_with_notes(api):
+    api.post.return_value = {"id": 3}
+    await record_price_check(5, "https://example.com/p", price=99.0, notes="sale ends Friday")
+    call_body = api.post.call_args[0][1]
+    assert call_body["notes"] == "sale ends Friday"
+
+
+async def test_get_price_history(api):
+    api.get.return_value = {
+        "checks": [
+            {"id": 2, "price": 89.95, "checked_at": "2026-05-07T12:00:00Z"},
+            {"id": 1, "price": 99.95, "checked_at": "2026-05-06T12:00:00Z"},
+        ]
+    }
+    result = await get_price_history(5)
+    api.get.assert_called_once_with("/api/deals/price-history/5")
+    assert len(result["checks"]) == 2
+
+
+async def test_get_price_history_with_limit(api):
+    api.get.return_value = {"checks": []}
+    await get_price_history(5, limit=10)
+    api.get.assert_called_once_with("/api/deals/price-history/5", limit=10)
+
+
+async def test_get_price_history_with_url_filter(api):
+    api.get.return_value = {"checks": []}
+    await get_price_history(5, url="https://example.com/p")
+    api.get.assert_called_once_with("/api/deals/price-history/5", url="https://example.com/p")
+
+
+async def test_report_dead_url(api):
+    api.post.return_value = {
+        "id": 1,
+        "url": "https://dead.com",
+        "fail_count": 1,
+    }
+    result = await report_dead_url("https://dead.com", "deal", "404 Not Found")
+    api.post.assert_called_once_with(
+        "/api/deals/dead-urls",
+        {"url": "https://dead.com", "category": "deal", "last_error": "404 Not Found"},
+    )
+    assert result["fail_count"] == 1
+
+
+async def test_list_dead_urls(api):
+    api.get.return_value = {"urls": [{"id": 1, "url": "https://dead.com"}]}
+    result = await list_dead_urls()
+    api.get.assert_called_once_with("/api/deals/dead-urls")
+    assert len(result["urls"]) == 1
+
+
+async def test_list_dead_urls_by_category(api):
+    api.get.return_value = {"urls": []}
+    await list_dead_urls(category="deal")
+    api.get.assert_called_once_with("/api/deals/dead-urls", category="deal")
+
+
+async def test_update_dead_url(api):
+    api.put.return_value = {"id": 1, "disabled": True}
+    result = await update_dead_url(1, disabled=True)
+    api.put.assert_called_once_with("/api/deals/dead-urls/1", {"disabled": True})
+    assert result["disabled"] is True

--- a/bede-data-mcp/tests/test_news_tools.py
+++ b/bede-data-mcp/tests/test_news_tools.py
@@ -15,7 +15,11 @@ async def test_save_article(api):
         "category": "ai",
     }
     result = await save_article(
-        "https://example.com/article", "AI News", "TLDR AI", category="ai", summary="Big things."
+        "https://example.com/article",
+        "AI News",
+        "TLDR AI",
+        category="ai",
+        summary="Big things.",
     )
     api.post.assert_called_once_with(
         "/api/news/articles",
@@ -61,7 +65,9 @@ async def test_list_articles_by_source(api):
 async def test_check_article_exists(api):
     api.get.return_value = {"exists": True, "url": "https://example.com"}
     result = await check_article_exists("https://example.com")
-    api.get.assert_called_once_with("/api/news/articles/exists", url="https://example.com")
+    api.get.assert_called_once_with(
+        "/api/news/articles/exists", url="https://example.com"
+    )
     assert result["exists"] is True
 
 

--- a/bede-data-mcp/tests/test_news_tools.py
+++ b/bede-data-mcp/tests/test_news_tools.py
@@ -1,0 +1,74 @@
+from bede_data_mcp.server import (
+    check_article_exists,
+    list_articles,
+    mark_article_in_digest,
+    save_article,
+)
+
+
+async def test_save_article(api):
+    api.post.return_value = {
+        "id": 1,
+        "url": "https://example.com/article",
+        "title": "AI News",
+        "source_name": "TLDR AI",
+        "category": "ai",
+    }
+    result = await save_article(
+        "https://example.com/article", "AI News", "TLDR AI", category="ai", summary="Big things."
+    )
+    api.post.assert_called_once_with(
+        "/api/news/articles",
+        {
+            "url": "https://example.com/article",
+            "title": "AI News",
+            "source_name": "TLDR AI",
+            "category": "ai",
+            "summary": "Big things.",
+        },
+    )
+    assert result["id"] == 1
+
+
+async def test_save_article_minimal(api):
+    api.post.return_value = {"id": 2}
+    await save_article("https://example.com/a", "Title", "Source")
+    api.post.assert_called_once_with(
+        "/api/news/articles",
+        {"url": "https://example.com/a", "title": "Title", "source_name": "Source"},
+    )
+
+
+async def test_list_articles(api):
+    api.get.return_value = {"articles": [{"id": 1, "title": "A"}]}
+    result = await list_articles()
+    api.get.assert_called_once_with("/api/news/articles")
+    assert len(result["articles"]) == 1
+
+
+async def test_list_articles_filtered(api):
+    api.get.return_value = {"articles": []}
+    await list_articles(category="ai", unsent=True)
+    api.get.assert_called_once_with("/api/news/articles", category="ai", unsent=True)
+
+
+async def test_list_articles_by_source(api):
+    api.get.return_value = {"articles": []}
+    await list_articles(source_name="Hacker News")
+    api.get.assert_called_once_with("/api/news/articles", source_name="Hacker News")
+
+
+async def test_check_article_exists(api):
+    api.get.return_value = {"exists": True, "url": "https://example.com"}
+    result = await check_article_exists("https://example.com")
+    api.get.assert_called_once_with("/api/news/articles/exists", url="https://example.com")
+    assert result["exists"] is True
+
+
+async def test_mark_article_in_digest(api):
+    api.put.return_value = {"id": 1, "digest_date": "2026-05-07"}
+    result = await mark_article_in_digest(1, "2026-05-07")
+    api.put.assert_called_once_with(
+        "/api/news/articles/1/digest", {"digest_date": "2026-05-07"}
+    )
+    assert result["digest_date"] == "2026-05-07"

--- a/bede-data/src/bede_data/api/config_api.py
+++ b/bede-data/src/bede_data/api/config_api.py
@@ -207,6 +207,31 @@ def delete_monitored_item(item_id: int, conn: sqlite3.Connection = Depends(get_d
     return {"status": "deleted", "id": item_id}
 
 
+@router.put("/monitored-items/{item_id}")
+def update_monitored_item(
+    item_id: int, body: MonitoredItemUpdate, conn: sqlite3.Connection = Depends(get_db)
+):
+    existing = _get_monitored_item(conn, item_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Monitored item not found")
+
+    updates: dict = {"updated_at": _now()}
+    if body.name is not None:
+        updates["name"] = body.name
+    if body.config is not None:
+        updates["config"] = body.config
+    if body.enabled is not None:
+        updates["enabled"] = int(body.enabled)
+
+    set_clause = ", ".join(f"{k} = ?" for k in updates)
+    conn.execute(
+        f"UPDATE monitored_items SET {set_clause} WHERE id = ?",
+        [*updates.values(), item_id],
+    )
+    conn.commit()
+    return _get_monitored_item(conn, item_id)
+
+
 def _get_monitored_item(conn: sqlite3.Connection, item_id: int) -> dict | None:
     cursor = conn.execute(
         "SELECT id, category, name, config, enabled, created_at, updated_at FROM monitored_items WHERE id = ?",

--- a/bede-data/src/bede_data/api/deals.py
+++ b/bede-data/src/bede_data/api/deals.py
@@ -1,0 +1,174 @@
+import sqlite3
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+
+from bede_data.db.connection import get_db
+
+router = APIRouter(prefix="/api/deals", tags=["deals"])
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---- Price checks ----
+
+
+class PriceCheckCreate(BaseModel):
+    monitored_item_id: int
+    url: str
+    price: float | None = None
+    currency: str = "AUD"
+    in_stock: bool | None = None
+    notes: str | None = None
+
+
+@router.post("/price-checks", status_code=201)
+def record_price_check(
+    body: PriceCheckCreate, conn: sqlite3.Connection = Depends(get_db)
+):
+    now = _now()
+    cursor = conn.execute(
+        "INSERT INTO price_history (monitored_item_id, url, price, currency, in_stock, notes, checked_at) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            body.monitored_item_id,
+            body.url,
+            body.price,
+            body.currency,
+            int(body.in_stock) if body.in_stock is not None else None,
+            body.notes,
+            now,
+        ),
+    )
+    conn.commit()
+    return _get_price_check(conn, cursor.lastrowid)
+
+
+@router.get("/price-history/{item_id}")
+def get_price_history(
+    item_id: int,
+    limit: int = Query(50, ge=1, le=500),
+    url: str | None = Query(None),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    query = "SELECT id, monitored_item_id, url, price, currency, in_stock, notes, checked_at FROM price_history WHERE monitored_item_id = ?"
+    params: list = [item_id]
+    if url:
+        query += " AND url = ?"
+        params.append(url)
+    query += " ORDER BY checked_at DESC LIMIT ?"
+    params.append(limit)
+    cursor = conn.execute(query, params)
+    rows = [dict(r) for r in cursor.fetchall()]
+    for r in rows:
+        if r["in_stock"] is not None:
+            r["in_stock"] = bool(r["in_stock"])
+    return {"checks": rows}
+
+
+def _get_price_check(conn: sqlite3.Connection, check_id: int) -> dict:
+    cursor = conn.execute(
+        "SELECT id, monitored_item_id, url, price, currency, in_stock, notes, checked_at FROM price_history WHERE id = ?",
+        (check_id,),
+    )
+    row = cursor.fetchone()
+    if not row:
+        return {}
+    r = dict(row)
+    if r["in_stock"] is not None:
+        r["in_stock"] = bool(r["in_stock"])
+    return r
+
+
+# ---- Dead URLs ----
+
+
+class DeadUrlReport(BaseModel):
+    url: str
+    category: str | None = None
+    last_error: str | None = None
+
+
+class DeadUrlUpdate(BaseModel):
+    disabled: bool | None = None
+    last_error: str | None = None
+
+
+@router.post("/dead-urls", status_code=201)
+def report_dead_url(body: DeadUrlReport, conn: sqlite3.Connection = Depends(get_db)):
+    now = _now()
+    existing = conn.execute(
+        "SELECT id, fail_count FROM dead_urls WHERE url = ?", (body.url,)
+    ).fetchone()
+
+    if existing:
+        conn.execute(
+            "UPDATE dead_urls SET fail_count = fail_count + 1, last_error = ?, checked_at = ? WHERE id = ?",
+            (body.last_error, now, existing["id"]),
+        )
+        conn.commit()
+        return _get_dead_url(conn, existing["id"])
+
+    cursor = conn.execute(
+        "INSERT INTO dead_urls (url, category, last_error, first_seen, checked_at) VALUES (?, ?, ?, ?, ?)",
+        (body.url, body.category, body.last_error, now, now),
+    )
+    conn.commit()
+    return _get_dead_url(conn, cursor.lastrowid)
+
+
+@router.get("/dead-urls")
+def list_dead_urls(
+    category: str | None = Query(None),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    query = "SELECT id, url, category, fail_count, last_error, first_seen, checked_at, disabled FROM dead_urls WHERE disabled = 0"
+    params: list = []
+    if category:
+        query += " AND category = ?"
+        params.append(category)
+    query += " ORDER BY checked_at DESC"
+    cursor = conn.execute(query, params)
+    rows = [dict(r) for r in cursor.fetchall()]
+    for r in rows:
+        r["disabled"] = bool(r["disabled"])
+    return {"urls": rows}
+
+
+@router.put("/dead-urls/{url_id}")
+def update_dead_url(
+    url_id: int, body: DeadUrlUpdate, conn: sqlite3.Connection = Depends(get_db)
+):
+    existing = _get_dead_url(conn, url_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Dead URL not found")
+
+    updates: dict = {"checked_at": _now()}
+    if body.disabled is not None:
+        updates["disabled"] = int(body.disabled)
+    if body.last_error is not None:
+        updates["last_error"] = body.last_error
+
+    set_clause = ", ".join(f"{k} = ?" for k in updates)
+    conn.execute(
+        f"UPDATE dead_urls SET {set_clause} WHERE id = ?",
+        [*updates.values(), url_id],
+    )
+    conn.commit()
+    return _get_dead_url(conn, url_id)
+
+
+def _get_dead_url(conn: sqlite3.Connection, url_id: int) -> dict:
+    cursor = conn.execute(
+        "SELECT id, url, category, fail_count, last_error, first_seen, checked_at, disabled FROM dead_urls WHERE id = ?",
+        (url_id,),
+    )
+    row = cursor.fetchone()
+    if not row:
+        return {}
+    r = dict(row)
+    r["disabled"] = bool(r["disabled"])
+    return r

--- a/bede-data/src/bede_data/api/deals.py
+++ b/bede-data/src/bede_data/api/deals.py
@@ -111,7 +111,9 @@ def report_dead_url(body: DeadUrlReport, conn: sqlite3.Connection = Depends(get_
             (body.last_error, now, existing["id"]),
         )
         conn.commit()
-        return JSONResponse(content=_get_dead_url(conn, existing["id"]), status_code=200)
+        return JSONResponse(
+            content=_get_dead_url(conn, existing["id"]), status_code=200
+        )
 
     cursor = conn.execute(
         "INSERT INTO dead_urls (url, category, last_error, first_seen, checked_at) VALUES (?, ?, ?, ?, ?)",

--- a/bede-data/src/bede_data/api/deals.py
+++ b/bede-data/src/bede_data/api/deals.py
@@ -2,6 +2,7 @@ import sqlite3
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 from bede_data.db.connection import get_db
@@ -76,7 +77,7 @@ def _get_price_check(conn: sqlite3.Connection, check_id: int) -> dict:
     )
     row = cursor.fetchone()
     if not row:
-        return {}
+        return None
     r = dict(row)
     if r["in_stock"] is not None:
         r["in_stock"] = bool(r["in_stock"])
@@ -110,7 +111,7 @@ def report_dead_url(body: DeadUrlReport, conn: sqlite3.Connection = Depends(get_
             (body.last_error, now, existing["id"]),
         )
         conn.commit()
-        return _get_dead_url(conn, existing["id"])
+        return JSONResponse(content=_get_dead_url(conn, existing["id"]), status_code=200)
 
     cursor = conn.execute(
         "INSERT INTO dead_urls (url, category, last_error, first_seen, checked_at) VALUES (?, ?, ?, ?, ?)",
@@ -146,11 +147,14 @@ def update_dead_url(
     if not existing:
         raise HTTPException(status_code=404, detail="Dead URL not found")
 
-    updates: dict = {"checked_at": _now()}
+    updates: dict = {}
     if body.disabled is not None:
         updates["disabled"] = int(body.disabled)
     if body.last_error is not None:
         updates["last_error"] = body.last_error
+
+    if not updates:
+        return _get_dead_url(conn, url_id)
 
     set_clause = ", ".join(f"{k} = ?" for k in updates)
     conn.execute(
@@ -168,7 +172,7 @@ def _get_dead_url(conn: sqlite3.Connection, url_id: int) -> dict:
     )
     row = cursor.fetchone()
     if not row:
-        return {}
+        return None
     r = dict(row)
     r["disabled"] = bool(r["disabled"])
     return r

--- a/bede-data/src/bede_data/api/news.py
+++ b/bede-data/src/bede_data/api/news.py
@@ -1,0 +1,104 @@
+import sqlite3
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from bede_data.db.connection import get_db
+
+router = APIRouter(prefix="/api/news", tags=["news"])
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class ArticleCreate(BaseModel):
+    url: str
+    title: str
+    source_name: str
+    category: str | None = None
+    summary: str | None = None
+
+
+class DigestMark(BaseModel):
+    digest_date: str
+
+
+@router.post("/articles", status_code=201)
+def save_article(body: ArticleCreate, conn: sqlite3.Connection = Depends(get_db)):
+    existing = conn.execute(
+        "SELECT id, url, title, source_name, category, summary, fetched_at, digest_date FROM articles WHERE url = ?",
+        (body.url,),
+    ).fetchone()
+    if existing:
+        r = dict(existing)
+        r["already_existed"] = True
+        return JSONResponse(content=r, status_code=200)
+
+    now = _now()
+    cursor = conn.execute(
+        "INSERT INTO articles (url, title, source_name, category, summary, fetched_at) VALUES (?, ?, ?, ?, ?, ?)",
+        (body.url, body.title, body.source_name, body.category, body.summary, now),
+    )
+    conn.commit()
+    return _get_article(conn, cursor.lastrowid)
+
+
+@router.get("/articles")
+def list_articles(
+    category: str | None = Query(None),
+    source_name: str | None = Query(None),
+    unsent: bool = Query(False),
+    limit: int = Query(50, ge=1, le=500),
+    conn: sqlite3.Connection = Depends(get_db),
+):
+    query = "SELECT id, url, title, source_name, category, summary, fetched_at, digest_date FROM articles WHERE 1=1"
+    params: list = []
+    if category:
+        query += " AND category = ?"
+        params.append(category)
+    if source_name:
+        query += " AND source_name = ?"
+        params.append(source_name)
+    if unsent:
+        query += " AND digest_date IS NULL"
+    query += " ORDER BY fetched_at DESC LIMIT ?"
+    params.append(limit)
+    cursor = conn.execute(query, params)
+    return {"articles": [dict(r) for r in cursor.fetchall()]}
+
+
+@router.get("/articles/exists")
+def check_article_exists(
+    url: str = Query(...), conn: sqlite3.Connection = Depends(get_db)
+):
+    row = conn.execute("SELECT 1 FROM articles WHERE url = ?", (url,)).fetchone()
+    return {"exists": row is not None, "url": url}
+
+
+@router.put("/articles/{article_id}/digest")
+def mark_article_in_digest(
+    article_id: int, body: DigestMark, conn: sqlite3.Connection = Depends(get_db)
+):
+    existing = _get_article(conn, article_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Article not found")
+    conn.execute(
+        "UPDATE articles SET digest_date = ? WHERE id = ?",
+        (body.digest_date, article_id),
+    )
+    conn.commit()
+    return _get_article(conn, article_id)
+
+
+def _get_article(conn: sqlite3.Connection, article_id: int) -> dict | None:
+    cursor = conn.execute(
+        "SELECT id, url, title, source_name, category, summary, fetched_at, digest_date FROM articles WHERE id = ?",
+        (article_id,),
+    )
+    row = cursor.fetchone()
+    if not row:
+        return None
+    return dict(row)

--- a/bede-data/src/bede_data/app.py
+++ b/bede-data/src/bede_data/app.py
@@ -7,6 +7,7 @@ from fastapi.responses import JSONResponse
 from bede_data.api.analytics import router as analytics_router
 from bede_data.api.conversations import router as conversations_router
 from bede_data.api.deals import router as deals_router
+from bede_data.api.news import router as news_router
 from bede_data.api.message_queue import router as message_queue_router
 from bede_data.api.config_api import router as config_router
 from bede_data.api.freshness import router as freshness_router
@@ -52,6 +53,7 @@ def create_app() -> FastAPI:
     app.include_router(conversations_router)
     app.include_router(message_queue_router)
     app.include_router(deals_router)
+    app.include_router(news_router)
 
     @app.get("/health")
     def health_check(conn: sqlite3.Connection = Depends(get_db)):

--- a/bede-data/src/bede_data/app.py
+++ b/bede-data/src/bede_data/app.py
@@ -6,6 +6,7 @@ from fastapi.responses import JSONResponse
 
 from bede_data.api.analytics import router as analytics_router
 from bede_data.api.conversations import router as conversations_router
+from bede_data.api.deals import router as deals_router
 from bede_data.api.message_queue import router as message_queue_router
 from bede_data.api.config_api import router as config_router
 from bede_data.api.freshness import router as freshness_router
@@ -50,6 +51,7 @@ def create_app() -> FastAPI:
     app.include_router(retention_router)
     app.include_router(conversations_router)
     app.include_router(message_queue_router)
+    app.include_router(deals_router)
 
     @app.get("/health")
     def health_check(conn: sqlite3.Connection = Depends(get_db)):

--- a/bede-data/src/bede_data/db/schema.py
+++ b/bede-data/src/bede_data/db/schema.py
@@ -1,4 +1,4 @@
-SCHEMA_VERSION = 9
+SCHEMA_VERSION = 10
 
 # Tables whose column names changed from the prototype bede schema.
 # init_db drops these if they have old-style columns, then SCHEMA_SQL recreates them.
@@ -323,6 +323,17 @@ CREATE TABLE IF NOT EXISTS dead_urls (
     first_seen   TEXT NOT NULL DEFAULT (datetime('now')),
     checked_at   TEXT NOT NULL DEFAULT (datetime('now')),
     disabled     INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS articles (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    url              TEXT NOT NULL UNIQUE,
+    title            TEXT NOT NULL,
+    source_name      TEXT NOT NULL,
+    category         TEXT,
+    summary          TEXT,
+    fetched_at       TEXT NOT NULL DEFAULT (datetime('now')),
+    digest_date      TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_price_history_item ON price_history(monitored_item_id, checked_at);

--- a/bede-data/src/bede_data/db/schema.py
+++ b/bede-data/src/bede_data/db/schema.py
@@ -324,4 +324,6 @@ CREATE TABLE IF NOT EXISTS dead_urls (
     checked_at   TEXT NOT NULL DEFAULT (datetime('now')),
     disabled     INTEGER NOT NULL DEFAULT 0
 );
+
+CREATE INDEX IF NOT EXISTS idx_price_history_item ON price_history(monitored_item_id, checked_at);
 """

--- a/bede-data/src/bede_data/db/schema.py
+++ b/bede-data/src/bede_data/db/schema.py
@@ -1,4 +1,4 @@
-SCHEMA_VERSION = 8
+SCHEMA_VERSION = 9
 
 # Tables whose column names changed from the prototype bede schema.
 # init_db drops these if they have old-style columns, then SCHEMA_SQL recreates them.
@@ -301,5 +301,27 @@ CREATE TABLE IF NOT EXISTS geocode_cache (
     place_name  TEXT NOT NULL,
     created_at  TEXT NOT NULL DEFAULT (datetime('now')),
     PRIMARY KEY (lat_round, lon_round)
+);
+
+CREATE TABLE IF NOT EXISTS price_history (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    monitored_item_id INTEGER NOT NULL REFERENCES monitored_items(id),
+    url               TEXT NOT NULL,
+    price             REAL,
+    currency          TEXT NOT NULL DEFAULT 'AUD',
+    in_stock          INTEGER,
+    notes             TEXT,
+    checked_at        TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS dead_urls (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    url          TEXT NOT NULL UNIQUE,
+    category     TEXT,
+    fail_count   INTEGER NOT NULL DEFAULT 1,
+    last_error   TEXT,
+    first_seen   TEXT NOT NULL DEFAULT (datetime('now')),
+    checked_at   TEXT NOT NULL DEFAULT (datetime('now')),
+    disabled     INTEGER NOT NULL DEFAULT 0
 );
 """

--- a/bede-data/tests/test_api_config.py
+++ b/bede-data/tests/test_api_config.py
@@ -96,6 +96,45 @@ def test_delete_monitored_item(client):
     assert len(client.get("/api/config/monitored-items").json()["items"]) == 0
 
 
+def test_update_monitored_item(client):
+    resp = client.post(
+        "/api/config/monitored-items",
+        json={"category": "deal", "name": "Camping Gear", "config": '{"items": []}'},
+    )
+    item_id = resp.json()["id"]
+
+    response = client.put(
+        f"/api/config/monitored-items/{item_id}",
+        json={"config": '{"items": ["tent"]}'},
+    )
+    assert response.status_code == 200
+    assert json.loads(response.json()["config"]) == {"items": ["tent"]}
+    assert response.json()["name"] == "Camping Gear"
+
+
+def test_update_monitored_item_name(client):
+    resp = client.post(
+        "/api/config/monitored-items",
+        json={"category": "deal", "name": "Old Name", "config": "{}"},
+    )
+    item_id = resp.json()["id"]
+
+    response = client.put(
+        f"/api/config/monitored-items/{item_id}",
+        json={"name": "New Name"},
+    )
+    assert response.status_code == 200
+    assert response.json()["name"] == "New Name"
+
+
+def test_update_monitored_item_not_found(client):
+    response = client.put(
+        "/api/config/monitored-items/999",
+        json={"name": "X"},
+    )
+    assert response.status_code == 404
+
+
 class TestScheduleTaskConfig:
     def test_create_schedule_with_task_config(self, client):
         config = {

--- a/bede-data/tests/test_api_deals.py
+++ b/bede-data/tests/test_api_deals.py
@@ -1,0 +1,169 @@
+import json
+
+
+def test_record_price_check(client):
+    item = client.post(
+        "/api/config/monitored-items",
+        json={"category": "deal", "name": "Camping Gear", "config": "{}"},
+    ).json()
+
+    response = client.post(
+        "/api/deals/price-checks",
+        json={
+            "monitored_item_id": item["id"],
+            "url": "https://anaconda.com.au/product/123",
+            "price": 149.95,
+            "currency": "AUD",
+            "in_stock": True,
+        },
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["price"] == 149.95
+    assert data["in_stock"] is True
+
+
+def test_record_price_check_out_of_stock(client):
+    item = client.post(
+        "/api/config/monitored-items",
+        json={"category": "deal", "name": "Gear", "config": "{}"},
+    ).json()
+
+    response = client.post(
+        "/api/deals/price-checks",
+        json={
+            "monitored_item_id": item["id"],
+            "url": "https://example.com/product",
+            "in_stock": False,
+        },
+    )
+    assert response.status_code == 201
+    assert response.json()["price"] is None
+    assert response.json()["in_stock"] is False
+
+
+def test_get_price_history(client):
+    item = client.post(
+        "/api/config/monitored-items",
+        json={"category": "deal", "name": "Gear", "config": "{}"},
+    ).json()
+
+    client.post(
+        "/api/deals/price-checks",
+        json={
+            "monitored_item_id": item["id"],
+            "url": "https://example.com/p",
+            "price": 100.0,
+            "in_stock": True,
+        },
+    )
+    client.post(
+        "/api/deals/price-checks",
+        json={
+            "monitored_item_id": item["id"],
+            "url": "https://example.com/p",
+            "price": 89.95,
+            "in_stock": True,
+        },
+    )
+
+    response = client.get(f"/api/deals/price-history/{item['id']}")
+    assert response.status_code == 200
+    checks = response.json()["checks"]
+    assert len(checks) == 2
+    assert checks[0]["price"] == 89.95  # most recent first
+
+
+def test_get_price_history_with_limit(client):
+    item = client.post(
+        "/api/config/monitored-items",
+        json={"category": "deal", "name": "Gear", "config": "{}"},
+    ).json()
+
+    for i in range(5):
+        client.post(
+            "/api/deals/price-checks",
+            json={
+                "monitored_item_id": item["id"],
+                "url": "https://example.com/p",
+                "price": 100.0 + i,
+                "in_stock": True,
+            },
+        )
+
+    response = client.get(f"/api/deals/price-history/{item['id']}", params={"limit": 3})
+    assert len(response.json()["checks"]) == 3
+
+
+def test_report_dead_url(client):
+    response = client.post(
+        "/api/deals/dead-urls",
+        json={
+            "url": "https://broken.example.com/product",
+            "category": "deal",
+            "last_error": "404 Not Found",
+        },
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["fail_count"] == 1
+    assert data["url"] == "https://broken.example.com/product"
+
+
+def test_report_dead_url_increments_fail_count(client):
+    for _ in range(3):
+        client.post(
+            "/api/deals/dead-urls",
+            json={
+                "url": "https://broken.example.com",
+                "category": "deal",
+                "last_error": "timeout",
+            },
+        )
+
+    response = client.get("/api/deals/dead-urls")
+    urls = response.json()["urls"]
+    assert len(urls) == 1
+    assert urls[0]["fail_count"] == 3
+
+
+def test_list_dead_urls(client):
+    client.post(
+        "/api/deals/dead-urls",
+        json={"url": "https://a.com", "category": "deal", "last_error": "404"},
+    )
+    client.post(
+        "/api/deals/dead-urls",
+        json={"url": "https://b.com", "category": "news", "last_error": "403"},
+    )
+
+    response = client.get("/api/deals/dead-urls")
+    assert len(response.json()["urls"]) == 2
+
+    response = client.get("/api/deals/dead-urls", params={"category": "deal"})
+    assert len(response.json()["urls"]) == 1
+
+
+def test_list_dead_urls_excludes_disabled(client):
+    resp = client.post(
+        "/api/deals/dead-urls",
+        json={"url": "https://old.com", "category": "deal", "last_error": "gone"},
+    )
+    url_id = resp.json()["id"]
+
+    client.put(f"/api/deals/dead-urls/{url_id}", json={"disabled": True})
+
+    response = client.get("/api/deals/dead-urls")
+    assert len(response.json()["urls"]) == 0
+
+
+def test_update_dead_url(client):
+    resp = client.post(
+        "/api/deals/dead-urls",
+        json={"url": "https://old.com", "category": "deal", "last_error": "404"},
+    )
+    url_id = resp.json()["id"]
+
+    response = client.put(f"/api/deals/dead-urls/{url_id}", json={"disabled": True})
+    assert response.status_code == 200
+    assert response.json()["disabled"] is True

--- a/bede-data/tests/test_api_deals.py
+++ b/bede-data/tests/test_api_deals.py
@@ -1,6 +1,3 @@
-import json
-
-
 def test_record_price_check(client):
     item = client.post(
         "/api/config/monitored-items",
@@ -111,7 +108,7 @@ def test_report_dead_url(client):
 
 
 def test_report_dead_url_increments_fail_count(client):
-    for _ in range(3):
+    for _ in range(2):
         client.post(
             "/api/deals/dead-urls",
             json={
@@ -121,10 +118,19 @@ def test_report_dead_url_increments_fail_count(client):
             },
         )
 
-    response = client.get("/api/deals/dead-urls")
-    urls = response.json()["urls"]
-    assert len(urls) == 1
-    assert urls[0]["fail_count"] == 3
+    response = client.post(
+        "/api/deals/dead-urls",
+        json={
+            "url": "https://broken.example.com",
+            "category": "deal",
+            "last_error": "timeout",
+        },
+    )
+    assert response.status_code == 200  # update, not create
+
+    all_urls = client.get("/api/deals/dead-urls").json()["urls"]
+    assert len(all_urls) == 1
+    assert all_urls[0]["fail_count"] == 3
 
 
 def test_list_dead_urls(client):

--- a/bede-data/tests/test_api_news.py
+++ b/bede-data/tests/test_api_news.py
@@ -1,0 +1,123 @@
+def test_save_article(client):
+    response = client.post(
+        "/api/news/articles",
+        json={
+            "url": "https://example.com/article-1",
+            "title": "AI Breakthrough",
+            "source_name": "Hacker News",
+            "category": "ai",
+            "summary": "Researchers achieved...",
+        },
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["title"] == "AI Breakthrough"
+    assert data["digest_date"] is None
+
+
+def test_save_article_duplicate_returns_existing(client):
+    client.post(
+        "/api/news/articles",
+        json={
+            "url": "https://example.com/dupe",
+            "title": "Original",
+            "source_name": "HN",
+            "category": "tech",
+        },
+    )
+    response = client.post(
+        "/api/news/articles",
+        json={
+            "url": "https://example.com/dupe",
+            "title": "Duplicate Attempt",
+            "source_name": "HN",
+            "category": "tech",
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["title"] == "Original"
+    assert response.json()["already_existed"] is True
+
+
+def test_list_articles(client):
+    client.post(
+        "/api/news/articles",
+        json={"url": "https://a.com", "title": "A", "source_name": "HN", "category": "tech"},
+    )
+    client.post(
+        "/api/news/articles",
+        json={"url": "https://b.com", "title": "B", "source_name": "HN", "category": "ai"},
+    )
+
+    response = client.get("/api/news/articles")
+    assert len(response.json()["articles"]) == 2
+
+
+def test_list_articles_filter_category(client):
+    client.post(
+        "/api/news/articles",
+        json={"url": "https://a.com", "title": "A", "source_name": "HN", "category": "tech"},
+    )
+    client.post(
+        "/api/news/articles",
+        json={"url": "https://b.com", "title": "B", "source_name": "HN", "category": "ai"},
+    )
+
+    response = client.get("/api/news/articles", params={"category": "ai"})
+    articles = response.json()["articles"]
+    assert len(articles) == 1
+    assert articles[0]["category"] == "ai"
+
+
+def test_list_articles_unsent_only(client):
+    client.post(
+        "/api/news/articles",
+        json={"url": "https://a.com", "title": "A", "source_name": "HN", "category": "tech"},
+    )
+    resp = client.post(
+        "/api/news/articles",
+        json={"url": "https://b.com", "title": "B", "source_name": "HN", "category": "tech"},
+    )
+    article_id = resp.json()["id"]
+    client.put(
+        f"/api/news/articles/{article_id}/digest",
+        json={"digest_date": "2026-05-07"},
+    )
+
+    response = client.get("/api/news/articles", params={"unsent": "true"})
+    articles = response.json()["articles"]
+    assert len(articles) == 1
+    assert articles[0]["url"] == "https://a.com"
+
+
+def test_mark_article_in_digest(client):
+    resp = client.post(
+        "/api/news/articles",
+        json={"url": "https://a.com", "title": "A", "source_name": "HN", "category": "tech"},
+    )
+    article_id = resp.json()["id"]
+
+    response = client.put(
+        f"/api/news/articles/{article_id}/digest",
+        json={"digest_date": "2026-05-07"},
+    )
+    assert response.status_code == 200
+    assert response.json()["digest_date"] == "2026-05-07"
+
+
+def test_check_article_exists(client):
+    response = client.get(
+        "/api/news/articles/exists",
+        params={"url": "https://nonexistent.com"},
+    )
+    assert response.json()["exists"] is False
+
+    client.post(
+        "/api/news/articles",
+        json={"url": "https://exists.com", "title": "X", "source_name": "HN", "category": "tech"},
+    )
+    response = client.get(
+        "/api/news/articles/exists",
+        params={"url": "https://exists.com"},
+    )
+    assert response.json()["exists"] is True

--- a/bede-data/tests/test_api_news.py
+++ b/bede-data/tests/test_api_news.py
@@ -42,11 +42,21 @@ def test_save_article_duplicate_returns_existing(client):
 def test_list_articles(client):
     client.post(
         "/api/news/articles",
-        json={"url": "https://a.com", "title": "A", "source_name": "HN", "category": "tech"},
+        json={
+            "url": "https://a.com",
+            "title": "A",
+            "source_name": "HN",
+            "category": "tech",
+        },
     )
     client.post(
         "/api/news/articles",
-        json={"url": "https://b.com", "title": "B", "source_name": "HN", "category": "ai"},
+        json={
+            "url": "https://b.com",
+            "title": "B",
+            "source_name": "HN",
+            "category": "ai",
+        },
     )
 
     response = client.get("/api/news/articles")
@@ -56,11 +66,21 @@ def test_list_articles(client):
 def test_list_articles_filter_category(client):
     client.post(
         "/api/news/articles",
-        json={"url": "https://a.com", "title": "A", "source_name": "HN", "category": "tech"},
+        json={
+            "url": "https://a.com",
+            "title": "A",
+            "source_name": "HN",
+            "category": "tech",
+        },
     )
     client.post(
         "/api/news/articles",
-        json={"url": "https://b.com", "title": "B", "source_name": "HN", "category": "ai"},
+        json={
+            "url": "https://b.com",
+            "title": "B",
+            "source_name": "HN",
+            "category": "ai",
+        },
     )
 
     response = client.get("/api/news/articles", params={"category": "ai"})
@@ -72,11 +92,21 @@ def test_list_articles_filter_category(client):
 def test_list_articles_unsent_only(client):
     client.post(
         "/api/news/articles",
-        json={"url": "https://a.com", "title": "A", "source_name": "HN", "category": "tech"},
+        json={
+            "url": "https://a.com",
+            "title": "A",
+            "source_name": "HN",
+            "category": "tech",
+        },
     )
     resp = client.post(
         "/api/news/articles",
-        json={"url": "https://b.com", "title": "B", "source_name": "HN", "category": "tech"},
+        json={
+            "url": "https://b.com",
+            "title": "B",
+            "source_name": "HN",
+            "category": "tech",
+        },
     )
     article_id = resp.json()["id"]
     client.put(
@@ -93,7 +123,12 @@ def test_list_articles_unsent_only(client):
 def test_mark_article_in_digest(client):
     resp = client.post(
         "/api/news/articles",
-        json={"url": "https://a.com", "title": "A", "source_name": "HN", "category": "tech"},
+        json={
+            "url": "https://a.com",
+            "title": "A",
+            "source_name": "HN",
+            "category": "tech",
+        },
     )
     article_id = resp.json()["id"]
 
@@ -114,7 +149,12 @@ def test_check_article_exists(client):
 
     client.post(
         "/api/news/articles",
-        json={"url": "https://exists.com", "title": "X", "source_name": "HN", "category": "tech"},
+        json={
+            "url": "https://exists.com",
+            "title": "X",
+            "source_name": "HN",
+            "category": "tech",
+        },
     )
     response = client.get(
         "/api/news/articles/exists",

--- a/bede-data/tests/test_app.py
+++ b/bede-data/tests/test_app.py
@@ -3,4 +3,4 @@ def test_health_check(client):
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "ok"
-    assert data["schema_version"] == 9
+    assert data["schema_version"] == 10

--- a/bede-data/tests/test_app.py
+++ b/bede-data/tests/test_app.py
@@ -3,4 +3,4 @@ def test_health_check(client):
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "ok"
-    assert data["schema_version"] == 8
+    assert data["schema_version"] == 9

--- a/bede-data/tests/test_db.py
+++ b/bede-data/tests/test_db.py
@@ -157,6 +157,7 @@ def test_articles_url_unique(db):
         "VALUES ('https://example.com/a', 'First', 'src', 'tech', '2026-05-07T00:00:00Z')"
     )
     import sqlite3 as _sqlite3
+
     try:
         db.execute(
             "INSERT INTO articles (url, title, source_name, category, fetched_at) "

--- a/bede-data/tests/test_db.py
+++ b/bede-data/tests/test_db.py
@@ -36,6 +36,8 @@ def test_schema_creates_all_tables(db):
         "message_queue",
         "data_freshness",
         "retention_policies",
+        "price_history",
+        "dead_urls",
     }
     assert expected.issubset(tables), f"Missing tables: {expected - tables}"
 
@@ -48,7 +50,7 @@ def test_wal_mode_enabled(db):
 def test_schema_version_is_set(db):
     cursor = db.execute("SELECT MAX(version) FROM schema_version")
     version = cursor.fetchone()[0]
-    assert version == 8
+    assert version == 9
 
 
 def test_health_metrics_upsert_by_natural_key(db):
@@ -113,3 +115,23 @@ def test_prototype_schema_not_detected_for_new_tables(db):
     from bede_data.db.schema import tables_needing_reset
 
     assert tables_needing_reset(db) == []
+
+
+def test_price_history_table_exists(db):
+    db.execute(
+        "INSERT INTO price_history (monitored_item_id, url, price, currency, in_stock, checked_at) "
+        "VALUES (1, 'https://example.com', 99.95, 'AUD', 1, '2026-05-07T00:00:00Z')"
+    )
+    row = db.execute("SELECT * FROM price_history WHERE id = 1").fetchone()
+    assert row is not None
+    assert row["price"] == 99.95
+
+
+def test_dead_urls_table_exists(db):
+    db.execute(
+        "INSERT INTO dead_urls (url, category, last_error, checked_at) "
+        "VALUES ('https://dead.example.com', 'deal', '404 Not Found', '2026-05-07T00:00:00Z')"
+    )
+    row = db.execute("SELECT * FROM dead_urls WHERE id = 1").fetchone()
+    assert row is not None
+    assert row["fail_count"] == 1

--- a/bede-data/tests/test_db.py
+++ b/bede-data/tests/test_db.py
@@ -38,6 +38,7 @@ def test_schema_creates_all_tables(db):
         "retention_policies",
         "price_history",
         "dead_urls",
+        "articles",
     }
     assert expected.issubset(tables), f"Missing tables: {expected - tables}"
 
@@ -50,7 +51,7 @@ def test_wal_mode_enabled(db):
 def test_schema_version_is_set(db):
     cursor = db.execute("SELECT MAX(version) FROM schema_version")
     version = cursor.fetchone()[0]
-    assert version == 9
+    assert version == 10
 
 
 def test_health_metrics_upsert_by_natural_key(db):
@@ -138,3 +139,29 @@ def test_dead_urls_table_exists(db):
     row = db.execute("SELECT * FROM dead_urls WHERE id = 1").fetchone()
     assert row is not None
     assert row["fail_count"] == 1
+
+
+def test_articles_table_exists(db):
+    db.execute(
+        "INSERT INTO articles (url, title, source_name, category, summary, fetched_at) "
+        "VALUES ('https://example.com/article', 'Test Article', 'Hacker News', 'tech', 'Summary text', '2026-05-07T00:00:00Z')"
+    )
+    row = db.execute("SELECT * FROM articles WHERE id = 1").fetchone()
+    assert row is not None
+    assert row["title"] == "Test Article"
+
+
+def test_articles_url_unique(db):
+    db.execute(
+        "INSERT INTO articles (url, title, source_name, category, fetched_at) "
+        "VALUES ('https://example.com/a', 'First', 'src', 'tech', '2026-05-07T00:00:00Z')"
+    )
+    import sqlite3 as _sqlite3
+    try:
+        db.execute(
+            "INSERT INTO articles (url, title, source_name, category, fetched_at) "
+            "VALUES ('https://example.com/a', 'Duplicate', 'src', 'tech', '2026-05-07T01:00:00Z')"
+        )
+        assert False, "Should have raised IntegrityError"
+    except _sqlite3.IntegrityError:
+        pass

--- a/bede-data/tests/test_db.py
+++ b/bede-data/tests/test_db.py
@@ -119,6 +119,9 @@ def test_prototype_schema_not_detected_for_new_tables(db):
 
 def test_price_history_table_exists(db):
     db.execute(
+        "INSERT INTO monitored_items (category, name, config) VALUES ('deal', 'Test', '{}')"
+    )
+    db.execute(
         "INSERT INTO price_history (monitored_item_id, url, price, currency, in_stock, checked_at) "
         "VALUES (1, 'https://example.com', 99.95, 'AUD', 1, '2026-05-07T00:00:00Z')"
     )

--- a/scripts/seed-monitored-items.py
+++ b/scripts/seed-monitored-items.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Seed monitored_items table from vault preference files.
+
+Run after deploying the deal-monitoring-news-curation branch:
+  docker exec bede-data python /scripts/seed-monitored-items.py
+
+Or from the host via the API (if accessible):
+  BEDE_DATA_URL=http://localhost:8001 python scripts/seed-monitored-items.py
+"""
+
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+
+BASE_URL = os.environ.get("BEDE_DATA_URL", "http://localhost:8001")
+
+ITEMS = [
+    {
+        "category": "deal",
+        "name": "Camping Gear",
+        "config": json.dumps({
+            "items": [
+                {"name": "Mont Helium 300 (-1C)", "target_price": 450, "urls": [
+                    "https://www.mont.com.au/products/helium-300-lightweight-down-sleeping-bag",
+                    "https://www.paddypallin.com.au/mont-helium-300-sleeping-bag-w22.html",
+                ]},
+                {"name": "Mont Helium 450 (-7C)", "target_price": 550, "urls": [
+                    "https://www.mont.com.au/products/helium-450-lightweight-down-sleeping-bag",
+                ]},
+                {"name": "Sea to Summit Spark -9C", "target_price": 500, "urls": [
+                    "https://www.paddypallin.com.au/sea-to-summit-spark-down-sleeping-bag-9c.html",
+                    "https://seatosummit.com.au/products/spark-down-sleeping-bag?variant=43615199985850",
+                ]},
+                {"name": "Sea to Summit Spark SpIII -8C", "target_price": 400, "urls": [
+                    "https://www.paddypallin.com.au/sea-to-summit-spark-spiii-sleeping-bag-8-c.html",
+                ]},
+                {"name": "Macpac Dragonfly 400 (-5C)", "target_price": 420, "urls": [
+                    "https://www.macpac.com.au/dragonfly-sleeping-bags",
+                ]},
+                {"name": "One Planet Nitrous series", "target_price": 450, "urls": [
+                    "https://oneplanet.au/category/sleeping-bags/down/",
+                ]},
+                {"name": "Exped Ultra 5R (R4.8)", "target_price": 220, "urls": [
+                    "https://www.tomsoutdoors.com.au/products/exped-ultra-5r-ultralight-4-season-sleeping-mat",
+                    "https://ultralightgear.com.au/products/exped-ultra-5r-ultralight-4-season-sleeping-mat",
+                    "https://www.mont.com.au/products/exped-ultra-5r",
+                ]},
+                {"name": "Nemo Tensor All-Season (R5.4)", "target_price": 250, "urls": [
+                    "https://www.paddypallin.com.au/nemo-equipment-tensor-allseason-insulated-sleeping-mat.html",
+                    "https://adventurecurated.com.au/products/nemo-tensor-all-season-ultralight-insulated-sleeping-pad",
+                ]},
+                {"name": "Nemo Tensor Extreme Conditions (R8.5)", "target_price": 300, "urls": [
+                    "https://www.paddypallin.com.au/nemo-equipment-tensor-extreme-conditions-insulated-sleeping-mat.html",
+                ]},
+                {"name": "Sea to Summit Ether Light XR Insulated (R4.0)", "target_price": 220, "urls": [
+                    "https://seatosummit.com.au/products/ether-light-xr-insulated-air-sleeping-pad",
+                ]},
+                {"name": "Sea to Summit Ether Light XR Pro (R7.4)", "target_price": 300, "urls": [
+                    "https://seatosummit.com.au/products/ether-light-xr-pro-insulated-air-sleeping-pad",
+                ]},
+            ],
+            "retailers": [
+                {"name": "Paddy Pallin", "url": "https://www.paddypallin.com.au", "clearance_url": "https://www.paddypallin.com.au/clearance/equipment/sleeping-equipment.html"},
+                {"name": "Mont", "url": "https://www.mont.com.au", "clearance_url": "https://www.mont.com.au/collections/sleeping-bag-clearance"},
+                {"name": "Macpac", "url": "https://www.macpac.com.au"},
+                {"name": "Sea to Summit AU", "url": "https://seatosummit.com.au"},
+                {"name": "Tom's Outdoors", "url": "https://www.tomsoutdoors.com.au"},
+                {"name": "Ultralight Gear", "url": "https://ultralightgear.com.au"},
+                {"name": "Adventure Curated", "url": "https://adventurecurated.com.au"},
+                {"name": "Snowys", "url": "https://www.snowys.com.au"},
+                {"name": "Wild Earth", "url": "https://www.wildearth.com.au"},
+                {"name": "Bogong Equipment", "url": "https://www.bogong.com.au"},
+                {"name": "One Planet", "url": "https://oneplanet.au"},
+            ],
+            "thresholds": {
+                "report_below_target": True,
+                "notes": "Best sale window: end-of-winter clearance (Aug-Sep). During sale windows, alert even if price is above target."
+            },
+            "search_hints": [
+                "OzBargain: search 'sleeping bag', 'sleeping mat', 'camping' in last 7 days",
+                "Check retailer clearance pages directly",
+                "Shopify stores (Mont, Sea to Summit) share common HTML structure",
+            ],
+            "stock_quirks": {
+                "Paddy Pallin": "Out of Stock",
+                "Wild Earth": "Sold Out / Notify Me",
+                "Macpac": "greyed-out size picker",
+                "Mont": "Notify Me form",
+            },
+        }),
+    },
+    {
+        "category": "deal",
+        "name": "Clothing",
+        "config": json.dumps({
+            "items": [
+                {"name": "Shirts (M, L)", "sizes": ["M", "L"], "notes": "Button-up, casual and smart-casual"},
+                {"name": "T-shirts (M, L)", "sizes": ["M", "L"], "notes": "Quality basics and graphic tees"},
+                {"name": "Blundstone Men's Original", "sizes": ["US 9", "US 9.5", "US 10"], "notes": "Classic style, NOT work/safety"},
+                {"name": "Blundstone Men's Classic", "sizes": ["US 9", "US 9.5", "US 10"]},
+                {"name": "Blundstone Men's Dress", "sizes": ["US 9", "US 9.5", "US 10"]},
+                {"name": "Blundstone Men's Heritage", "sizes": ["US 9", "US 9.5", "US 10"], "notes": "NOT work/safety models"},
+                {"name": "Budgy Smuggler", "sizes": ["32"], "target_price": 40, "notes": "Men's swimming briefs only"},
+                {"name": "Blundstone Kids", "notes": "For Joe Jr"},
+            ],
+            "retailers": [
+                {"name": "RB Sellars", "url": "https://www.rbsellars.com.au", "sale_url": "https://www.rbsellars.com.au/collections/online-outlet"},
+                {"name": "Proper Cloth", "url": "https://propercloth.com"},
+                {"name": "AS Colour", "url": "https://www.ascolour.com.au", "sale_url": "https://www.ascolour.com.au/outlet/"},
+                {"name": "Pendleton", "url": "https://pendletonwoolenmills.com.au"},
+                {"name": "Budgy Smuggler", "url": "https://budgysmuggler.com.au", "sale_url": "https://budgysmuggler.com.au/collections/mens-outlet"},
+                {"name": "Blundstone Official", "url": "https://www.blundstone.com.au"},
+            ],
+            "thresholds": {
+                "report_any_discount": True,
+                "notes": "Any percentage off is worth reporting. Blundstones: especially winter season (May-Aug)."
+            },
+            "search_hints": [
+                "For brands with sale URLs, fetch the page directly",
+                "For others, search '[Brand] sale shirts Australia'",
+                "Patagonia AU currently unavailable - check periodically",
+            ],
+        }),
+    },
+    {
+        "category": "deal",
+        "name": "Vacuum",
+        "config": json.dumps({
+            "items": [
+                {"name": "SEBO X7 Boost", "target_price": 1000, "rrp": 1100, "role": "Deep clean (weekly)", "notes": "Sensitive Choice + British Allergy Foundation approved. S-Class sealed filtration."},
+                {"name": "Dreame L50 Ultra", "target_price": 900, "rrp": 999, "role": "Daily auto (robot)", "notes": "TUV Rheinland Allergy Care certified. HEPA 0.3um, 19500Pa, sealed 3.2L bag."},
+            ],
+            "alternatives": [
+                {"name": "Dyson Gen5detect Absolute", "price": 1549, "notes": "Best cordless for allergies. Only if going single-vacuum route. Strong deal at $750."},
+                {"name": "Dreame Z30 Station", "price": 999, "notes": "Best value cordless. HEPA H14, 310 AW."},
+                {"name": "Miele Complete C3 Cat & Dog", "price_range": "699-879", "notes": "Alternative to SEBO."},
+            ],
+            "retailers": [
+                {"name": "JB Hi-Fi", "url": "https://www.jbhifi.com.au"},
+                {"name": "Harvey Norman", "url": "https://www.harveynorman.com.au"},
+                {"name": "The Good Guys", "url": "https://www.thegoodguys.com.au"},
+                {"name": "Bing Lee", "url": "https://www.binglee.com.au"},
+                {"name": "Amazon AU", "url": "https://www.amazon.com.au"},
+                {"name": "Appliances Online", "url": "https://www.appliancesonline.com.au"},
+                {"name": "SEBO AU", "url": "https://sebo.com.au"},
+                {"name": "SEBO AU Shop", "url": "https://shop.sebo.com.au"},
+                {"name": "Dreame AU", "url": "https://dreame.com.au"},
+                {"name": "Bunnings", "url": "https://www.bunnings.com.au"},
+            ],
+            "thresholds": {
+                "budget": 2000,
+                "notes": "Total budget A$2,000 for both. SEBO strong deal at $900. Dreame strong deal at $800. 20%+ off RRP = strong deal. Exclude eBay and refurbished."
+            },
+            "requirements": [
+                "True HEPA (not HEPA-style/grade)",
+                "No trigger hold - push-button or toggle",
+                "Handles cat hair on hard floors, carpet, upholstery",
+                "Bagged or sealed auto-empty preferred",
+            ],
+            "search_hints": [
+                "StaticICE: search 'SEBO X7 Boost', 'Dreame L50 Ultra'",
+                "OzBargain tags: vacuum-cleaner, robot-vacuum",
+                "Dreame AU runs launch/flash sales",
+                "SEBO pricing more stable - check Bunnings and specialist shops",
+            ],
+        }),
+    },
+    {
+        "category": "deal",
+        "name": "Grocery Staples",
+        "config": json.dumps({
+            "items": [
+                {"name": "Jalna Greek Style Yoghurt Natural 2kg"},
+                {"name": "Weet-Bix Cereal 1.2kg"},
+                {"name": "Finish Dishwash Powder Lemon Sparkle 2kg"},
+                {"name": "Huggies Size 4 nappies or pullups", "notes": "boys"},
+                {"name": "Quilton 3 ply toilet paper 24 pack"},
+                {"name": "OMO Ultimate powder 5kg"},
+                {"name": "Hill's Science Diet Oral Care adult cat food 4kg"},
+                {"name": "Apple Gift Cards", "notes": "any denomination"},
+                {"name": "Carman's Muesli Bars 12 pack", "notes": "any variety"},
+                {"name": "Sirena Tuna in Olive Oil", "notes": "95g tins or multipacks"},
+                {"name": "San Remo Pasta 500g", "notes": "any shape"},
+            ],
+            "retailers": [
+                {"name": "Coles", "url": "https://www.coles.com.au"},
+                {"name": "Woolworths", "url": "https://www.woolworths.com.au"},
+                {"name": "Aldi", "url": "https://www.aldi.com.au/en/special-buys/"},
+                {"name": "Chemist Warehouse", "url": "https://www.chemistwarehouse.com.au"},
+                {"name": "PetBarn", "url": "https://www.petbarn.com.au"},
+                {"name": "PetStock", "url": "https://www.petstock.com.au"},
+            ],
+            "thresholds": {
+                "report_any_discount": True,
+                "notes": "Any discount vs regular shelf price. Half-price specials always notable. Bulk/multipack deals worth flagging."
+            },
+            "search_hints": [
+                "OzBargain for each item by keyword",
+                "Coles and Woolworths weekly specials (Wed-Tue)",
+                "Aldi Special Buys rotate Wed and Sat",
+            ],
+        }),
+    },
+    {
+        "category": "event",
+        "name": "Events",
+        "config": json.dumps({
+            "artists": [
+                {"name": "Four Tet", "genre": "electronic"},
+                {"name": "Radiohead", "genre": "rock"},
+                {"name": "The Gaslight Anthem", "genre": "rock"},
+                {"name": "Sydney Symphony Orchestra", "genre": "classical"},
+            ],
+            "venues": [
+                {"name": "Sydney Opera House", "url": "https://www.sydneyoperahouse.com"},
+                {"name": "City Recital Hall", "url": "https://www.cityrecitalhall.com"},
+                {"name": "Ticketek", "url": "https://www.ticketek.com.au"},
+                {"name": "Ticketmaster", "url": "https://www.ticketmaster.com.au"},
+                {"name": "Moshtix", "url": "https://www.moshtix.com.au"},
+            ],
+            "thresholds": {
+                "max_results": 5,
+                "lookahead_months": 3,
+                "notes": "Quality over quantity. 3-5 strong matches per category. Check Google Calendar for conflicts."
+            },
+            "search_hints": [
+                "Search each venue URL for artist/venue names",
+                "Every event MUST link to a real webpage",
+                "Rumours fine but must cite source URL",
+            ],
+        }),
+    },
+    {
+        "category": "news",
+        "name": "News Sources",
+        "config": json.dumps({
+            "sources": [
+                {"name": "The Mandarin", "url": "https://www.themandarin.com.au", "topic": "public_sector"},
+                {"name": "Government News", "url": "https://www.govnews.com.au", "topic": "public_sector"},
+                {"name": "Digital.NSW", "url": "https://www.digital.nsw.gov.au/blog", "topic": "public_sector"},
+                {"name": "Microsoft 365 Blog", "url": "https://techcommunity.microsoft.com/blog/microsoft365blog", "topic": "platform_tech"},
+                {"name": "Power Platform Blog", "url": "https://www.microsoft.com/en-us/power-platform/blog", "topic": "platform_tech"},
+                {"name": "Salesforce Admins Blog", "url": "https://admin.salesforce.com/blog", "topic": "platform_tech"},
+                {"name": "Drupal Security Advisories", "url": "https://www.drupal.org/security", "topic": "platform_tech"},
+                {"name": "TLDR AI", "url": "https://tldr.tech/ai", "topic": "ai"},
+            ],
+            "preferences": {
+                "signal_over_firehose": True,
+                "max_articles_per_source": 5,
+            },
+        }),
+    },
+]
+
+
+def post(path: str, body: dict) -> dict:
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(
+        f"{BASE_URL}{path}",
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read().decode())
+    except urllib.error.HTTPError as e:
+        error_body = e.read().decode() if e.fp else ""
+        print(f"  ERROR {e.code}: {error_body}", file=sys.stderr)
+        return {"error": e.code}
+
+
+def main():
+    print(f"Seeding monitored_items at {BASE_URL}")
+    for item in ITEMS:
+        print(f"  {item['category']}/{item['name']}...", end=" ")
+        result = post("/api/config/monitored-items", item)
+        if "error" in result:
+            print("FAILED")
+        else:
+            print(f"OK (id={result.get('id')})")
+
+    print("\nDone. Verify with: GET /api/config/monitored-items")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Add `price_history`, `dead_urls`, and `articles` tables to SQLite schema (v10)
- Add deals API router (`/api/deals/`) with price check recording, price history queries, and dead URL tracking
- Add news API router (`/api/news/`) with article storage, deduplication, and digest tracking
- Add `update_monitored_item` PUT endpoint to config API
- Add 11 new MCP tools: 6 for deal monitoring, 4 for news curation, 1 for config updates
- Add `/digest` Telegram command for manual news digest trigger

This enables Bede to use browser-mcp to scrape retailer sites, track price changes, and curate news digests — replacing the current vault-based preference files with SQLite-managed config.

## Test plan

- [x] 209 bede-data tests pass (28 new)
- [x] 95 bede-data-mcp tests pass (17 new)
- [ ] Deploy to server, seed `monitored_items` from vault files
- [ ] Trigger `/scout` and `/digest` via Telegram to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)