### PR TITLE
feat: populate bede-web pages (memories, goals, conversations)

### DIFF
--- a/CLAUDE.md.example
+++ b/CLAUDE.md.example
@@ -54,6 +54,33 @@ Follow the "How Bede Uses These Goals" section in goals.md for accountability gu
 - When creating markdown files, include `author: Bede` in YAML frontmatter
 - After any vault write, commit and push: `cd /vault && git add -A && git commit -m "<short description>" && git push`
 
+## Memory
+
+You have a persistent memory system. Use it to remember important facts, preferences, and corrections across conversations.
+
+**When to memorize:**
+- After substantive conversations (not quick factual lookups), propose 1-3 memories worth keeping
+- Frame proposals naturally: "I'd like to remember that..." — wait for confirmation before storing
+- Don't propose memories during scheduled tasks (briefings, reflections) — those are operational
+
+**How to memorize:**
+- Use `create_memory(content, type)` only after the user confirms
+- Types: `fact` (information about the user), `preference` (likes/dislikes), `correction` (overrides a previous memory), `commitment` (promises or intentions — short-lived, distinct from goals)
+- When correcting a previous memory, use `create_memory()` with `type="correction"` and `supersedes=<old_id>`
+- When recalling a stored memory, call `reference_memory(id)` to update the relevance timestamp
+
+**What to memorize:**
+- Personal facts: relationships, health conditions, birthdays, work details
+- Preferences: communication style, things to avoid, food preferences
+- Work context: team, tools, projects, role details
+- Corrections: when the user corrects a previously stored fact
+
+**What NOT to memorize:**
+- Things derivable from data (sleep patterns, screen time — analytics handles these)
+- Ephemeral state ("need to buy milk tomorrow")
+- Things already tracked in goals
+- Anything already stored — check `list_memories(search="keyword")` before creating duplicates
+
 ## Personal Data
 
 Use the `personal-data` MCP tools to query location, health, and vault data.

--- a/CLAUDE.md.example
+++ b/CLAUDE.md.example
@@ -23,10 +23,27 @@ Read `/vault/Bede/user.md` for full context. Key details:
 
 ## Goals and Accountability
 
-Read `/vault/01 Projects/Career Direction 2026/goals.md` for the goals you measure against.
-Read `/vault/01 Projects/Career Direction 2026/weekly-schedule.md` for the daily rhythm.
+Goals are tracked in the database. Use the goal tools to manage them.
 
-Follow the "How Bede Uses These Goals" section in goals.md for accountability guidance.
+**Checking goals:**
+- Use `list_goals(status="active")` to see current goals
+- Read `/vault/01 Projects/Career Direction 2026/weekly-schedule.md` for daily rhythm
+
+**Creating goals:**
+- When the user mentions a new commitment or objective, offer to create it via `create_goal()`
+- Goals should have: name, description (include targets and tracking methods), deadline (if applicable), measurable_indicators
+- Don't create goals for ephemeral tasks — goals are medium-to-long-term objectives
+
+**Updating goals:**
+- Use `update_goal()` to track progress — update description with notes, adjust deadlines
+- Mark goals `completed` or `dropped` when appropriate — don't delete
+
+**During evening reflections:**
+- Check active goals against the day's evidence (health data, location, calendar, screen time)
+- Surface patterns over daily misses: "You've swum twice this week" matters more than "you didn't swim today"
+- Be a supportive coach, not a critic — surface gaps honestly, ask why, suggest adjustments
+- If a goal hasn't been updated in 14+ days, raise it
+- Suggest tomorrow's priorities based on the weekly-schedule, active goals, and calendar events
 
 ## What You Can Do
 

--- a/bede-data/src/bede_data/api/conversations.py
+++ b/bede-data/src/bede_data/api/conversations.py
@@ -12,17 +12,15 @@ _SESSION_ID_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 
 
 def _scan_sessions() -> list[dict]:
-    """Walk the sessions directory for subdirectories containing session.jsonl files. Returns lightweight metadata (id, message count, first timestamp) without loading full transcripts."""
+    """Walk the sessions directory for .jsonl files. Returns lightweight metadata
+    (id, message count, first timestamp) without loading full transcripts."""
     sessions_path = Path(settings.claude_sessions_dir)
     if not sessions_path.exists():
         return []
 
     sessions = []
-    for session_dir in sorted(sessions_path.iterdir()):
-        if not session_dir.is_dir():
-            continue
-        jsonl_file = session_dir / "session.jsonl"
-        if not jsonl_file.exists():
+    for jsonl_file in sorted(sessions_path.glob("*.jsonl")):
+        if not jsonl_file.is_file():
             continue
 
         first_line = None
@@ -41,7 +39,7 @@ def _scan_sessions() -> list[dict]:
 
         sessions.append(
             {
-                "session_id": session_dir.name,
+                "session_id": jsonl_file.stem,
                 "message_count": line_count,
                 "first_timestamp": first_line.get("timestamp") if first_line else None,
             }
@@ -59,7 +57,7 @@ def list_conversations():
 def get_conversation(session_id: str):
     if not _SESSION_ID_RE.match(session_id):
         raise HTTPException(status_code=400, detail="Invalid session ID")
-    jsonl_file = Path(settings.claude_sessions_dir) / session_id / "session.jsonl"
+    jsonl_file = Path(settings.claude_sessions_dir) / f"{session_id}.jsonl"
     if not jsonl_file.exists():
         raise HTTPException(status_code=404, detail="Session not found")
 

--- a/bede-data/tests/test_api_conversations.py
+++ b/bede-data/tests/test_api_conversations.py
@@ -9,9 +9,7 @@ from bede_data.config import settings
 def sessions_dir(tmp_path):
     settings.claude_sessions_dir = str(tmp_path)
 
-    session_dir = tmp_path / "abc-123"
-    session_dir.mkdir()
-    jsonl_file = session_dir / "session.jsonl"
+    jsonl_file = tmp_path / "abc-123.jsonl"
     lines = [
         json.dumps(
             {
@@ -30,9 +28,7 @@ def sessions_dir(tmp_path):
     ]
     jsonl_file.write_text("\n".join(lines))
 
-    session_dir2 = tmp_path / "def-456"
-    session_dir2.mkdir()
-    jsonl_file2 = session_dir2 / "session.jsonl"
+    jsonl_file2 = tmp_path / "def-456.jsonl"
     lines2 = [
         json.dumps(
             {
@@ -54,6 +50,14 @@ def test_list_conversations(client, sessions_dir):
     assert len(data["sessions"]) == 2
 
 
+def test_list_conversations_has_metadata(client, sessions_dir):
+    response = client.get("/api/conversations")
+    sessions = response.json()["sessions"]
+    abc = next(s for s in sessions if s["session_id"] == "abc-123")
+    assert abc["message_count"] == 2
+    assert abc["first_timestamp"] == "2026-04-29T08:00:00Z"
+
+
 def test_get_conversation(client, sessions_dir):
     response = client.get("/api/conversations/abc-123")
     assert response.status_code == 200
@@ -66,3 +70,15 @@ def test_get_conversation(client, sessions_dir):
 def test_get_conversation_not_found(client, sessions_dir):
     response = client.get("/api/conversations/nonexistent")
     assert response.status_code == 404
+
+
+def test_list_conversations_empty_dir(client, tmp_path):
+    settings.claude_sessions_dir = str(tmp_path)
+    response = client.get("/api/conversations")
+    assert response.json()["sessions"] == []
+
+
+def test_list_conversations_ignores_non_jsonl_files(client, sessions_dir):
+    (sessions_dir / "README.md").write_text("not a session")
+    response = client.get("/api/conversations")
+    assert len(response.json()["sessions"]) == 2


### PR DESCRIPTION
## Summary
- Fix conversations API to scan flat `.jsonl` session files instead of subdirectories
- Add Memory behavioral section to CLAUDE.md.example (instructs Claude when/how to create memories)
- Replace Goals section in CLAUDE.md.example (switch from vault goals.md to SQLite goal tools)

## Context
bede-web pages for memories, goals, and conversations are empty despite the API endpoints, MCP tools, and UI all being fully built. Root causes: no behavioral instructions for memory creation, goals tracked in vault not SQLite, and conversation API expects wrong file format.

## Test plan
- [ ] `cd bede-data && python -m pytest -v` — all pass
- [ ] After deploy: conversations page shows session data
- [ ] After deploy: memories accumulate from conversations
- [ ] After goal seed: goals page shows active goals

🤖 Generated with [Claude Code](https://claude.com/claude-code)