### PR TITLE
fix: preserve request URI in variable-based proxy_pass

### DIFF
--- a/bede-web/nginx.conf
+++ b/bede-web/nginx.conf
@@ -7,7 +7,7 @@ server {
     location /api/ {
         resolver 127.0.0.11 valid=10s;
         set $upstream bede-data;
-        proxy_pass http://$upstream:8001/api/;
+        proxy_pass http://$upstream:8001;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
     }


### PR DESCRIPTION
## Summary
- Follow-up to #74 — the variable-based `proxy_pass` broke URI forwarding
- With a variable in `proxy_pass`, nginx skips URI substitution, so all requests arrived at bede-data as `/api/` instead of the full path (e.g. `/api/freshness`)
- Removing the path from `proxy_pass` lets the full original request URI pass through

## Test plan
- [ ] Deploy to server, verify all bede-web API panels return data
- [ ] Restart bede-data, confirm bede-web still works (the DNS fix from #74)

🤖 Generated with [Claude Code](https://claude.com/claude-code)