### PR TITLE
fix: nginx DNS caching and docs update

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -134,6 +134,8 @@ flowchart TD
         /api/goals
         /api/analytics/*
         /api/config/*
+        /api/deals/*
+        /api/news/*
         /api/conversations
         /api/vault-queue"]
         sqlite[("SQLite
@@ -145,11 +147,12 @@ flowchart TD
     end
 
     subgraph mcp["bede-data-mcp :8002"]
-        tools["40+ MCP tools
+        tools["50+ MCP tools
         time, health, vault,
         location, weather,
         memories, goals,
-        analytics, config"]
+        analytics, config,
+        deals, news"]
     end
 
     subgraph mac["Data sources (Mac)"]
@@ -218,7 +221,7 @@ The data layer. FastAPI service handling ingest, storage, querying, and live dat
 | Module | Purpose |
 |--------|---------|
 | `ingest/` | Token-authenticated endpoints for health and vault data ingestion |
-| `api/` | Query routers: health, vault, location, weather, memories, goals, analytics, config, sessions, conversations, vault-queue, freshness, storage, retention |
+| `api/` | Query routers: health, vault, location, weather, memories, goals, analytics, config, deals, news, sessions, conversations, vault-queue, freshness, storage, retention |
 | `db/` | SQLite connection management and schema migrations |
 | `live/` | Real-time proxies: OwnTracks location (with reverse geocode caching), Homepage API weather, air quality |
 | `analytics/` | Signal engine computing wellbeing flags from raw data |
@@ -231,7 +234,7 @@ The data layer. FastAPI service handling ingest, storage, querying, and live dat
 
 Thin MCP proxy. Translates Claude's MCP tool calls into bede-data HTTP API requests. No business logic — just parameter mapping.
 
-40+ tools across: time, health, vault data, location, weather, memories, goals, analytics, config/schedules, conversations, task history, vault publish queue.
+50+ tools across: time, health, vault data, location, weather, memories, goals, analytics, config/schedules, deal monitoring (price checks, price history, dead URLs), news curation (articles, digest tracking), conversations, task history, vault publish queue.
 
 Built with FastMCP. Runs as a Streamable HTTP MCP server on port 8002.
 
@@ -313,7 +316,7 @@ All persistent data lives in `./data/bede/` on the home server host, bind-mounte
 └── CLAUDE.md            ← bede-core: persona file (bind-mounted read-only)
 ```
 
-**SQLite is the single source of truth** for all structured data. Health metrics, vault exports, memories, goals, conversation history, scheduled task config, and analytics flags all live in `bede.db`. Schema migrations are applied on startup via `bede_data.db.schema`.
+**SQLite is the single source of truth** for all structured data. Health metrics, vault exports, memories, goals, conversation history, scheduled task config, deal monitoring data (price history, dead URLs), news articles, monitored item configs, and analytics flags all live in `bede.db`. Schema migrations are applied on startup via `bede_data.db.schema`.
 
 The Obsidian vault is a git clone pulled before each Claude invocation. Bede reads vault files during task execution for context (persona, preferences, journal entries). Scheduled task definitions are stored in the `schedules` SQLite table and managed via `/api/config/schedules`. The vault publish queue (via `/api/vault-queue`) stages content for writing back to the vault.
 

--- a/CLAUDE.md.example
+++ b/CLAUDE.md.example
@@ -104,7 +104,20 @@ All tools handle timezone conversion internally — pass local dates, never UTC.
 **Config tools:**
 - `list_schedules()` / `create_schedule(...)` / `update_schedule(...)` — manage scheduled tasks
 - `list_settings()` / `get_setting(key)` / `set_setting(key, value)` — manage settings
-- `list_monitored_items(category?)` / `create_monitored_item(...)` / `delete_monitored_item(id)` — manage deal/news monitoring
+- `list_monitored_items(category?)` / `create_monitored_item(...)` / `update_monitored_item(item_id, name?, config?, enabled?)` / `delete_monitored_item(id)` — manage deal/news/event monitoring config
+
+**Deal monitoring tools:**
+- `record_price_check(monitored_item_id, url, price?, currency?, in_stock?, notes?)` — save a price/stock observation after scraping a retailer page
+- `get_price_history(monitored_item_id, limit?, url?)` — query past price checks to detect drops and restocks
+- `report_dead_url(url, category?, error?)` — report a URL that failed (404, redirect, timeout)
+- `list_dead_urls(category?)` — get known dead URLs to skip during scraping
+- `update_dead_url(url_id, disabled?, last_error?)` — disable a dead URL permanently
+
+**News curation tools:**
+- `save_article(url, title, source_name, category?, summary?)` — save a curated article (deduplicates by URL)
+- `list_articles(category?, source_name?, unsent?, limit?)` — query saved articles; use `unsent=true` to build a digest
+- `check_article_exists(url)` — dedup check before saving
+- `mark_article_in_digest(article_id, digest_date)` — mark an article as included in a digest
 
 **Data pipeline tools:**
 - `get_data_freshness()` — check when each data source last received data


### PR DESCRIPTION
## Summary
- Fix bede-web nginx proxy to use dynamic DNS resolution (avoids stale IPs when containers restart)
- Drop path from variable `proxy_pass` to preserve request URI
- Document deal monitoring and news curation features in ARCHITECTURE.md and CLAUDE.md.example

## Test plan
- [ ] bede-web proxies API requests correctly after container restarts
- [ ] ARCHITECTURE.md accurately reflects current API surfaces and MCP tool count
- [ ] CLAUDE.md.example includes all deal/news MCP tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)