### PR TITLE
fix: use dynamic DNS resolution in bede-web nginx proxy

### DIFF
--- a/bede-web/nginx.conf
+++ b/bede-web/nginx.conf
@@ -5,7 +5,9 @@ server {
     index index.html;
 
     location /api/ {
-        proxy_pass http://bede-data:8001/api/;
+        resolver 127.0.0.11 valid=10s;
+        set $upstream bede-data;
+        proxy_pass http://$upstream:8001/api/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }


### PR DESCRIPTION
## Summary
- nginx caches DNS at startup, so when bede-data restarts and gets a new container IP, bede-web's cached resolution goes stale and all API calls return 502
- Uses Docker's embedded DNS resolver (`127.0.0.11`) with a 10s TTL and variable-based `proxy_pass` to force per-request resolution

## Test plan
- [ ] Deploy to server, verify bede-web API panels load
- [ ] Restart bede-data, confirm bede-web continues serving API requests without needing its own restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)