### PR TITLE
docs: explain data freshness and remove AI from identity

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -57,7 +57,7 @@ graph TB
     subgraph Mac["Mac (launchd agents)"]
         HAE["Health Auto Export
         iPhone → bede-data"]
-        DailyCollect["daily-raw-collect.sh
+        DailyCollect["usage-collect.sh
         screen time, Safari, podcasts"]
         VaultSync["obsidian-git-backup.sh
         vault → GitHub every 2 min"]
@@ -158,7 +158,7 @@ flowchart TD
     subgraph mac["Data sources (Mac)"]
         hae["Health Auto Export
         (iPhone)"]
-        daily["daily-raw-collect.sh
+        daily["usage-collect.sh
         screen time, Safari,
         podcasts, sessions"]
     end
@@ -226,7 +226,7 @@ The data layer. FastAPI service handling ingest, storage, querying, and live dat
 | `live/` | Real-time proxies: OwnTracks location (with reverse geocode caching), Homepage API weather, air quality |
 | `analytics/` | Signal engine computing wellbeing flags from raw data |
 
-**Ingest pipeline:** iPhone Health Auto Export and Mac daily-raw-collect.sh POST data with a bearer token. Parsers normalise the payloads and upsert into SQLite tables.
+**Ingest pipeline:** iPhone Health Auto Export and Mac usage-collect.sh POST data with a bearer token. Parsers normalise the payloads and upsert into SQLite tables.
 
 **Live queries:** Location and weather data are fetched on demand from OwnTracks and Homepage API rather than stored. Reverse geocode results are cached in both memory and SQLite to respect Nominatim rate limits.
 

--- a/CLAUDE.md.example
+++ b/CLAUDE.md.example
@@ -120,7 +120,7 @@ All tools handle timezone conversion internally — pass local dates, never UTC.
 - `mark_article_in_digest(article_id, digest_date)` — mark an article as included in a digest
 
 **Data pipeline tools:**
-- `get_data_freshness()` — returns two sources: `health` (Apple Health Auto Export from iPhone, pushed daily) and `vault` (screen time, Safari history, podcasts, Claude sessions — collected nightly from Joe's Mac by `daily-raw-collect.sh`). Each source shows `last_received_at` and `expected_interval_seconds` (86400 = daily). If `last_received_at` is more than `expected_interval_seconds` ago, that pipeline is stale — mention it proactively.
+- `get_data_freshness()` — returns two sources: `health` (Apple Health Auto Export from iPhone, pushed daily) and `vault` (screen time, Safari history, podcasts, Claude sessions — collected nightly from Joe's Mac by `usage-collect.sh`). Each source shows `last_received_at` and `expected_interval_seconds` (86400 = daily). If `last_received_at` is more than `expected_interval_seconds` ago, that pipeline is stale — mention it proactively.
 - `get_storage()` — database size and row counts
 
 **Other tools:**

--- a/CLAUDE.md.example
+++ b/CLAUDE.md.example
@@ -1,6 +1,6 @@
 # Bede
 
-You are Bede, a personal AI assistant.
+You are Bede, a personal assistant.
 
 ## Identity
 
@@ -120,7 +120,7 @@ All tools handle timezone conversion internally — pass local dates, never UTC.
 - `mark_article_in_digest(article_id, digest_date)` — mark an article as included in a digest
 
 **Data pipeline tools:**
-- `get_data_freshness()` — check when each data source last received data
+- `get_data_freshness()` — returns two sources: `health` (Apple Health Auto Export from iPhone, pushed daily) and `vault` (screen time, Safari history, podcasts, Claude sessions — collected nightly from Joe's Mac by `daily-raw-collect.sh`). Each source shows `last_received_at` and `expected_interval_seconds` (86400 = daily). If `last_received_at` is more than `expected_interval_seconds` ago, that pipeline is stale — mention it proactively.
 - `get_storage()` — database size and row counts
 
 **Other tools:**

--- a/bede-data/docs/data-sources.md
+++ b/bede-data/docs/data-sources.md
@@ -1,0 +1,63 @@
+# Data Sources
+
+Reference for all data ingested by bede-data: where it comes from, which devices it covers, and how often it arrives.
+
+## Health Data (iPhone → HAE → bede-data)
+
+Source: Apple Health Auto Export (HAE) iOS app. Six separate automations, all firing every 30 minutes via background refresh. Endpoint: `POST /ingest/health`.
+
+| Source | Data | Notes |
+|--------|------|-------|
+| health_metrics | Steps, active energy, HRV, resting HR, etc. | Minute grouping |
+| health_metrics_day | Daily aggregates | Day grouping |
+| sleep | Sleep analysis + related metrics | Summarize off |
+| workouts | Type, duration, calories, route data | Minute grouping |
+| state_of_mind | Mood/wellbeing entries | No batching |
+| medications | Medication log | iOS 26.0+ required |
+
+All automations fire regardless of whether there's new data (Date Range: Default = full previous day + today). A stale source reliably means the pipeline is broken.
+
+Expected freshness interval: **30 minutes** (all sources).
+
+Setup details: [hae-setup.md](hae-setup.md)
+
+## Usage Data (Mac → usage-collect.sh → bede-data)
+
+Source: `usage-collect.sh` launchd agent on the Mac. Runs 13 times daily (8am–11pm, irregular intervals, worst-case gap 3h). Endpoint: `POST /ingest/vault`.
+
+| Source | File | Devices | Underlying DB | Always present? |
+|--------|------|---------|---------------|-----------------|
+| screen_time_mac | `screentime.csv` | Mac only | knowledgeC.db | Yes |
+| screen_time_iphone | `iphone-screentime.csv` | iPhone only | Biome App.InFocus SEGB | Yes |
+| safari_history | `safari-pages.csv` | Mac + iPhone | History.db (iCloud sync) | Yes |
+| youtube_history | `youtube.csv` | Mac + iPhone | History.db (subset of Safari) | No — only if YouTube was visited |
+| podcasts | `podcasts.csv` | Mac + iPhone | MTLibrary.sqlite (iCloud sync) | No — only if podcasts were played |
+| claude_sessions | `claude-sessions.md` | Mac only | Claude Code projects dir | No — only if Claude was used |
+| bede_sessions | `bede-sessions.json` | Mac only | Bede conversation logs | No — only if Bede was used |
+
+Expected freshness interval: **3 hours** (worst-case gap between scheduled runs).
+
+### iCloud sync pattern
+
+Safari, YouTube, and Podcasts include iPhone activity because their underlying macOS databases sync from iPhone via iCloud:
+
+- **History.db** — Safari's SQLite database. iPhone visits appear with `origin = 1`. Sync is near-realtime (forced via `SafariHistoryServiceAgent`).
+- **MTLibrary.sqlite** — Apple Podcasts database. iPhone-played episodes sync via iCloud. Reliable same-day sync.
+
+Screen time does NOT benefit from this pattern — it requires two separate collection pipelines because the Mac database (knowledgeC.db) and iPhone data (Biome SEGB files) are completely independent sources.
+
+### "Always present" distinction
+
+Sources marked "Yes" are always collected regardless of user activity — if the file is missing from an upload, the pipeline is broken. Sources marked "No" are only included when there's activity to report — absence means no activity, not a failure.
+
+## Location Data (iPhone → OwnTracks → owntracks-recorder)
+
+Source: OwnTracks iOS app publishing to the owntracks-recorder container. Not stored in bede-data's SQLite — queried live via HTTP API (`/api/0/last`).
+
+Expected freshness: **1 hour** (OwnTracks publishes on significant location changes and periodic pings).
+
+The `tst` field in the recorder's `last` endpoint response is the authoritative freshness timestamp.
+
+## Music Listens (not yet implemented)
+
+Planned approach: Last.fm scrobbling API. See `dotfiles/docs/apple-music-play-history.md` for research and decision rationale. Will cover Mac + iPhone via Last.fm's own device-agnostic collection.


### PR DESCRIPTION
## Summary
- Expand `get_data_freshness()` description to explain health (iPhone HAE) and vault (Mac daily-raw-collect.sh) sources
- Remove "AI" from identity line ("personal assistant" not "personal AI assistant")

🤖 Generated with [Claude Code](https://claude.com/claude-code)