### PR TITLE
feat: granular data freshness with per-source tracking

### DIFF
--- a/bede-data-mcp/src/bede_data_mcp/server.py
+++ b/bede-data-mcp/src/bede_data_mcp/server.py
@@ -165,7 +165,7 @@ async def get_medications(date: str, timezone: str = "Australia/Sydney") -> dict
 
 
 # ---------------------------------------------------------------------------
-# Vault data tools
+# Usage data tools
 # ---------------------------------------------------------------------------
 
 
@@ -189,7 +189,7 @@ async def get_screen_time(
         kwargs["device"] = device
     if top_n is not None:
         kwargs["top_n"] = top_n
-    return await client.get("/api/vault/screen-time", **kwargs)
+    return await client.get("/api/usage/screen-time", **kwargs)
 
 
 @mcp.tool()
@@ -216,7 +216,7 @@ async def get_safari_history(
         kwargs["domain"] = domain_filter
     if top_n is not None:
         kwargs["top_n"] = top_n
-    return await client.get("/api/vault/safari", **kwargs)
+    return await client.get("/api/usage/safari", **kwargs)
 
 
 @mcp.tool()
@@ -227,7 +227,7 @@ async def get_youtube_history(date: str, timezone: str = "Australia/Sydney") -> 
         date: Local date -- 'YYYY-MM-DD', 'today', or 'yesterday'.
         timezone: Olson timezone name.
     """
-    return await client.get("/api/vault/youtube", date=date, timezone=timezone)
+    return await client.get("/api/usage/youtube", date=date, timezone=timezone)
 
 
 @mcp.tool()
@@ -242,7 +242,7 @@ async def get_podcasts(date: str, timezone: str = "Australia/Sydney") -> dict:
         date: Local date -- 'YYYY-MM-DD', 'today', or 'yesterday'.
         timezone: Olson timezone name.
     """
-    return await client.get("/api/vault/podcasts", date=date, timezone=timezone)
+    return await client.get("/api/usage/podcasts", date=date, timezone=timezone)
 
 
 @mcp.tool()
@@ -253,7 +253,7 @@ async def get_claude_sessions(date: str, timezone: str = "Australia/Sydney") -> 
         date: Local date -- 'YYYY-MM-DD', 'today', or 'yesterday'.
         timezone: Olson timezone name.
     """
-    return await client.get("/api/vault/claude-sessions", date=date, timezone=timezone)
+    return await client.get("/api/usage/claude-sessions", date=date, timezone=timezone)
 
 
 @mcp.tool()
@@ -264,7 +264,7 @@ async def get_bede_sessions(date: str, timezone: str = "Australia/Sydney") -> di
         date: Local date -- 'YYYY-MM-DD', 'today', or 'yesterday'.
         timezone: Olson timezone name.
     """
-    return await client.get("/api/vault/bede-sessions", date=date, timezone=timezone)
+    return await client.get("/api/usage/bede-sessions", date=date, timezone=timezone)
 
 
 # ---------------------------------------------------------------------------

--- a/bede-data-mcp/tests/test_usage_tools.py
+++ b/bede-data-mcp/tests/test_usage_tools.py
@@ -15,7 +15,7 @@ async def test_get_screen_time(api):
     }
     result = await get_screen_time("2026-04-30")
     api.get.assert_called_once_with(
-        "/api/vault/screen-time", date="2026-04-30", timezone="Australia/Sydney"
+        "/api/usage/screen-time", date="2026-04-30", timezone="Australia/Sydney"
     )
     assert len(result["entries"]) == 1
 
@@ -24,7 +24,7 @@ async def test_get_screen_time_with_filters(api):
     api.get.return_value = {"date": "2026-04-30", "entries": []}
     await get_screen_time("2026-04-30", device="iphone", top_n=5)
     api.get.assert_called_once_with(
-        "/api/vault/screen-time",
+        "/api/usage/screen-time",
         date="2026-04-30",
         device="iphone",
         top_n=5,
@@ -39,7 +39,7 @@ async def test_get_safari_history(api):
     }
     result = await get_safari_history("2026-04-30")
     api.get.assert_called_once_with(
-        "/api/vault/safari", date="2026-04-30", timezone="Australia/Sydney"
+        "/api/usage/safari", date="2026-04-30", timezone="Australia/Sydney"
     )
     assert result["entries"][0]["domain"] == "github.com"
 
@@ -50,7 +50,7 @@ async def test_get_safari_history_with_domain_filter(api):
         "2026-04-30", device="mac", domain_filter="github.com", top_n=10
     )
     api.get.assert_called_once_with(
-        "/api/vault/safari",
+        "/api/usage/safari",
         date="2026-04-30",
         device="mac",
         domain="github.com",
@@ -66,7 +66,7 @@ async def test_get_youtube_history(api):
     }
     result = await get_youtube_history("2026-04-30")
     api.get.assert_called_once_with(
-        "/api/vault/youtube", date="2026-04-30", timezone="Australia/Sydney"
+        "/api/usage/youtube", date="2026-04-30", timezone="Australia/Sydney"
     )
     assert len(result["entries"]) == 1
 
@@ -85,7 +85,7 @@ async def test_get_podcasts(api):
     }
     result = await get_podcasts("2026-04-30")
     api.get.assert_called_once_with(
-        "/api/vault/podcasts", date="2026-04-30", timezone="Australia/Sydney"
+        "/api/usage/podcasts", date="2026-04-30", timezone="Australia/Sydney"
     )
     assert result["entries"][0]["podcast"] == "The Daily"
 
@@ -97,7 +97,7 @@ async def test_get_claude_sessions(api):
     }
     result = await get_claude_sessions("2026-04-30")
     api.get.assert_called_once_with(
-        "/api/vault/claude-sessions", date="2026-04-30", timezone="Australia/Sydney"
+        "/api/usage/claude-sessions", date="2026-04-30", timezone="Australia/Sydney"
     )
     assert result["sessions"][0]["project"] == "bede"
 
@@ -109,6 +109,6 @@ async def test_get_bede_sessions(api):
     }
     result = await get_bede_sessions("2026-04-30")
     api.get.assert_called_once_with(
-        "/api/vault/bede-sessions", date="2026-04-30", timezone="Australia/Sydney"
+        "/api/usage/bede-sessions", date="2026-04-30", timezone="Australia/Sydney"
     )
     assert result["sessions"][0]["task_name"] == "morning_briefing"

--- a/bede-data/docs/data-sources.md
+++ b/bede-data/docs/data-sources.md
@@ -23,7 +23,7 @@ Setup details: [hae-setup.md](hae-setup.md)
 
 ## Usage Data (Mac → usage-collect.sh → bede-data)
 
-Source: `usage-collect.sh` launchd agent on the Mac. Runs 13 times daily (8am–11pm, irregular intervals, worst-case gap 3h). Endpoint: `POST /ingest/vault`.
+Source: `usage-collect.sh` launchd agent on the Mac. Runs 13 times daily (8am–11pm, irregular intervals, worst-case gap 3h). Endpoint: `POST /ingest/usage`.
 
 | Source | File | Devices | Underlying DB | Always present? |
 |--------|------|---------|---------------|-----------------|

--- a/bede-data/src/bede_data/api/freshness.py
+++ b/bede-data/src/bede_data/api/freshness.py
@@ -1,10 +1,44 @@
 import sqlite3
+from datetime import datetime, timezone
 
+import httpx
 from fastapi import APIRouter, Depends
 
+from bede_data.config import settings
 from bede_data.db.connection import get_db
 
 router = APIRouter(prefix="/api/freshness", tags=["freshness"])
+
+
+def _fetch_owntracks_freshness() -> dict | None:
+    try:
+        resp = httpx.get(
+            f"{settings.owntracks_url}/api/0/last",
+            timeout=5,
+        )
+        if resp.status_code != 200:
+            return None
+        data = resp.json()
+        if isinstance(data, list) and data:
+            tst = data[0].get("tst")
+        elif isinstance(data, dict):
+            tst = data.get("tst")
+        else:
+            return None
+        if tst is None:
+            return None
+        last_received = datetime.fromtimestamp(tst, tz=timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+        return {
+            "source": "owntracks",
+            "last_received_at": last_received,
+            "expected_interval_seconds": 3600,
+            "always_expected": 1,
+            "updated_at": None,
+        }
+    except (httpx.HTTPError, KeyError, ValueError, TypeError):
+        return None
 
 
 @router.get("")
@@ -12,4 +46,11 @@ def get_freshness(conn: sqlite3.Connection = Depends(get_db)):
     cursor = conn.execute(
         "SELECT source, last_received_at, expected_interval_seconds, always_expected, updated_at FROM data_freshness ORDER BY source"
     )
-    return {"sources": [dict(r) for r in cursor.fetchall()]}
+    sources = [dict(r) for r in cursor.fetchall()]
+
+    owntracks = _fetch_owntracks_freshness()
+    if owntracks is not None:
+        sources.append(owntracks)
+        sources.sort(key=lambda s: s["source"])
+
+    return {"sources": sources}

--- a/bede-data/src/bede_data/api/freshness.py
+++ b/bede-data/src/bede_data/api/freshness.py
@@ -10,6 +10,6 @@ router = APIRouter(prefix="/api/freshness", tags=["freshness"])
 @router.get("")
 def get_freshness(conn: sqlite3.Connection = Depends(get_db)):
     cursor = conn.execute(
-        "SELECT source, last_received_at, expected_interval_seconds, updated_at FROM data_freshness ORDER BY source"
+        "SELECT source, last_received_at, expected_interval_seconds, always_expected, updated_at FROM data_freshness ORDER BY source"
     )
     return {"sources": [dict(r) for r in cursor.fetchall()]}

--- a/bede-data/src/bede_data/api/usage_data.py
+++ b/bede-data/src/bede_data/api/usage_data.py
@@ -8,7 +8,7 @@ from bede_data.config import settings
 from bede_data.db.connection import get_db
 from bede_data.tz import utc_to_local
 
-router = APIRouter(prefix="/api/vault", tags=["vault"])
+router = APIRouter(prefix="/api/usage", tags=["usage"])
 
 _DEVICE_ALIASES = {"phone": "iphone", "mobile": "iphone"}
 

--- a/bede-data/src/bede_data/app.py
+++ b/bede-data/src/bede_data/app.py
@@ -19,7 +19,7 @@ from bede_data.api.retention import router as retention_router
 from bede_data.api.sessions import router as sessions_router
 from bede_data.api.storage import router as storage_router
 from bede_data.api.task_log import router as task_log_router
-from bede_data.api.vault_data import router as vault_data_router
+from bede_data.api.usage_data import router as usage_data_router
 from bede_data.api.vault_queue import router as vault_queue_router
 from bede_data.api.weather import router as weather_router
 from bede_data.db.connection import get_db, init_db
@@ -37,7 +37,7 @@ def create_app() -> FastAPI:
 
     app.include_router(ingest_router)
     app.include_router(health_router)
-    app.include_router(vault_data_router)
+    app.include_router(usage_data_router)
     app.include_router(location_router)
     app.include_router(weather_router)
     app.include_router(memories_router)

--- a/bede-data/src/bede_data/db/connection.py
+++ b/bede-data/src/bede_data/db/connection.py
@@ -60,6 +60,15 @@ def init_db() -> None:
             except sqlite3.OperationalError:
                 pass
             conn.commit()
+        if existing is not None and existing < 11:
+            try:
+                conn.execute(
+                    "ALTER TABLE data_freshness ADD COLUMN always_expected INTEGER NOT NULL DEFAULT 1"
+                )
+            except sqlite3.OperationalError:
+                pass
+            conn.execute("DELETE FROM data_freshness WHERE source IN ('health', 'vault')")
+            conn.commit()
         conn.commit()
         conn.executescript(SCHEMA_SQL)
         existing = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()[0]

--- a/bede-data/src/bede_data/db/connection.py
+++ b/bede-data/src/bede_data/db/connection.py
@@ -67,7 +67,9 @@ def init_db() -> None:
                 )
             except sqlite3.OperationalError:
                 pass
-            conn.execute("DELETE FROM data_freshness WHERE source IN ('health', 'vault')")
+            conn.execute(
+                "DELETE FROM data_freshness WHERE source IN ('health', 'vault')"
+            )
             conn.commit()
         conn.commit()
         conn.executescript(SCHEMA_SQL)

--- a/bede-data/src/bede_data/db/schema.py
+++ b/bede-data/src/bede_data/db/schema.py
@@ -1,4 +1,4 @@
-SCHEMA_VERSION = 10
+SCHEMA_VERSION = 11
 
 # Tables whose column names changed from the prototype bede schema.
 # init_db drops these if they have old-style columns, then SCHEMA_SQL recreates them.
@@ -286,6 +286,7 @@ CREATE TABLE IF NOT EXISTS data_freshness (
     source                   TEXT PRIMARY KEY,
     last_received_at         TEXT NOT NULL,
     expected_interval_seconds INTEGER NOT NULL,
+    always_expected          INTEGER NOT NULL DEFAULT 1,
     updated_at               TEXT NOT NULL DEFAULT (datetime('now'))
 );
 

--- a/bede-data/src/bede_data/ingest/router.py
+++ b/bede-data/src/bede_data/ingest/router.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends
 from bede_data.db.connection import get_db
 from bede_data.ingest.auth import verify_ingest_token
 from bede_data.ingest.health_parser import parse_health_payload
-from bede_data.ingest.vault_parser import parse_vault_payload
+from bede_data.ingest.usage_parser import parse_usage_payload
 
 router = APIRouter(prefix="/ingest", tags=["ingest"])
 
@@ -81,13 +81,13 @@ def ingest_health(
     return {"status": "ok", "records": total}
 
 
-@router.post("/vault")
-def ingest_vault(
+@router.post("/usage")
+def ingest_usage(
     payload: dict,
     _token: str = Depends(verify_ingest_token),
     conn: sqlite3.Connection = Depends(get_db),
 ):
-    parsed = parse_vault_payload(payload)
+    parsed = parse_usage_payload(payload)
     date = payload.get("date", "")
     total = 0
 
@@ -103,6 +103,6 @@ def ingest_vault(
     total += _upsert_rows(conn, "claude_sessions", parsed["claude_sessions"])
     total += _upsert_rows(conn, "bede_sessions", parsed["bede_sessions"])
     total += _upsert_rows(conn, "music_listens", parsed.get("music_listens", []))
-    _update_freshness(conn, "vault", 86400)
+    _update_freshness(conn, "usage", 86400)
     conn.commit()
     return {"status": "ok", "records": total}

--- a/bede-data/src/bede_data/ingest/router.py
+++ b/bede-data/src/bede_data/ingest/router.py
@@ -81,6 +81,31 @@ def ingest_health(
     return {"status": "ok", "records": total}
 
 
+_USAGE_FRESHNESS = {
+    "screen_time_mac": {"files": {"screentime.csv"}, "always_expected": True},
+    "screen_time_iphone": {"files": {"iphone-screentime.csv"}, "always_expected": True},
+    "safari_history": {"prefix": "safari", "always_expected": True},
+    "youtube_history": {"prefix": "youtube", "always_expected": False},
+    "podcasts": {"prefix": "podcasts", "always_expected": False},
+    "claude_sessions": {"prefix": "claude-sessions", "always_expected": False},
+    "bede_sessions": {"prefix": "bede-sessions", "always_expected": False},
+}
+
+
+def _usage_sources_present(files: dict[str, str]) -> set[str]:
+    """Return the set of freshness source keys whose files appear in the upload."""
+    present = set()
+    filenames = set(files.keys())
+    for source_key, spec in _USAGE_FRESHNESS.items():
+        if "files" in spec:
+            if spec["files"] & filenames:
+                present.add(source_key)
+        elif "prefix" in spec:
+            if any(f.startswith(spec["prefix"]) for f in filenames):
+                present.add(source_key)
+    return present
+
+
 @router.post("/usage")
 def ingest_usage(
     payload: dict,
@@ -103,6 +128,10 @@ def ingest_usage(
     total += _upsert_rows(conn, "claude_sessions", parsed["claude_sessions"])
     total += _upsert_rows(conn, "bede_sessions", parsed["bede_sessions"])
     total += _upsert_rows(conn, "music_listens", parsed.get("music_listens", []))
-    _update_freshness(conn, "usage", 86400)
+
+    for source_key in _usage_sources_present(payload.get("files", {})):
+        spec = _USAGE_FRESHNESS[source_key]
+        _update_freshness(conn, source_key, 10800, always_expected=spec["always_expected"])
+
     conn.commit()
     return {"status": "ok", "records": total}

--- a/bede-data/src/bede_data/ingest/router.py
+++ b/bede-data/src/bede_data/ingest/router.py
@@ -43,7 +43,11 @@ def _replace_daily(
 
 
 def _update_freshness(
-    conn: sqlite3.Connection, source: str, expected_interval: int, *, always_expected: bool = True
+    conn: sqlite3.Connection,
+    source: str,
+    expected_interval: int,
+    *,
+    always_expected: bool = True,
 ):
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     conn.execute(
@@ -63,7 +67,13 @@ def ingest_health(
     parsed = parse_health_payload(payload)
     total = 0
     counts = {}
-    for table in ("health_metrics", "sleep_phases", "workouts", "medications", "state_of_mind"):
+    for table in (
+        "health_metrics",
+        "sleep_phases",
+        "workouts",
+        "medications",
+        "state_of_mind",
+    ):
         n = _upsert_rows(conn, table, parsed[table])
         total += n
         counts[table] = n
@@ -131,7 +141,9 @@ def ingest_usage(
 
     for source_key in _usage_sources_present(payload.get("files", {})):
         spec = _USAGE_FRESHNESS[source_key]
-        _update_freshness(conn, source_key, 10800, always_expected=spec["always_expected"])
+        _update_freshness(
+            conn, source_key, 10800, always_expected=spec["always_expected"]
+        )
 
     conn.commit()
     return {"status": "ok", "records": total}

--- a/bede-data/src/bede_data/ingest/router.py
+++ b/bede-data/src/bede_data/ingest/router.py
@@ -42,12 +42,15 @@ def _replace_daily(
     return _upsert_rows(conn, table, rows)
 
 
-def _update_freshness(conn: sqlite3.Connection, source: str, expected_interval: int):
+def _update_freshness(
+    conn: sqlite3.Connection, source: str, expected_interval: int, *, always_expected: bool = True
+):
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     conn.execute(
-        """INSERT OR REPLACE INTO data_freshness (source, last_received_at, expected_interval_seconds, updated_at)
-           VALUES (?, ?, ?, ?)""",
-        (source, now, expected_interval, now),
+        """INSERT OR REPLACE INTO data_freshness
+           (source, last_received_at, expected_interval_seconds, always_expected, updated_at)
+           VALUES (?, ?, ?, ?, ?)""",
+        (source, now, expected_interval, int(always_expected), now),
     )
 
 
@@ -59,12 +62,21 @@ def ingest_health(
 ):
     parsed = parse_health_payload(payload)
     total = 0
-    total += _upsert_rows(conn, "health_metrics", parsed["health_metrics"])
-    total += _upsert_rows(conn, "sleep_phases", parsed["sleep_phases"])
-    total += _upsert_rows(conn, "workouts", parsed["workouts"])
-    total += _upsert_rows(conn, "medications", parsed["medications"])
-    total += _upsert_rows(conn, "state_of_mind", parsed["state_of_mind"])
-    _update_freshness(conn, "health", 86400)
+    counts = {}
+    for table in ("health_metrics", "sleep_phases", "workouts", "medications", "state_of_mind"):
+        n = _upsert_rows(conn, table, parsed[table])
+        total += n
+        counts[table] = n
+    _HEALTH_SOURCE_KEYS = {
+        "health_metrics": "health_metrics",
+        "sleep_phases": "sleep",
+        "workouts": "workouts",
+        "medications": "medications",
+        "state_of_mind": "state_of_mind",
+    }
+    for table, source_key in _HEALTH_SOURCE_KEYS.items():
+        if counts[table] > 0:
+            _update_freshness(conn, source_key, 1800)
     conn.commit()
     return {"status": "ok", "records": total}
 

--- a/bede-data/src/bede_data/ingest/usage_parser.py
+++ b/bede-data/src/bede_data/ingest/usage_parser.py
@@ -145,8 +145,8 @@ def _parse_sessions(date: str, content: str, name_field: str) -> list[dict]:
 SCREEN_TIME_FILES = {"screentime.csv", "iphone-screentime.csv"}
 
 
-def parse_vault_payload(payload: dict) -> dict:
-    """Parse a vault ingest payload containing {date, files: {filename: content}}. Files are routed by filename prefix to the appropriate CSV or markdown parser."""
+def parse_usage_payload(payload: dict) -> dict:
+    """Parse a usage ingest payload containing {date, files: {filename: content}}. Files are routed by filename prefix to the appropriate CSV or markdown parser."""
     date = payload.get("date", "")
     files = payload.get("files", {})
     result = {

--- a/bede-data/tests/test_api_freshness.py
+++ b/bede-data/tests/test_api_freshness.py
@@ -81,9 +81,7 @@ def test_freshness_includes_owntracks(client, db, monkeypatch):
         200,
         json=[{"tst": 1715320500, "_type": "location"}],
     )
-    monkeypatch.setattr(
-        "httpx.get", lambda *args, **kwargs: mock_response
-    )
+    monkeypatch.setattr("httpx.get", lambda *args, **kwargs: mock_response)
 
     response = client.get("/api/freshness")
     sources = {s["source"]: s for s in response.json()["sources"]}

--- a/bede-data/tests/test_api_freshness.py
+++ b/bede-data/tests/test_api_freshness.py
@@ -59,3 +59,49 @@ def test_health_ingest_updates_granular_freshness(client, db):
     assert sources["health_metrics"]["expected_interval_seconds"] == 1800
     assert sources["health_metrics"]["always_expected"] == 1
     assert "health" not in sources
+
+
+def test_freshness_includes_always_expected_field(client, db):
+    db.execute(
+        "INSERT INTO data_freshness (source, last_received_at, expected_interval_seconds, always_expected) VALUES (?, ?, ?, ?)",
+        ("youtube_history", "2026-05-10T08:00:00Z", 10800, 0),
+    )
+    db.commit()
+
+    response = client.get("/api/freshness")
+    sources = response.json()["sources"]
+    assert len(sources) == 1
+    assert sources[0]["always_expected"] == 0
+
+
+def test_freshness_includes_owntracks(client, db, monkeypatch):
+    import httpx
+
+    mock_response = httpx.Response(
+        200,
+        json=[{"tst": 1715320500, "_type": "location"}],
+    )
+    monkeypatch.setattr(
+        "httpx.get", lambda *args, **kwargs: mock_response
+    )
+
+    response = client.get("/api/freshness")
+    sources = {s["source"]: s for s in response.json()["sources"]}
+    assert "owntracks" in sources
+    assert sources["owntracks"]["expected_interval_seconds"] == 3600
+    assert sources["owntracks"]["always_expected"] == 1
+    assert sources["owntracks"]["updated_at"] is None
+
+
+def test_freshness_omits_owntracks_when_recorder_unreachable(client, db, monkeypatch):
+    import httpx
+
+    def raise_error(*args, **kwargs):
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr("httpx.get", raise_error)
+
+    response = client.get("/api/freshness")
+    assert response.status_code == 200
+    sources = [s["source"] for s in response.json()["sources"]]
+    assert "owntracks" not in sources

--- a/bede-data/tests/test_api_freshness.py
+++ b/bede-data/tests/test_api_freshness.py
@@ -6,16 +6,56 @@ def test_get_freshness_empty(client):
 
 def test_get_freshness_with_data(client, db):
     db.execute(
-        "INSERT INTO data_freshness (source, last_received_at, expected_interval_seconds) VALUES (?, ?, ?)",
-        ("health", "2026-04-29T08:00:00Z", 86400),
+        "INSERT INTO data_freshness (source, last_received_at, expected_interval_seconds, always_expected) VALUES (?, ?, ?, ?)",
+        ("health_metrics", "2026-04-29T08:00:00Z", 1800, 1),
     )
     db.execute(
-        "INSERT INTO data_freshness (source, last_received_at, expected_interval_seconds) VALUES (?, ?, ?)",
-        ("vault", "2026-04-29T06:00:00Z", 86400),
+        "INSERT INTO data_freshness (source, last_received_at, expected_interval_seconds, always_expected) VALUES (?, ?, ?, ?)",
+        ("screen_time_mac", "2026-04-29T06:00:00Z", 10800, 1),
     )
     db.commit()
 
     response = client.get("/api/freshness")
     data = response.json()
     assert len(data["sources"]) == 2
-    assert all("source" in s and "last_received_at" in s for s in data["sources"])
+    assert all(
+        "source" in s and "last_received_at" in s and "always_expected" in s
+        for s in data["sources"]
+    )
+
+
+def test_health_ingest_updates_granular_freshness(client, db):
+    from bede_data.config import settings
+
+    settings.ingest_write_token = "test-token"
+    payload = {
+        "data": {
+            "metrics": [
+                {
+                    "name": "step_count",
+                    "data": [
+                        {
+                            "date": "2026-05-10 00:00:00 +1000",
+                            "qty": 8000,
+                            "source": "Apple Watch",
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+    response = client.post(
+        "/ingest/health",
+        json=payload,
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert response.status_code == 200
+
+    cursor = db.execute(
+        "SELECT source, expected_interval_seconds, always_expected FROM data_freshness ORDER BY source"
+    )
+    sources = {row["source"]: row for row in cursor.fetchall()}
+    assert "health_metrics" in sources
+    assert sources["health_metrics"]["expected_interval_seconds"] == 1800
+    assert sources["health_metrics"]["always_expected"] == 1
+    assert "health" not in sources

--- a/bede-data/tests/test_api_usage_data.py
+++ b/bede-data/tests/test_api_usage_data.py
@@ -79,7 +79,7 @@ def _seed_vault_data(db):
 
 def test_get_screen_time(client, db):
     _seed_vault_data(db)
-    response = client.get("/api/vault/screen-time", params={"date": "2026-04-29"})
+    response = client.get("/api/usage/screen-time", params={"date": "2026-04-29"})
     assert response.status_code == 200
     data = response.json()
     assert len(data["entries"]) == 4
@@ -88,7 +88,7 @@ def test_get_screen_time(client, db):
 def test_get_screen_time_filter_device(client, db):
     _seed_vault_data(db)
     response = client.get(
-        "/api/vault/screen-time", params={"date": "2026-04-29", "device": "mac"}
+        "/api/usage/screen-time", params={"date": "2026-04-29", "device": "mac"}
     )
     assert response.status_code == 200
     data = response.json()
@@ -99,7 +99,7 @@ def test_get_screen_time_filter_device(client, db):
 def test_get_screen_time_device_alias(client, db):
     _seed_vault_data(db)
     response = client.get(
-        "/api/vault/screen-time", params={"date": "2026-04-29", "device": "phone"}
+        "/api/usage/screen-time", params={"date": "2026-04-29", "device": "phone"}
     )
     assert response.status_code == 200
     data = response.json()
@@ -110,7 +110,7 @@ def test_get_screen_time_device_alias(client, db):
 def test_get_screen_time_device_case_insensitive(client, db):
     _seed_vault_data(db)
     response = client.get(
-        "/api/vault/screen-time", params={"date": "2026-04-29", "device": "Mac"}
+        "/api/usage/screen-time", params={"date": "2026-04-29", "device": "Mac"}
     )
     assert response.status_code == 200
     data = response.json()
@@ -131,7 +131,7 @@ def test_get_safari_device_case_insensitive(client, db):
     )
     db.commit()
     response = client.get(
-        "/api/vault/safari", params={"date": "2026-04-29", "device": "phone"}
+        "/api/usage/safari", params={"date": "2026-04-29", "device": "phone"}
     )
     assert response.status_code == 200
     data = response.json()
@@ -142,7 +142,7 @@ def test_get_safari_device_case_insensitive(client, db):
 def test_get_screen_time_top_n(client, db):
     _seed_vault_data(db)
     response = client.get(
-        "/api/vault/screen-time",
+        "/api/usage/screen-time",
         params={"date": "2026-04-29", "device": "mac", "top_n": 2},
     )
     assert response.status_code == 200
@@ -153,7 +153,7 @@ def test_get_screen_time_top_n(client, db):
 
 def test_get_safari(client, db):
     _seed_vault_data(db)
-    response = client.get("/api/vault/safari", params={"date": "2026-04-29"})
+    response = client.get("/api/usage/safari", params={"date": "2026-04-29"})
     assert response.status_code == 200
     data = response.json()
     assert len(data["entries"]) == 2
@@ -162,7 +162,7 @@ def test_get_safari(client, db):
 def test_get_safari_filter_domain(client, db):
     _seed_vault_data(db)
     response = client.get(
-        "/api/vault/safari", params={"date": "2026-04-29", "domain": "github.com"}
+        "/api/usage/safari", params={"date": "2026-04-29", "domain": "github.com"}
     )
     assert response.status_code == 200
     data = response.json()
@@ -172,7 +172,7 @@ def test_get_safari_filter_domain(client, db):
 
 def test_get_youtube(client, db):
     _seed_vault_data(db)
-    response = client.get("/api/vault/youtube", params={"date": "2026-04-29"})
+    response = client.get("/api/usage/youtube", params={"date": "2026-04-29"})
     assert response.status_code == 200
     data = response.json()
     assert len(data["entries"]) == 1
@@ -181,7 +181,7 @@ def test_get_youtube(client, db):
 
 def test_get_podcasts(client, db):
     _seed_vault_data(db)
-    response = client.get("/api/vault/podcasts", params={"date": "2026-04-29"})
+    response = client.get("/api/usage/podcasts", params={"date": "2026-04-29"})
     assert response.status_code == 200
     data = response.json()
     assert len(data["entries"]) == 1
@@ -190,7 +190,7 @@ def test_get_podcasts(client, db):
 
 def test_get_claude_sessions(client, db):
     _seed_vault_data(db)
-    response = client.get("/api/vault/claude-sessions", params={"date": "2026-04-29"})
+    response = client.get("/api/usage/claude-sessions", params={"date": "2026-04-29"})
     assert response.status_code == 200
     data = response.json()
     assert len(data["sessions"]) == 1
@@ -199,7 +199,7 @@ def test_get_claude_sessions(client, db):
 
 def test_get_bede_sessions(client, db):
     _seed_vault_data(db)
-    response = client.get("/api/vault/bede-sessions", params={"date": "2026-04-29"})
+    response = client.get("/api/usage/bede-sessions", params={"date": "2026-04-29"})
     assert response.status_code == 200
     data = response.json()
     assert len(data["sessions"]) == 1
@@ -210,7 +210,7 @@ class TestTimezoneConversion:
     def test_safari_timestamps_converted_to_local(self, client, db):
         _seed_vault_data(db)
         response = client.get(
-            "/api/vault/safari",
+            "/api/usage/safari",
             params={"date": "2026-04-29", "timezone": "Australia/Sydney"},
         )
         entries = response.json()["entries"]
@@ -220,7 +220,7 @@ class TestTimezoneConversion:
     def test_youtube_timestamps_converted_to_local(self, client, db):
         _seed_vault_data(db)
         response = client.get(
-            "/api/vault/youtube",
+            "/api/usage/youtube",
             params={"date": "2026-04-29", "timezone": "Australia/Sydney"},
         )
         entries = response.json()["entries"]
@@ -229,7 +229,7 @@ class TestTimezoneConversion:
     def test_podcast_timestamps_converted_to_local(self, client, db):
         _seed_vault_data(db)
         response = client.get(
-            "/api/vault/podcasts",
+            "/api/usage/podcasts",
             params={"date": "2026-04-29", "timezone": "Australia/Sydney"},
         )
         entries = response.json()["entries"]
@@ -238,7 +238,7 @@ class TestTimezoneConversion:
     def test_session_timestamps_not_converted(self, client, db):
         _seed_vault_data(db)
         response = client.get(
-            "/api/vault/claude-sessions",
+            "/api/usage/claude-sessions",
             params={"date": "2026-04-29", "timezone": "Australia/Sydney"},
         )
         sessions = response.json()["sessions"]
@@ -248,7 +248,7 @@ class TestTimezoneConversion:
     def test_different_timezone_changes_output(self, client, db):
         _seed_vault_data(db)
         response = client.get(
-            "/api/vault/podcasts",
+            "/api/usage/podcasts",
             params={"date": "2026-04-29", "timezone": "US/Eastern"},
         )
         entries = response.json()["entries"]

--- a/bede-data/tests/test_app.py
+++ b/bede-data/tests/test_app.py
@@ -3,4 +3,4 @@ def test_health_check(client):
     assert response.status_code == 200
     data = response.json()
     assert data["status"] == "ok"
-    assert data["schema_version"] == 10
+    assert data["schema_version"] == 11

--- a/bede-data/tests/test_db.py
+++ b/bede-data/tests/test_db.py
@@ -169,14 +169,18 @@ def test_articles_url_unique(db):
 
 
 def test_data_freshness_has_always_expected_column(db):
-    cols = {row[1] for row in db.execute("PRAGMA table_info(data_freshness)").fetchall()}
+    cols = {
+        row[1] for row in db.execute("PRAGMA table_info(data_freshness)").fetchall()
+    }
     assert "always_expected" in cols
     db.execute(
         "INSERT INTO data_freshness (source, last_received_at, expected_interval_seconds, always_expected) VALUES (?, ?, ?, ?)",
         ("test_source", "2026-05-10T00:00:00Z", 1800, 1),
     )
     db.commit()
-    row = db.execute("SELECT always_expected FROM data_freshness WHERE source = 'test_source'").fetchone()
+    row = db.execute(
+        "SELECT always_expected FROM data_freshness WHERE source = 'test_source'"
+    ).fetchone()
     assert row["always_expected"] == 1
 
 
@@ -186,5 +190,7 @@ def test_data_freshness_always_expected_defaults_to_true(db):
         ("test_default", "2026-05-10T00:00:00Z", 1800),
     )
     db.commit()
-    row = db.execute("SELECT always_expected FROM data_freshness WHERE source = 'test_default'").fetchone()
+    row = db.execute(
+        "SELECT always_expected FROM data_freshness WHERE source = 'test_default'"
+    ).fetchone()
     assert row["always_expected"] == 1

--- a/bede-data/tests/test_db.py
+++ b/bede-data/tests/test_db.py
@@ -51,7 +51,7 @@ def test_wal_mode_enabled(db):
 def test_schema_version_is_set(db):
     cursor = db.execute("SELECT MAX(version) FROM schema_version")
     version = cursor.fetchone()[0]
-    assert version == 10
+    assert version == 11
 
 
 def test_health_metrics_upsert_by_natural_key(db):
@@ -166,3 +166,25 @@ def test_articles_url_unique(db):
         assert False, "Should have raised IntegrityError"
     except _sqlite3.IntegrityError:
         pass
+
+
+def test_data_freshness_has_always_expected_column(db):
+    cols = {row[1] for row in db.execute("PRAGMA table_info(data_freshness)").fetchall()}
+    assert "always_expected" in cols
+    db.execute(
+        "INSERT INTO data_freshness (source, last_received_at, expected_interval_seconds, always_expected) VALUES (?, ?, ?, ?)",
+        ("test_source", "2026-05-10T00:00:00Z", 1800, 1),
+    )
+    db.commit()
+    row = db.execute("SELECT always_expected FROM data_freshness WHERE source = 'test_source'").fetchone()
+    assert row["always_expected"] == 1
+
+
+def test_data_freshness_always_expected_defaults_to_true(db):
+    db.execute(
+        "INSERT INTO data_freshness (source, last_received_at, expected_interval_seconds) VALUES (?, ?, ?)",
+        ("test_default", "2026-05-10T00:00:00Z", 1800),
+    )
+    db.commit()
+    row = db.execute("SELECT always_expected FROM data_freshness WHERE source = 'test_default'").fetchone()
+    assert row["always_expected"] == 1

--- a/bede-data/tests/test_ingest_usage.py
+++ b/bede-data/tests/test_ingest_usage.py
@@ -166,3 +166,65 @@ def test_ingest_vault_replaces_daily_data(client, db):
     assert len(rows) == 1
     assert rows[0]["name"] == "Safari"
     assert rows[0]["seconds"] == 5400
+
+
+def test_ingest_usage_updates_granular_freshness(client, db):
+    settings.ingest_write_token = "test-token"
+    payload = {
+        "date": "2026-04-29",
+        "files": {
+            "screentime.csv": "device,entry_type,name,seconds\nmac,app,Safari,3600\n",
+            "iphone-screentime.csv": "device,entry_type,name,seconds\niphone,app,Instagram,2400\n",
+            "safari-pages.csv": "device,domain,title,url,visited_at\nmac,github.com,GitHub,https://github.com,2026-04-29T10:00:00Z\n",
+            "youtube.csv": "title,url,visited_at\nCool Video,https://youtube.com/watch?v=abc,2026-04-29T14:00:00Z\n",
+        },
+    }
+    response = client.post(
+        "/ingest/usage",
+        json=payload,
+        headers={"Authorization": "Bearer test-token"},
+    )
+    assert response.status_code == 200
+
+    cursor = db.execute(
+        "SELECT source, expected_interval_seconds, always_expected FROM data_freshness ORDER BY source"
+    )
+    sources = {row["source"]: dict(row) for row in cursor.fetchall()}
+
+    assert "screen_time_mac" in sources
+    assert sources["screen_time_mac"]["expected_interval_seconds"] == 10800
+    assert sources["screen_time_mac"]["always_expected"] == 1
+
+    assert "screen_time_iphone" in sources
+    assert sources["screen_time_iphone"]["always_expected"] == 1
+
+    assert "safari_history" in sources
+    assert sources["safari_history"]["always_expected"] == 1
+
+    assert "youtube_history" in sources
+    assert sources["youtube_history"]["always_expected"] == 0
+
+    assert "vault" not in sources
+    assert "usage" not in sources
+
+
+def test_ingest_usage_skips_freshness_for_absent_optional_sources(client, db):
+    settings.ingest_write_token = "test-token"
+    payload = {
+        "date": "2026-04-29",
+        "files": {
+            "screentime.csv": "device,entry_type,name,seconds\nmac,app,Safari,3600\n",
+        },
+    }
+    client.post(
+        "/ingest/usage",
+        json=payload,
+        headers={"Authorization": "Bearer test-token"},
+    )
+
+    cursor = db.execute("SELECT source FROM data_freshness ORDER BY source")
+    sources = [row["source"] for row in cursor.fetchall()]
+    assert "screen_time_mac" in sources
+    assert "youtube_history" not in sources
+    assert "podcasts" not in sources
+    assert "claude_sessions" not in sources

--- a/bede-data/tests/test_ingest_usage.py
+++ b/bede-data/tests/test_ingest_usage.py
@@ -1,5 +1,5 @@
 from bede_data.config import settings
-from bede_data.ingest.vault_parser import parse_vault_payload
+from bede_data.ingest.usage_parser import parse_usage_payload
 
 
 def test_parse_screen_time_csv():
@@ -14,7 +14,7 @@ def test_parse_screen_time_csv():
             ),
         },
     }
-    result = parse_vault_payload(payload)
+    result = parse_usage_payload(payload)
     assert len(result["screen_time"]) == 3
     assert result["screen_time"][0]["device"] == "mac"
     assert result["screen_time"][0]["name"] == "Safari"
@@ -30,7 +30,7 @@ def test_parse_iphone_screen_time_csv():
             ),
         },
     }
-    result = parse_vault_payload(payload)
+    result = parse_usage_payload(payload)
     assert len(result["screen_time"]) == 1
     assert result["screen_time"][0]["device"] == "iphone"
 
@@ -45,7 +45,7 @@ def test_parse_safari_csv():
             ),
         },
     }
-    result = parse_vault_payload(payload)
+    result = parse_usage_payload(payload)
     assert len(result["safari_history"]) == 1
     assert result["safari_history"][0]["domain"] == "github.com"
     assert result["safari_history"][0]["url"] == "https://github.com"
@@ -61,7 +61,7 @@ def test_parse_youtube_csv():
             ),
         },
     }
-    result = parse_vault_payload(payload)
+    result = parse_usage_payload(payload)
     assert len(result["youtube_history"]) == 1
     assert result["youtube_history"][0]["title"] == "Cool Video"
 
@@ -76,7 +76,7 @@ def test_parse_podcasts_csv():
             ),
         },
     }
-    result = parse_vault_payload(payload)
+    result = parse_usage_payload(payload)
     assert len(result["podcasts"]) == 1
     assert result["podcasts"][0]["podcast"] == "The Daily"
     assert result["podcasts"][0]["duration_seconds"] == 1800
@@ -99,7 +99,7 @@ def test_parse_claude_sessions_markdown():
             ),
         },
     }
-    result = parse_vault_payload(payload)
+    result = parse_usage_payload(payload)
     assert len(result["claude_sessions"]) == 1
     assert result["claude_sessions"][0]["project"] == "home-server-stack"
     assert result["claude_sessions"][0]["duration_min"] == 90
@@ -107,7 +107,7 @@ def test_parse_claude_sessions_markdown():
 
 def test_parse_empty_files():
     payload = {"date": "2026-04-29", "files": {}}
-    result = parse_vault_payload(payload)
+    result = parse_usage_payload(payload)
     assert result["screen_time"] == []
     assert result["safari_history"] == []
 
@@ -121,7 +121,7 @@ def test_ingest_vault_stores_data(client, db):
         },
     }
     response = client.post(
-        "/ingest/vault",
+        "/ingest/usage",
         json=payload,
         headers={"Authorization": "Bearer test-token"},
     )
@@ -148,7 +148,7 @@ def test_ingest_vault_replaces_daily_data(client, db):
             ),
         },
     }
-    client.post("/ingest/vault", json=payload1, headers=headers)
+    client.post("/ingest/usage", json=payload1, headers=headers)
 
     payload2 = {
         "date": "2026-04-29",
@@ -156,7 +156,7 @@ def test_ingest_vault_replaces_daily_data(client, db):
             "screentime.csv": ("device,entry_type,name,seconds\nmac,app,Safari,5400\n"),
         },
     }
-    response = client.post("/ingest/vault", json=payload2, headers=headers)
+    response = client.post("/ingest/usage", json=payload2, headers=headers)
     assert response.status_code == 200
 
     cursor = db.execute(

--- a/bede-web/src/css/app.css
+++ b/bede-web/src/css/app.css
@@ -8,6 +8,7 @@
   --color-status-warn: #fbbf24;
   --color-status-error: #f87171;
   --color-status-pending: #93c5fd;
+  --color-status-muted: #6b7280;
 }
 
 body {

--- a/bede-web/src/index.html
+++ b/bede-web/src/index.html
@@ -18,17 +18,22 @@
         <template x-if="error">
           <p class="text-status-error text-sm" x-text="error"></p>
         </template>
-        <div class="space-y-1">
-          <template x-for="src in freshness" :key="src.source">
-            <div class="flex items-center justify-between text-sm">
-              <span class="flex items-center gap-2">
-                <span class="w-2 h-2 rounded-full" :class="freshnessColor(src)"></span>
-                <span x-text="src.source"></span>
-              </span>
-              <span class="text-gray-500 text-xs" x-text="timeAgo(src.last_received_at)"></span>
+        <template x-for="group in freshnessGroups" :key="group.label">
+          <div class="mb-3 last:mb-0">
+            <h3 class="text-[10px] uppercase text-gray-600 mb-1" x-text="group.label"></h3>
+            <div class="space-y-1">
+              <template x-for="src in group.sources" :key="src.source">
+                <div class="flex items-center justify-between text-sm">
+                  <span class="flex items-center gap-2">
+                    <span class="w-2 h-2 rounded-full" :class="freshnessColor(src)"></span>
+                    <span x-text="sourceLabel(src.source)"></span>
+                  </span>
+                  <span class="text-gray-500 text-xs" x-text="timeAgo(src.last_received_at)"></span>
+                </div>
+              </template>
             </div>
-          </template>
-        </div>
+          </div>
+        </template>
         <a href="/tasks.html" class="text-xs text-gray-500 hover:text-gray-300 mt-3 inline-block">View all →</a>
       </div>
 
@@ -95,6 +100,7 @@
     function dashboard() {
       return {
         freshness: [],
+        freshnessGroups: [],
         recentTasks: [],
         storage: null,
         schedule: [],
@@ -123,6 +129,7 @@
 
           this.error = null;
           this.freshness = freshRes.data.sources;
+          this.freshnessGroups = this.groupFreshness(freshRes.data.sources);
           this.recentTasks = taskRes.data.executions;
           this.storage = storageRes.data;
 
@@ -145,6 +152,7 @@
           const expected = src.expected_interval_seconds || 86400;
           if (age <= expected) return "bg-status-ok";
           if (age <= expected * 2) return "bg-status-warn";
+          if (!src.always_expected) return "bg-status-muted";
           return "bg-status-error";
         },
 
@@ -183,6 +191,39 @@
           if (seconds < 3600) return Math.floor(seconds / 60) + "m ago";
           if (seconds < 86400) return Math.floor(seconds / 3600) + "h ago";
           return Math.floor(seconds / 86400) + "d ago";
+        },
+
+        sourceLabel(source) {
+          const labels = {
+            health_metrics: "Metrics",
+            sleep: "Sleep",
+            workouts: "Workouts",
+            medications: "Medications",
+            state_of_mind: "Wellbeing",
+            screen_time_mac: "Screen Time (Mac)",
+            screen_time_iphone: "Screen Time (iPhone)",
+            safari_history: "Safari",
+            youtube_history: "YouTube",
+            podcasts: "Podcasts",
+            claude_sessions: "Claude",
+            bede_sessions: "Bede",
+            owntracks: "Location",
+          };
+          return labels[source] || source;
+        },
+
+        groupFreshness(sources) {
+          const groups = {
+            "Health": ["health_metrics", "sleep", "workouts", "medications", "state_of_mind"],
+            "Usage": ["screen_time_mac", "screen_time_iphone", "safari_history", "youtube_history", "podcasts", "claude_sessions", "bede_sessions"],
+            "Location": ["owntracks"],
+          };
+          return Object.entries(groups)
+            .map(([label, keys]) => ({
+              label,
+              sources: keys.map(k => sources.find(s => s.source === k)).filter(Boolean),
+            }))
+            .filter(g => g.sources.length > 0);
         },
       };
     }


### PR DESCRIPTION
## Summary
- Add `always_expected` column to `data_freshness` table (schema v11) to distinguish required vs optional sources
- Replace coarse "health" and "vault" freshness entries with 13 granular per-source entries (health_metrics, sleep, workouts, medications, state_of_mind, screen_time_mac, screen_time_iphone, safari_history, youtube_history, podcasts, claude_sessions, bede_sessions)
- Add live OwnTracks freshness to the API by querying the recorder at request time
- Rename "vault" pipeline to "usage" across bede-data ingest, API, MCP server, and all tests
- Group freshness sources by pipeline (Health/Usage/Location) in bede-web dashboard with human-readable labels and muted status for optional sources

## Test plan
- [x] bede-data: 197/197 tests passing
- [x] No stale `/api/vault/` or `/ingest/vault` references in bede-data or bede-data-mcp
- [ ] Deploy to server, verify freshness card shows grouped sources
- [ ] Verify OwnTracks freshness appears in API response
- [ ] Update dotfiles `.env` to point INGEST_URL to `/ingest/usage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)